### PR TITLE
ci: add auto-versioning release pipeline and improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 jobs:
-  test:
+  check:
     strategy:
       fail-fast: false
       matrix:
@@ -22,7 +22,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
 
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
@@ -38,7 +43,7 @@ jobs:
       - name: Install frontend dependencies
         run: bun install
 
-      - name: Check TypeScript
+      - name: Type check frontend
         run: bun run build
 
       - name: Check Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,82 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - main
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  build:
+  # ─── Job 1: Version check + bump ──────────────────────────
+  check-and-bump:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.bump.outputs.should_release }}
+      version: ${{ steps.bump.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes and bump version
+        id: bump
+        run: |
+          # Get current version from tauri.conf.json
+          CURRENT_VERSION=$(jq -r '.version' src-tauri/tauri.conf.json)
+          echo "Current version: $CURRENT_VERSION"
+
+          # Check if tag for current version exists
+          if git tag -l "v$CURRENT_VERSION" | grep -q "v$CURRENT_VERSION"; then
+            echo "Tag v$CURRENT_VERSION already exists"
+
+            # Check if there are commits since the last tag
+            COMMITS_SINCE=$(git rev-list "v$CURRENT_VERSION"..HEAD --count 2>/dev/null || echo "0")
+            echo "Commits since v$CURRENT_VERSION: $COMMITS_SINCE"
+
+            if [ "$COMMITS_SINCE" -eq "0" ]; then
+              echo "No new commits since last release — skipping"
+              echo "should_release=false" >> $GITHUB_OUTPUT
+              echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+
+            # Auto-bump patch version
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+            NEW_PATCH=$((PATCH + 1))
+            NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
+            echo "Bumping version: $CURRENT_VERSION → $NEW_VERSION"
+
+            # Update tauri.conf.json
+            jq --arg v "$NEW_VERSION" '.version = $v' src-tauri/tauri.conf.json > tmp.json && mv tmp.json src-tauri/tauri.conf.json
+
+            # Update package.json
+            jq --arg v "$NEW_VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
+
+            # Update Cargo.toml version
+            sed -i "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" src-tauri/Cargo.toml
+
+            # Commit the version bump
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add src-tauri/tauri.conf.json package.json src-tauri/Cargo.toml
+            git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+            git push
+
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "Tag v$CURRENT_VERSION does not exist — first release"
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          fi
+
+  # ─── Job 2: Build + Release ────────────────────────────────
+  release:
+    needs: check-and-bump
+    if: needs.check-and-bump.outputs.should_release == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -22,11 +90,18 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - name: Checkout repository
+      - name: Checkout repository (with bumped version)
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './src-tauri -> target'
 
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
@@ -47,14 +122,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: ${{ github.ref_name }}
-          releaseName: 'MarkLite ${{ github.ref_name }}'
+          tauriScript: bun run tauri
+          tagName: v__VERSION__
+          releaseName: 'MarkLite v__VERSION__'
           releaseBody: |
-            ## What's Changed
-            See the [CHANGELOG.md](https://github.com/Razee4315/MarkLite/blob/main/CHANGELOG.md) for details.
-            
-            ## Installation
-            Download the appropriate installer for your platform below.
+            ## MarkLite v__VERSION__
+
+            A minimal, distraction-free markdown editor.
+
+            ### Installation
+            - **Windows:** `.msi` (recommended) or `.exe` (NSIS installer)
+            - **Linux:** `.deb` or `.AppImage`
+
+            See the [CHANGELOG](https://github.com/Razee4315/MarkLite/blob/main/CHANGELOG.md) for details.
+          args: ${{ matrix.args }}
           releaseDraft: false
           prerelease: false
           includeUpdaterJson: true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marklite",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marklite"
-version = "0.1.0"
+version = "0.5.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MarkLite",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "identifier": "com.saqla.marklite",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
- Release workflow now triggers on push to main instead of manual tags
- Auto-bumps patch version (0.5.0 → 0.5.1 → ...) when new commits exist
- Syncs version across tauri.conf.json, package.json, and Cargo.toml
- Version bump commits use [skip ci] to prevent infinite loops
- Separate check-and-bump job on ubuntu-latest for cost efficiency
- Add Rust build caching (swatinem/rust-cache) to both CI and release
- Switch to dtolnay/rust-toolchain@stable for Rust installation
- Sync version files to 0.5.0 to match latest existing release tag