### PR TITLE
v0.6.0 — editor power features, preview polish, command palette, AI scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,84 @@ All notable changes to MarkLite will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-29
+
+### Added — Editor
+
+- Tab / Shift+Tab indent (multi-line aware)
+- Auto-pair for `()`, `[]`, `{}`, `` ` ``, `""`, `''` — wraps selection or inserts pair, type-past closer, atomic backspace
+- Enter continues lists, blockquotes, and task items
+- Markdown formatting shortcuts: Ctrl+B / Ctrl+I / Ctrl+K / Ctrl+/
+- Find & Replace (Ctrl+F / Ctrl+H) with regex, case-sensitive, match counter
+- Slash commands `/` with 13 block transformations
+- Smart paste: URL → link, plain URL → autolink, rich HTML → markdown (Turndown), TSV → GFM table
+- Tab navigation inside markdown tables (skips separator, creates rows)
+- Formatting toolbar above editor (toggleable)
+- Focus mode (dim non-active lines)
+- Typewriter mode (caret stays vertically centered)
+- Active-line highlight in editor and gutter
+
+### Added — Preview
+
+- Code blocks have a hover-revealed Copy button
+- Headings get GitHub-style stable slug IDs and clickable anchor links
+- Click-to-zoom image lightbox
+- Lazy image loading
+- Interactive task checkboxes — toggling writes back to source
+- KaTeX math rendering (`$inline$`, `$$block$$`) — lazy-loaded
+- Mermaid diagrams (` ```mermaid `) — lazy-loaded
+- YAML frontmatter parsed and rendered as a collapsible, editable Properties card
+- Wikilinks `[[Foo]]` and `[[Foo|alias]]` clickable in preview
+
+### Added — App
+
+- Split view (Ctrl+\\) with draggable, keyboard-resizable divider
+- Bidirectional scroll sync between editor and preview in split mode
+- Restore last opened file on launch
+- View mode and split ratio persist across sessions
+- Recent files list on welcome screen with parent folder, time-ago, remove button; missing files struck through
+- New File (Ctrl+N) and Save As (Ctrl+Shift+S)
+- External-change detection — banner offers Reload/Keep mine when the file is modified outside MarkLite
+- Auto-save toggle (1.5s debounce) with status chip in StatusBar
+- Command palette (Ctrl+P) with fuzzy ranking — searches commands, files, headings, toggles
+- Settings modal (Ctrl+,) with sidebar navigation and search
+- Keyboard cheatsheet modal (`?`)
+- Outline pane highlights the heading the cursor is in; filter input for large docs
+- AI assist scaffold (Ctrl+J) — Rewrite / Shorten / Expand / Continue / Translate via configurable OpenAI-compatible endpoint (Ollama, llama.cpp, OpenAI, etc.)
+- Reading time and character count in StatusBar
+
+### Fixed
+
+- Caret no longer drifts vertically between the textarea and syntax-highlight overlay (font metric alignment, empty-line rendering, rAF-driven scroll sync)
+- Paper theme `--text-muted` darkened to pass WCAG AA contrast
+- Sidebar panels (FileExplorer, TableOfContents) now trap focus
+- Toast errors announce as `role="alert"` / `aria-live="assertive"`
+- `prefers-reduced-motion` is respected globally
+
+### Changed
+
+- Visible focus rings on all interactive elements (keyboard focus only)
+- Design tokens for radius and spacing in `:root`
+- StatusBar replaces inert "UTF-8" with icons next to word count and reading time
+- TitleBar shows a hint when no file is open
+- Welcome screen lists New File alongside Open File and surfaces Ctrl+P / `?` hints
+
+### Removed
+
+- The hidden off-screen markdown renderer used for export — capture happens directly from the visible preview now
+
+## [0.5.1] - 2026-01-XX
+
+### Added
+
+- Error boundary
+- Unsaved-changes protection on close
+- Loading state during file open
+
 ## [0.1.0] - 2025-01-01
 
 ### Added
+
 - Initial release of MarkLite
 - Clean markdown preview with live rendering
 - Code editor with syntax highlighting

--- a/README.md
+++ b/README.md
@@ -47,16 +47,56 @@ I wanted a simple, lightweight solution that renders markdown beautifully while 
 
 ## Features
 
-- **Clean Interface** - Minimal UI that stays out of your way
-- **Live Preview** - Switch between reader and code modes instantly with Ctrl+E
-- **Syntax Highlighting** - Full markdown syntax highlighting in the editor
-- **Three Themes** - Dark, Light, and Paper themes to match your preference
-- **Five Fonts** - Inter, Merriweather, Lora, Source Serif, Fira Sans
-- **Adjustable Font Size** - Small, Medium, and Large options
-- **File Explorer** - Quick access to markdown files in the current directory
-- **Table of Contents** - Navigate large documents easily
-- **Native Performance** - Built with Tauri for a lightweight, fast experience
-- **Cross-Platform** - Windows, macOS, and Linux support
+### Writing
+
+- **Clean Interface** — minimal UI that stays out of your way
+- **Reader / Code / Split view** — Ctrl+E to toggle, Ctrl+\\ for split with bidirectional scroll sync
+- **Focus mode** — dim non-active lines so you can think
+- **Typewriter mode** — caret stays vertically centered
+- **Formatting toolbar** (toggleable) and shortcuts: Ctrl+B / Ctrl+I / Ctrl+K / Ctrl+/
+- **Slash commands** — type `/` at line start for headings, lists, tables, math, mermaid, callouts, and more
+- **Auto-pair** brackets, quotes, and code marks; **list/quote continuation** on Enter
+- **Tab in tables** moves between cells; auto-creates new rows
+- **Find & Replace** (Ctrl+F / Ctrl+H) with regex and match counter
+- **Smart paste** — URL → link, rich HTML → markdown, TSV → GFM table
+
+### Preview
+
+- **GitHub Flavored Markdown** with task lists, tables, strikethrough
+- **Code blocks** with syntax highlighting and one-click copy
+- **Math** via KaTeX (`$inline$`, `$$block$$`) — loaded only when needed
+- **Mermaid diagrams** (` ```mermaid `) — loaded only when needed
+- **Image lightbox** — click to zoom; lazy loading
+- **Interactive task checkboxes** — toggling writes back to source
+- **Heading anchors** with click-to-jump
+- **Wikilinks** `[[other-file]]` resolve in the same folder
+- **Frontmatter** rendered as an editable Properties card
+
+### Files & workflow
+
+- **Command palette** (Ctrl+P) — search commands, files, headings, toggles
+- **Cheatsheet** (`?`) — every shortcut categorized and searchable
+- **Settings modal** (Ctrl+,) — sidebar nav with Appearance / Editor / AI / About
+- **New File** (Ctrl+N) and **Save As** (Ctrl+Shift+S)
+- **Auto-save** (optional, debounced) with status indicator
+- **External-change detection** — reload or keep your version when the file changes outside the app
+- **Recent files** on the welcome screen — missing files marked
+- **Restore last opened file** on launch
+- **File Explorer** for the current folder
+- **Outline pane** that follows the cursor
+
+### Customization
+
+- **Four themes** — Dark, Light, Paper, GitHub
+- **Five fonts** — Inter, Merriweather, Lora, Source Serif, Fira Sans
+- **Three font sizes**
+- **WCAG-friendly** — visible focus rings, `prefers-reduced-motion` respected
+- **AI assist** (optional) — Ctrl+J on a selection; configure any OpenAI-compatible endpoint (Ollama, llama.cpp, OpenAI, etc.) in Settings → AI
+
+### Platform
+
+- **Native performance** — built with Tauri
+- **Cross-platform** — Windows, macOS, Linux
 
 ## Installation
 
@@ -94,11 +134,24 @@ bun run tauri build
 
 ## Keyboard Shortcuts
 
+A few essentials — press `?` inside the app for the full searchable list.
+
 | Action | Shortcut |
 |--------|----------|
-| Open File | Ctrl+O |
-| Save File | Ctrl+S |
-| Toggle Mode | Ctrl+E |
+| Command palette | Ctrl+P |
+| Cheatsheet | ? |
+| Settings | Ctrl+, |
+| New file | Ctrl+N |
+| Open file | Ctrl+O |
+| Save | Ctrl+S |
+| Save As | Ctrl+Shift+S |
+| Toggle Reader / Code | Ctrl+E |
+| Toggle Split view | Ctrl+\\ |
+| File explorer / Outline | Ctrl+Shift+E / Ctrl+Shift+O |
+| Find / Replace | Ctrl+F / Ctrl+H |
+| Bold / Italic / Link | Ctrl+B / Ctrl+I / Ctrl+K |
+| Toggle blockquote | Ctrl+/ |
+| AI assist | Ctrl+J |
 
 ## Tech Stack
 

--- a/bun.lock
+++ b/bun.lock
@@ -21,11 +21,13 @@
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "tailwindcss": "^4.1.18",
+        "turndown": "^7.2.4",
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@types/turndown": "^5.0.6",
         "@vitejs/plugin-react": "^4.6.0",
         "sharp": "^0.34.5",
         "typescript": "~5.8.3",
@@ -207,6 +209,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.1.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw=="],
+
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
@@ -411,6 +415,8 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -887,6 +893,8 @@
     "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,12 +10,16 @@
         "@tauri-apps/plugin-dialog": "^2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.4",
         "@tauri-apps/plugin-opener": "^2",
-        "html2pdf.js": "^0.14.0",
+        "jspdf": "^4.0.0",
+        "katex": "^0.16.45",
+        "mermaid": "^11.14.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
+        "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
         "tailwindcss": "^4.1.18",
       },
       "devDependencies": {
@@ -30,6 +34,8 @@
     },
   },
   "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.28.5", "", {}, "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA=="],
@@ -69,6 +75,18 @@
     "@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@12.0.0", "", { "dependencies": { "@chevrotain/gast": "12.0.0", "@chevrotain/types": "12.0.0" } }, "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg=="],
+
+    "@chevrotain/gast": ["@chevrotain/gast@12.0.0", "", { "dependencies": { "@chevrotain/types": "12.0.0" } }, "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ=="],
+
+    "@chevrotain/regexp-to-ast": ["@chevrotain/regexp-to-ast@12.0.0", "", {}, "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@12.0.0", "", {}, "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA=="],
+
+    "@chevrotain/utils": ["@chevrotain/utils@12.0.0", "", {}, "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
 
@@ -123,6 +141,10 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
+
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.1", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "mlly": "^1.8.2" } }, "sha512-MwzoDtw9rO1x+qfgLTV/IVXsHDBqeYZoMIQC8SfxfYSlaSUG+oWiAcoiB1yajAda6mqblm4/1/w2E8tRu7a7Tw=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
@@ -183,6 +205,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.1.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
@@ -300,13 +324,79 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.3", "", {}, "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
 
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/katex": ["@types/katex@0.16.8", "", {}, "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
@@ -326,7 +416,11 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -350,19 +444,105 @@
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
+    "chevrotain": ["chevrotain@12.0.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "12.0.0", "@chevrotain/gast": "12.0.0", "@chevrotain/regexp-to-ast": "12.0.0", "@chevrotain/types": "12.0.0", "@chevrotain/utils": "12.0.0" } }, "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ=="],
+
+    "chevrotain-allstar": ["chevrotain-allstar@0.4.1", "", { "dependencies": { "lodash-es": "^4.17.21" }, "peerDependencies": { "chevrotain": "^12.0.0" } }, "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA=="],
+
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
+    "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "core-js": ["core-js@3.48.0", "", {}, "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ=="],
 
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
     "css-line-break": ["css-line-break@2.1.0", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cytoscape": ["cytoscape@3.33.2", "", {}, "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
+    "dayjs": ["dayjs@1.11.20", "", {}, "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.2.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -375,6 +555,8 @@
     "electron-to-chromium": ["electron-to-chromium@1.5.267", "", {}, "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.18.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q=="],
+
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
@@ -398,7 +580,19 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "hast-util-from-dom": ["hast-util-from-dom@5.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hastscript": "^9.0.0", "web-namespaces": "^2.0.0" } }, "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q=="],
+
+    "hast-util-from-html": ["hast-util-from-html@2.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.1.0", "hast-util-from-parse5": "^8.0.0", "parse5": "^7.0.0", "vfile": "^6.0.0", "vfile-message": "^4.0.0" } }, "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw=="],
+
+    "hast-util-from-html-isomorphic": ["hast-util-from-html-isomorphic@2.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-from-dom": "^5.0.0", "hast-util-from-html": "^2.0.0", "unist-util-remove-position": "^5.0.0" } }, "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw=="],
+
+    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
+
     "hast-util-is-element": ["hast-util-is-element@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g=="],
+
+    "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
 
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
@@ -406,15 +600,19 @@
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
+    "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
+
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "html2canvas": ["html2canvas@1.4.1", "", { "dependencies": { "css-line-break": "^2.1.0", "text-segmentation": "^1.0.3" } }, "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA=="],
 
-    "html2pdf.js": ["html2pdf.js@0.14.0", "", { "dependencies": { "dompurify": "^3.3.1", "html2canvas": "^1.0.0", "jspdf": "^4.0.0" } }, "sha512-yvNJgE/8yru2UeGflkPdjW8YEY+nDH5X7/2WG4uiuSCwYiCp8PZ8EKNiTAa6HxJ1NjC51fZSIEq6xld5CADKBQ=="],
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
+    "internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 
     "iobuffer": ["iobuffer@5.4.0", "", {}, "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA=="],
 
@@ -437,6 +635,14 @@
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jspdf": ["jspdf@4.0.0", "", { "dependencies": { "@babel/runtime": "^7.28.4", "fast-png": "^6.2.0", "fflate": "^0.8.1" }, "optionalDependencies": { "canvg": "^3.0.11", "core-js": "^3.6.0", "dompurify": "^3.2.4", "html2canvas": "^1.0.0-rc.5" } }, "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ=="],
+
+    "katex": ["katex@0.16.45", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
+    "langium": ["langium@4.2.2", "", { "dependencies": { "@chevrotain/regexp-to-ast": "~12.0.0", "chevrotain": "~12.0.0", "chevrotain-allstar": "~0.4.1", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.1.0" } }, "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
 
@@ -462,6 +668,8 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw=="],
 
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
     "lowlight": ["lowlight@3.3.0", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.0.0", "highlight.js": "~11.11.0" } }, "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ=="],
@@ -471,6 +679,8 @@
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
@@ -488,6 +698,8 @@
 
     "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
 
+    "mdast-util-math": ["mdast-util-math@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "longest-streak": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.1.0", "unist-util-remove-position": "^5.0.0" } }, "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w=="],
+
     "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
 
     "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="],
@@ -501,6 +713,8 @@
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mermaid": ["mermaid@11.14.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "katex": "^0.16.25", "khroma": "^2.1.0", "lodash-es": "^4.17.23", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -519,6 +733,8 @@
     "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
 
     "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-extension-math": ["micromark-extension-math@3.1.0", "", { "dependencies": { "@types/katex": "^0.16.0", "devlop": "^1.0.0", "katex": "^0.16.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg=="],
 
     "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
 
@@ -558,21 +774,37 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
+    "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
+    "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
     "pako": ["pako@2.1.0", "", {}, "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "performance-now": ["performance-now@2.1.0", "", {}, "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -592,7 +824,11 @@
 
     "rehype-highlight": ["rehype-highlight@7.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-text": "^4.0.0", "lowlight": "^3.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA=="],
 
+    "rehype-katex": ["rehype-katex@7.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/katex": "^0.16.0", "hast-util-from-html-isomorphic": "^2.0.0", "hast-util-to-text": "^4.0.0", "katex": "^0.16.0", "unist-util-visit-parents": "^6.0.0", "vfile": "^6.0.0" } }, "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA=="],
+
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-math": ["remark-math@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-math": "^3.0.0", "micromark-extension-math": "^3.0.0", "unified": "^11.0.0" } }, "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA=="],
 
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
@@ -602,7 +838,15 @@
 
     "rgbcolor": ["rgbcolor@1.0.1", "", {}, "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rollup": ["rollup@4.54.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.54.0", "@rollup/rollup-android-arm64": "4.54.0", "@rollup/rollup-darwin-arm64": "4.54.0", "@rollup/rollup-darwin-x64": "4.54.0", "@rollup/rollup-freebsd-arm64": "4.54.0", "@rollup/rollup-freebsd-x64": "4.54.0", "@rollup/rollup-linux-arm-gnueabihf": "4.54.0", "@rollup/rollup-linux-arm-musleabihf": "4.54.0", "@rollup/rollup-linux-arm64-gnu": "4.54.0", "@rollup/rollup-linux-arm64-musl": "4.54.0", "@rollup/rollup-linux-loong64-gnu": "4.54.0", "@rollup/rollup-linux-ppc64-gnu": "4.54.0", "@rollup/rollup-linux-riscv64-gnu": "4.54.0", "@rollup/rollup-linux-riscv64-musl": "4.54.0", "@rollup/rollup-linux-s390x-gnu": "4.54.0", "@rollup/rollup-linux-x64-gnu": "4.54.0", "@rollup/rollup-linux-x64-musl": "4.54.0", "@rollup/rollup-openharmony-arm64": "4.54.0", "@rollup/rollup-win32-arm64-msvc": "4.54.0", "@rollup/rollup-win32-ia32-msvc": "4.54.0", "@rollup/rollup-win32-x64-gnu": "4.54.0", "@rollup/rollup-win32-x64-msvc": "4.54.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -622,6 +866,8 @@
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
     "svg-pathdata": ["svg-pathdata@6.0.3", "", {}, "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw=="],
 
     "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
@@ -630,15 +876,21 @@
 
     "text-segmentation": ["text-segmentation@1.0.3", "", { "dependencies": { "utrie": "^1.0.2" } }, "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw=="],
 
+    "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
+    "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
+    "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
@@ -647,6 +899,8 @@
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 
     "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-remove-position": ["unist-util-remove-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q=="],
 
     "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
 
@@ -658,11 +912,29 @@
 
     "utrie": ["utrie@1.0.2", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" } }, "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw=="],
 
+    "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@7.3.0", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg=="],
+
+    "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
+
+    "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
+
+    "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
+
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
+
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
+    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
@@ -684,6 +956,18 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
-    "tailwindcss": "^4.1.18"
+    "tailwindcss": "^4.1.18",
+    "turndown": "^7.2.4"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/turndown": "^5.0.6",
     "@vitejs/plugin-react": "^4.6.0",
     "sharp": "^0.34.5",
     "typescript": "~5.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marklite",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,15 @@
     "@tauri-apps/plugin-fs": "^2.4.4",
     "@tauri-apps/plugin-opener": "^2",
     "jspdf": "^4.0.0",
+    "katex": "^0.16.45",
+    "mermaid": "^11.14.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
+    "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marklite"
-version = "0.5.1"
+version = "0.6.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MarkLite",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "identifier": "com.saqla.marklite",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { TableOfContents } from "./components/TableOfContents";
 import { Toast, ToastType } from "./components/Toast";
 import { UnsavedChangesDialog } from "./components/UnsavedChangesDialog";
 import { SplitDivider } from "./components/SplitDivider";
+import { createScrollSync } from "./utils/scrollSync";
 import {
   addRecentFile,
   getAutoSave,
@@ -73,6 +74,32 @@ function AppContent() {
   // Export HTML content ref - captures from visible preview
   const previewRef = useRef<HTMLDivElement>(null);
   const splitContainerRef = useRef<HTMLDivElement>(null);
+
+  // Bidirectional scroll sync between editor and preview (split mode only).
+  // Singleton instance — one sync controller for the lifetime of the app.
+  const scrollSyncRef = useRef(createScrollSync());
+
+  // Enable/disable based on view mode
+  useEffect(() => {
+    scrollSyncRef.current.setEnabled(mode === "split");
+  }, [mode]);
+
+  const registerCodeScroller = useCallback(
+    (s: import("./utils/scrollSync").Scroller | null) => scrollSyncRef.current.register("code", s),
+    []
+  );
+  const registerPreviewScroller = useCallback(
+    (s: import("./utils/scrollSync").Scroller | null) => scrollSyncRef.current.register("preview", s),
+    []
+  );
+  const onCodeScrollFraction = useCallback(
+    (f: number) => scrollSyncRef.current.notify("code", f),
+    []
+  );
+  const onPreviewScrollFraction = useCallback(
+    (f: number) => scrollSyncRef.current.notify("preview", f),
+    []
+  );
 
   // Derived state
   const isDirty = content !== originalContent;
@@ -474,6 +501,8 @@ function AppContent() {
                 onImagePaste={handleImagePaste}
                 onError={handleError}
                 filePath={filePath}
+                onScrollFraction={onCodeScrollFraction}
+                registerScroller={registerCodeScroller}
               />
             </div>
 
@@ -501,6 +530,8 @@ function AppContent() {
                 filePath={filePath}
                 markdownBodyRef={previewRef}
                 onContentChange={handleContentChange}
+                onScrollFraction={onPreviewScrollFraction}
+                registerScroller={registerPreviewScroller}
               />
             </div>
           </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -374,6 +374,7 @@ function AppContent() {
               onLineChange={(line) => setPreviewLine(line)}
               filePath={filePath}
               markdownBodyRef={previewRef}
+              onContentChange={handleContentChange}
             />
           </div>
           <div className="flex-1 overflow-hidden flex flex-col" style={{ display: mode === "code" ? "flex" : "none" }}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { listen, TauriEvent } from "@tauri-apps/api/event";
+import { stat } from "@tauri-apps/plugin-fs";
 
 import { ThemeProvider } from "./context/ThemeContext";
 import { TitleBar } from "./components/TitleBar";
@@ -68,6 +69,8 @@ function AppContent() {
   const [focusModeEnabled, setFocusModeEnabled] = useState<boolean>(() => getFocusMode());
   const [typewriterModeEnabled, setTypewriterModeEnabled] = useState<boolean>(() => getTypewriterMode());
   const [toolbarVisible, setToolbarVisible] = useState<boolean>(() => getToolbarEnabled());
+  const [autoSaveStatus, setAutoSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [externalChange, setExternalChange] = useState<{ kind: "modified" | "deleted"; lastMtime: number } | null>(null);
   const [cursorPosition, setCursorPosition] = useState({ line: 1, col: 1 });
   const [isLoading, setIsLoading] = useState(false);
 
@@ -189,6 +192,77 @@ function AppContent() {
     return () => window.removeEventListener("marklite:autosave-toggle", handler);
   }, []);
 
+  // External-change detection: poll file mtime every 4s. If the file was modified
+  // by something outside MarkLite, we either silently reload (clean buffer) or
+  // banner the user with a choice (dirty buffer). If it was deleted, banner only.
+  const lastMtimeRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!filePath) {
+      lastMtimeRef.current = null;
+      setExternalChange(null);
+      return;
+    }
+    let cancelled = false;
+    let didInit = false;
+
+    const tick = async () => {
+      if (cancelled || !filePath) return;
+      try {
+        const s = await stat(filePath);
+        const mtime = s.mtime ? new Date(s.mtime).getTime() : 0;
+        if (!didInit) {
+          lastMtimeRef.current = mtime;
+          didInit = true;
+          return;
+        }
+        if (mtime !== lastMtimeRef.current) {
+          // Changed externally
+          if (content === originalContent) {
+            // Silently reload — buffer was clean
+            try {
+              const fileData = await invoke<FileData>("read_file", { path: filePath });
+              setContent(fileData.content);
+              setOriginalContent(fileData.content);
+              setFileSize(fileData.size);
+              lastMtimeRef.current = mtime;
+            } catch {
+              setExternalChange({ kind: "deleted", lastMtime: mtime });
+            }
+          } else {
+            setExternalChange({ kind: "modified", lastMtime: mtime });
+          }
+        }
+      } catch {
+        // File no longer exists
+        if (!externalChange) setExternalChange({ kind: "deleted", lastMtime: lastMtimeRef.current ?? 0 });
+      }
+    };
+
+    tick();
+    const id = window.setInterval(tick, 4000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [filePath, content, originalContent, externalChange]);
+
+  const dismissExternalChange = useCallback(() => setExternalChange(null), []);
+  const reloadFromDisk = useCallback(async () => {
+    if (!filePath) return;
+    try {
+      const fileData = await invoke<FileData>("read_file", { path: filePath });
+      setContent(fileData.content);
+      setOriginalContent(fileData.content);
+      setFileSize(fileData.size);
+      const s = await stat(filePath);
+      lastMtimeRef.current = s.mtime ? new Date(s.mtime).getTime() : 0;
+      setExternalChange(null);
+    } catch (err) {
+      console.error("Reload failed:", err);
+      showToast("Failed to reload file", "error");
+    }
+  }, [filePath, showToast]);
+
   // Auto-save: debounced 1.5s after typing stops, only if a file is open and dirty
   useEffect(() => {
     if (!autoSaveEnabled) return;
@@ -196,9 +270,17 @@ function AppContent() {
     if (content === originalContent) return;
 
     const timer = window.setTimeout(() => {
+      setAutoSaveStatus("saving");
       invoke("save_file", { path: filePath, content })
-        .then(() => setOriginalContent(content))
-        .catch((err) => console.error("Auto-save failed:", err));
+        .then(() => {
+          setOriginalContent(content);
+          setAutoSaveStatus("saved");
+          window.setTimeout(() => setAutoSaveStatus((s) => (s === "saved" ? "idle" : s)), 1500);
+        })
+        .catch((err) => {
+          console.error("Auto-save failed:", err);
+          setAutoSaveStatus("error");
+        });
     }, 1500);
 
     return () => window.clearTimeout(timer);
@@ -236,7 +318,19 @@ function AppContent() {
     }
   }, [content, originalContent, loadFileDirect]);
 
-  // Handlers for unsaved-before-open dialog
+  // New file: clears buffer. Used by handleNewFile and the dialog handlers.
+  const startBlankFile = useCallback(() => {
+    setFilePath(null);
+    setFileName("Untitled.md");
+    setContent("");
+    setOriginalContent("");
+    setFileSize(0);
+    setLastFile(null);
+    setMode("code");
+  }, []);
+
+  // Handlers for unsaved-before-open dialog. Supports a "__NEW__" sentinel
+  // so the New File action routes through the same confirmation flow.
   const handleSaveAndOpen = useCallback(async () => {
     setShowUnsavedBeforeOpen(false);
     if (filePath) {
@@ -249,19 +343,23 @@ function AppContent() {
         return;
       }
     }
-    if (pendingFilePath) {
+    if (pendingFilePath === "__NEW__") {
+      startBlankFile();
+    } else if (pendingFilePath) {
       await loadFileDirect(pendingFilePath);
-      setPendingFilePath(null);
     }
-  }, [filePath, content, pendingFilePath, loadFileDirect, showToast]);
+    setPendingFilePath(null);
+  }, [filePath, content, pendingFilePath, loadFileDirect, showToast, startBlankFile]);
 
   const handleDiscardAndOpen = useCallback(async () => {
     setShowUnsavedBeforeOpen(false);
-    if (pendingFilePath) {
+    if (pendingFilePath === "__NEW__") {
+      startBlankFile();
+    } else if (pendingFilePath) {
       await loadFileDirect(pendingFilePath);
-      setPendingFilePath(null);
     }
-  }, [pendingFilePath, loadFileDirect]);
+    setPendingFilePath(null);
+  }, [pendingFilePath, loadFileDirect, startBlankFile]);
 
   const handleCancelOpen = useCallback(() => {
     setShowUnsavedBeforeOpen(false);
@@ -296,6 +394,15 @@ function AppContent() {
     };
   }, [loadFile]);
 
+  const handleNewFile = useCallback(() => {
+    if (content !== originalContent) {
+      setPendingFilePath("__NEW__");
+      setShowUnsavedBeforeOpen(true);
+    } else {
+      startBlankFile();
+    }
+  }, [content, originalContent, startBlankFile]);
+
   // Open file dialog
   const handleOpenFile = useCallback(async () => {
     try {
@@ -317,43 +424,43 @@ function AppContent() {
     }
   }, [loadFile]);
 
-  // Save file
+  // Save As — always prompts for a new path, even if a path is already set.
+  const handleSaveAs = useCallback(async () => {
+    const selected = await save({
+      filters: [{ name: "Markdown", extensions: ["md"] }],
+      defaultPath: fileName ?? undefined,
+    });
+    if (!selected) return;
+    try {
+      await invoke("save_file", { path: selected, content });
+      setFilePath(selected);
+      const name = selected.replace(/\\/g, "/").split("/").pop() || "Untitled";
+      setFileName(name);
+      setOriginalContent(content);
+      addRecentFile(selected, name);
+      setLastFile(selected);
+      showToast("File saved", "success");
+    } catch (err) {
+      console.error("Failed to save file:", err);
+      showToast("Failed to save file", "error");
+    }
+  }, [content, fileName, showToast]);
+
+  // Save file (Save As if no path yet)
   const handleSaveFile = useCallback(async () => {
     if (!filePath) {
-      // Save as new file
-      const selected = await save({
-        filters: [
-          {
-            name: "Markdown",
-            extensions: ["md"],
-          },
-        ],
-      });
-
-      if (selected) {
-        try {
-          await invoke("save_file", { path: selected, content });
-          setFilePath(selected);
-          const name = selected.replace(/\\/g, '/').split('/').pop() || 'Untitled';
-          setFileName(name);
-          setOriginalContent(content);
-          showToast("File saved", "success");
-        } catch (err) {
-          console.error("Failed to save file:", err);
-          showToast("Failed to save file", "error");
-        }
-      }
-    } else {
-      try {
-        await invoke("save_file", { path: filePath, content });
-        setOriginalContent(content);
-        showToast("File saved", "success");
-      } catch (err) {
-        console.error("Failed to save file:", err);
-        showToast("Failed to save file", "error");
-      }
+      await handleSaveAs();
+      return;
     }
-  }, [filePath, content, showToast]);
+    try {
+      await invoke("save_file", { path: filePath, content });
+      setOriginalContent(content);
+      showToast("File saved", "success");
+    } catch (err) {
+      console.error("Failed to save file:", err);
+      showToast("Failed to save file", "error");
+    }
+  }, [filePath, content, showToast, handleSaveAs]);
 
   // Listen for file open from CLI (when app is opened with a file by double-click)
   useEffect(() => {
@@ -465,6 +572,18 @@ function AppContent() {
           handleSaveFile();
         }
       }
+      // Ctrl+Shift+S - Save As
+      if (e.ctrlKey && e.shiftKey && (e.key === "s" || e.key === "S")) {
+        e.preventDefault();
+        if (hasFile || content) {
+          handleSaveAs();
+        }
+      }
+      // Ctrl+N - New file
+      if (e.ctrlKey && !e.shiftKey && e.key === "n") {
+        e.preventDefault();
+        handleNewFile();
+      }
       // Ctrl+E - Toggle preview/code mode (without Shift)
       if (e.ctrlKey && !e.shiftKey && e.key === "e") {
         e.preventDefault();
@@ -497,7 +616,7 @@ function AppContent() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [handleOpenFile, handleSaveFile, handleToggleMode, handleToggleSplit, handleToggleFileExplorer, handleToggleTOC, hasFile, content]);
+  }, [handleOpenFile, handleSaveFile, handleSaveAs, handleNewFile, handleToggleMode, handleToggleSplit, handleToggleFileExplorer, handleToggleTOC, hasFile, content]);
 
   // Get export HTML from the visible preview on demand (avoids duplicate rendering)
   const getExportHtml = useCallback((): string => {
@@ -514,6 +633,14 @@ function AppContent() {
 
     // === File ===
     items.push({
+      id: "file.new",
+      label: "New file",
+      hint: "Ctrl+N",
+      section: "File",
+      icon: "edit_note",
+      run: handleNewFile,
+    });
+    items.push({
       id: "file.open",
       label: "Open file…",
       hint: "Ctrl+O",
@@ -528,6 +655,14 @@ function AppContent() {
       section: "File",
       icon: "save",
       run: handleSaveFile,
+    });
+    items.push({
+      id: "file.saveas",
+      label: "Save As…",
+      hint: "Ctrl+Shift+S",
+      section: "File",
+      icon: "save_as",
+      run: handleSaveAs,
     });
 
     // === View ===
@@ -659,7 +794,8 @@ function AppContent() {
 
     return items;
   }, [
-    handleOpenFile, handleSaveFile, handleToggleSplit, handleToggleFileExplorer, handleToggleTOC,
+    handleNewFile, handleOpenFile, handleSaveFile, handleSaveAs,
+    handleToggleSplit, handleToggleFileExplorer, handleToggleTOC,
     loadFile, filePath, content,
     focusModeEnabled, typewriterModeEnabled, toolbarVisible, autoSaveEnabled,
   ]);
@@ -671,12 +807,34 @@ function AppContent() {
         isDirty={isDirty}
         filePath={filePath ?? undefined}
         onOpenFile={handleOpenFile}
+        onNewFile={handleNewFile}
         onSaveFile={handleSaveFile}
         getExportHtml={getExportHtml}
+        onExportSuccess={(fmt) => showToast(`Exported as ${fmt}`, "success")}
+        onExportError={(fmt) => showToast(`Failed to export ${fmt}`, "error")}
       />
 
+      {externalChange && hasFile && (
+        <div role="alert" className="px-4 py-2 bg-[var(--status-unsaved)]/15 border-b border-[var(--status-unsaved)]/30 flex items-center gap-3 text-sm text-[var(--text-primary)] animate-fade-in-down">
+          <span className="material-symbols-outlined text-[18px] text-[var(--status-unsaved)]">warning</span>
+          <span className="flex-1">
+            {externalChange.kind === "modified"
+              ? "This file was modified outside MarkLite."
+              : "This file was deleted or moved."}
+          </span>
+          {externalChange.kind === "modified" && (
+            <button onClick={reloadFromDisk} className="px-3 py-1 text-xs rounded-[var(--radius-sm)] bg-[var(--accent)] text-[var(--accent-text)] hover:opacity-90">
+              Reload from disk
+            </button>
+          )}
+          <button onClick={dismissExternalChange} className="px-3 py-1 text-xs rounded-[var(--radius-sm)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)]">
+            Keep mine
+          </button>
+        </div>
+      )}
+
       {!hasFile ? (
-        <WelcomeScreen onOpenFile={handleOpenFile} onFileDrop={handleFileDrop} onOpenRecent={loadFile} />
+        <WelcomeScreen onOpenFile={handleOpenFile} onNewFile={handleNewFile} onFileDrop={handleFileDrop} onOpenRecent={loadFile} />
       ) : (
         <>
           {/* Split-aware layout. Both views always mounted; CSS toggles their display
@@ -766,6 +924,7 @@ function AppContent() {
             wordCount={wordCount}
             charCount={charCount}
             readingTimeMin={readingTimeMin}
+            autoSaveStatus={autoSaveStatus}
           />
         </>
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,11 @@ import { SplitDivider } from "./components/SplitDivider";
 import { createScrollSync } from "./utils/scrollSync";
 import { ShortcutCheatsheet } from "./components/ShortcutCheatsheet";
 import { CommandPalette, type PaletteCommand } from "./components/CommandPalette";
+import { SettingsModal } from "./components/SettingsModal";
 import { getRecentFiles } from "./utils/persistence";
 import {
   addRecentFile,
+  getAIConfig,
   getAutoSave,
   getFocusMode,
   getLastFile,
@@ -64,8 +66,10 @@ function AppContent() {
   const [mode, setMode] = useState<ViewMode>(() => getSavedViewMode());
   const [showCheatsheet, setShowCheatsheet] = useState(false);
   const [showPalette, setShowPalette] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const [splitRatio, setSplitRatioState] = useState<number>(() => getSplitRatio());
   const [autoSaveEnabled, setAutoSaveEnabled] = useState<boolean>(() => getAutoSave());
+  const [aiConfig, setAiConfigState] = useState(() => getAIConfig());
   const [focusModeEnabled, setFocusModeEnabled] = useState<boolean>(() => getFocusMode());
   const [typewriterModeEnabled, setTypewriterModeEnabled] = useState<boolean>(() => getTypewriterMode());
   const [toolbarVisible, setToolbarVisible] = useState<boolean>(() => getToolbarEnabled());
@@ -179,7 +183,15 @@ function AppContent() {
       ["marklite:toolbar-toggle", (e) => setToolbarVisible(!!(e as CustomEvent).detail?.enabled)],
     ];
     handlers.forEach(([k, h]) => window.addEventListener(k, h));
-    return () => handlers.forEach(([k, h]) => window.removeEventListener(k, h));
+
+    // Re-read AI config when settings modal closes — cheap, single localStorage read
+    const onStorage = () => setAiConfigState(getAIConfig());
+    window.addEventListener("storage", onStorage);
+
+    return () => {
+      handlers.forEach(([k, h]) => window.removeEventListener(k, h));
+      window.removeEventListener("storage", onStorage);
+    };
   }, []);
 
   // Listen for SettingsMenu toggling auto-save (cross-component event keeps both sides in sync)
@@ -393,6 +405,28 @@ function AppContent() {
       unlisten?.();
     };
   }, [loadFile]);
+
+  // Wikilink click: resolve target relative to the current file's folder.
+  // Tries `<target>.md` first, then `<target>` literal. Silently fails if neither exists.
+  const handleWikilinkClick = useCallback(async (target: string) => {
+    if (!filePath) return;
+    const lastSep = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+    const dir = lastSep > 0 ? filePath.slice(0, lastSep) : "";
+    const sep = filePath.includes("\\") ? "\\" : "/";
+    const candidates = [
+      `${dir}${sep}${target}.md`,
+      `${dir}${sep}${target}.markdown`,
+      `${dir}${sep}${target}`,
+    ];
+    for (const c of candidates) {
+      try {
+        await stat(c);
+        loadFile(c);
+        return;
+      } catch {/* try next */}
+    }
+    showToast(`Could not resolve [[${target}]]`, "error");
+  }, [filePath, loadFile, showToast]);
 
   const handleNewFile = useCallback(() => {
     if (content !== originalContent) {
@@ -612,6 +646,11 @@ function AppContent() {
         e.preventDefault();
         setShowPalette(true);
       }
+      // Ctrl+, — Settings
+      if ((e.ctrlKey || e.metaKey) && e.key === ",") {
+        e.preventDefault();
+        setShowSettings(true);
+      }
     };
 
     window.addEventListener("keydown", handleKeyDown);
@@ -736,6 +775,15 @@ function AppContent() {
       section: "Toggles",
       icon: "save_as",
       run: () => setAutoSaveEnabled((v) => !v),
+    });
+
+    items.push({
+      id: "settings.open",
+      label: "Open Settings…",
+      hint: "Ctrl+,",
+      section: "Toggles",
+      icon: "settings",
+      run: () => setShowSettings(true),
     });
 
     // === Help ===
@@ -864,6 +912,7 @@ function AppContent() {
                 focusMode={focusModeEnabled}
                 typewriterMode={typewriterModeEnabled}
                 showToolbar={toolbarVisible}
+                aiConfig={aiConfig}
               />
             </div>
 
@@ -893,6 +942,7 @@ function AppContent() {
                 onContentChange={handleContentChange}
                 onScrollFraction={onPreviewScrollFraction}
                 registerScroller={registerPreviewScroller}
+                onWikilinkClick={handleWikilinkClick}
               />
             </div>
           </div>
@@ -910,6 +960,7 @@ function AppContent() {
             isOpen={showTOC}
             content={content}
             onClose={closeAllPanels}
+            activeLine={mode === "preview" ? previewLine : cursorPosition.line}
           />
 
 <StatusBar
@@ -949,6 +1000,13 @@ function AppContent() {
 
       <ShortcutCheatsheet isOpen={showCheatsheet} onClose={() => setShowCheatsheet(false)} />
       <CommandPalette isOpen={showPalette} items={paletteItems} onClose={() => setShowPalette(false)} />
+      <SettingsModal
+        isOpen={showSettings}
+        onClose={() => {
+          setShowSettings(false);
+          setAiConfigState(getAIConfig()); // pick up endpoint/key edits immediately
+        }}
+      />
 
       {/* Toast notifications */}
       <Toast

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ import { UnsavedChangesDialog } from "./components/UnsavedChangesDialog";
 import { SplitDivider } from "./components/SplitDivider";
 import { createScrollSync } from "./utils/scrollSync";
 import { ShortcutCheatsheet } from "./components/ShortcutCheatsheet";
+import { CommandPalette, type PaletteCommand } from "./components/CommandPalette";
+import { getRecentFiles } from "./utils/persistence";
 import {
   addRecentFile,
   getAutoSave,
@@ -60,6 +62,7 @@ function AppContent() {
   // UI state
   const [mode, setMode] = useState<ViewMode>(() => getSavedViewMode());
   const [showCheatsheet, setShowCheatsheet] = useState(false);
+  const [showPalette, setShowPalette] = useState(false);
   const [splitRatio, setSplitRatioState] = useState<number>(() => getSplitRatio());
   const [autoSaveEnabled, setAutoSaveEnabled] = useState<boolean>(() => getAutoSave());
   const [focusModeEnabled, setFocusModeEnabled] = useState<boolean>(() => getFocusMode());
@@ -485,6 +488,11 @@ function AppContent() {
           setShowCheatsheet(true);
         }
       }
+      // Ctrl+P / Ctrl+Shift+P — command palette
+      if ((e.ctrlKey || e.metaKey) && (e.key === "p" || e.key === "P")) {
+        e.preventDefault();
+        setShowPalette(true);
+      }
     };
 
     window.addEventListener("keydown", handleKeyDown);
@@ -498,6 +506,163 @@ function AppContent() {
     }
     return "";
   }, []);
+
+  // Build the command palette item list. Rebuilds on relevant state changes —
+  // recent files, current file, current view mode, toggles.
+  const paletteItems = useMemo<PaletteCommand[]>(() => {
+    const items: PaletteCommand[] = [];
+
+    // === File ===
+    items.push({
+      id: "file.open",
+      label: "Open file…",
+      hint: "Ctrl+O",
+      section: "File",
+      icon: "folder_open",
+      run: handleOpenFile,
+    });
+    items.push({
+      id: "file.save",
+      label: "Save",
+      hint: "Ctrl+S",
+      section: "File",
+      icon: "save",
+      run: handleSaveFile,
+    });
+
+    // === View ===
+    items.push({
+      id: "view.preview",
+      label: "Switch to Reader mode",
+      hint: "Ctrl+E",
+      section: "View",
+      icon: "visibility",
+      run: () => setMode("preview"),
+    });
+    items.push({
+      id: "view.code",
+      label: "Switch to Code editor",
+      section: "View",
+      icon: "code",
+      run: () => setMode("code"),
+    });
+    items.push({
+      id: "view.split",
+      label: "Toggle Split view",
+      hint: "Ctrl+\\",
+      section: "View",
+      icon: "vertical_split",
+      run: handleToggleSplit,
+    });
+    items.push({
+      id: "view.explorer",
+      label: "Toggle file explorer",
+      hint: "Ctrl+Shift+E",
+      section: "View",
+      icon: "folder",
+      run: handleToggleFileExplorer,
+    });
+    items.push({
+      id: "view.toc",
+      label: "Toggle outline",
+      hint: "Ctrl+Shift+O",
+      section: "View",
+      icon: "format_list_bulleted",
+      run: handleToggleTOC,
+    });
+
+    // === Toggles ===
+    items.push({
+      id: "toggle.focus",
+      label: focusModeEnabled ? "Disable Focus mode" : "Enable Focus mode",
+      section: "Toggles",
+      icon: "center_focus_strong",
+      keywords: "dim non-active line",
+      run: () => setFocusModeEnabled((v) => !v),
+    });
+    items.push({
+      id: "toggle.typewriter",
+      label: typewriterModeEnabled ? "Disable Typewriter mode" : "Enable Typewriter mode",
+      section: "Toggles",
+      icon: "keyboard",
+      keywords: "scroll caret center",
+      run: () => setTypewriterModeEnabled((v) => !v),
+    });
+    items.push({
+      id: "toggle.toolbar",
+      label: toolbarVisible ? "Hide formatting toolbar" : "Show formatting toolbar",
+      section: "Toggles",
+      icon: "format_paint",
+      run: () => setToolbarVisible((v) => !v),
+    });
+    items.push({
+      id: "toggle.autosave",
+      label: autoSaveEnabled ? "Disable auto-save" : "Enable auto-save",
+      section: "Toggles",
+      icon: "save_as",
+      run: () => setAutoSaveEnabled((v) => !v),
+    });
+
+    // === Help ===
+    items.push({
+      id: "help.cheatsheet",
+      label: "Show keyboard shortcuts",
+      hint: "?",
+      section: "Help",
+      icon: "keyboard",
+      run: () => setShowCheatsheet(true),
+    });
+
+    // === Recent files ===
+    const recents = getRecentFiles();
+    for (const r of recents) {
+      if (r.path === filePath) continue; // current file
+      items.push({
+        id: `recent.${r.path}`,
+        label: r.name,
+        hint: r.path,
+        section: "Recent files",
+        icon: "description",
+        keywords: r.path,
+        run: () => loadFile(r.path),
+      });
+    }
+
+    // === Headings of current document ===
+    if (content) {
+      const lines = content.split("\n");
+      lines.forEach((line, idx) => {
+        const m = line.match(/^(#{1,6})\s+(.+)$/);
+        if (m) {
+          const level = m[1].length;
+          const text = m[2].trim();
+          items.push({
+            id: `head.${idx}`,
+            label: text,
+            hint: `H${level}`,
+            section: "Headings",
+            icon: level === 1 ? "title" : level === 2 ? "format_h2" : "format_h3",
+            keywords: "jump heading",
+            run: () => {
+              // Switch to preview if in code-only mode, then scroll to heading
+              setMode((prev) => (prev === "code" ? "preview" : prev));
+              requestAnimationFrame(() => {
+                const slug = text.toLowerCase().trim().replace(/[^\w\s-]/g, "").replace(/\s+/g, "-").replace(/-+/g, "-");
+                const el = document.getElementById(slug);
+                el?.scrollIntoView({ behavior: "smooth", block: "start" });
+              });
+            },
+          });
+        }
+      });
+    }
+
+    return items;
+  }, [
+    handleOpenFile, handleSaveFile, handleToggleSplit, handleToggleFileExplorer, handleToggleTOC,
+    loadFile, filePath, content,
+    focusModeEnabled, typewriterModeEnabled, toolbarVisible, autoSaveEnabled,
+  ]);
 
   return (
     <div className="h-screen flex flex-col bg-[var(--bg-primary)] overflow-hidden transition-colors">
@@ -624,6 +789,7 @@ function AppContent() {
       )}
 
       <ShortcutCheatsheet isOpen={showCheatsheet} onClose={() => setShowCheatsheet(false)} />
+      <CommandPalette isOpen={showPalette} items={paletteItems} onClose={() => setShowPalette(false)} />
 
       {/* Toast notifications */}
       <Toast

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,11 +9,21 @@ import { WelcomeScreen } from "./components/WelcomeScreen";
 import { MarkdownPreview } from "./components/MarkdownPreview";
 import { CodeEditor } from "./components/CodeEditor";
 import { StatusBar } from "./components/StatusBar";
-import { ModeToggle } from "./components/ModeToggle";
+import { ModeToggle, type ViewMode } from "./components/ModeToggle";
 import { FileExplorer } from "./components/FileExplorer";
 import { TableOfContents } from "./components/TableOfContents";
 import { Toast, ToastType } from "./components/Toast";
 import { UnsavedChangesDialog } from "./components/UnsavedChangesDialog";
+import { SplitDivider } from "./components/SplitDivider";
+import {
+  addRecentFile,
+  getLastFile,
+  getSavedViewMode,
+  getSplitRatio,
+  setLastFile,
+  setSavedViewMode,
+  setSplitRatio,
+} from "./utils/persistence";
 
 interface FileData {
   path: string;
@@ -22,8 +32,6 @@ interface FileData {
   size: number;
   line_count: number;
 }
-
-type ViewMode = "preview" | "code";
 
 // Utility function to count words in text
 const getWordCount = (text: string): number => {
@@ -40,7 +48,8 @@ function AppContent() {
   const [fileSize, setFileSize] = useState<number>(0);
 
   // UI state
-  const [mode, setMode] = useState<ViewMode>("preview");
+  const [mode, setMode] = useState<ViewMode>(() => getSavedViewMode());
+  const [splitRatio, setSplitRatioState] = useState<number>(() => getSplitRatio());
   const [cursorPosition, setCursorPosition] = useState({ line: 1, col: 1 });
   const [isLoading, setIsLoading] = useState(false);
 
@@ -60,6 +69,7 @@ function AppContent() {
 
   // Export HTML content ref - captures from visible preview
   const previewRef = useRef<HTMLDivElement>(null);
+  const splitContainerRef = useRef<HTMLDivElement>(null);
 
   // Derived state
   const isDirty = content !== originalContent;
@@ -82,7 +92,9 @@ function AppContent() {
       setContent(fileData.content);
       setOriginalContent(fileData.content);
       setFileSize(fileData.size);
-      setMode("preview");
+      // Track recents + last-opened for restore-on-launch
+      addRecentFile(fileData.path, fileData.name);
+      setLastFile(fileData.path);
     } catch (err) {
       console.error("Failed to load file:", err);
       showToast("Failed to open file", "error");
@@ -90,6 +102,36 @@ function AppContent() {
       setIsLoading(false);
     }
   }, [showToast]);
+
+  // Persist view mode + restore last file on mount
+  useEffect(() => {
+    setSavedViewMode(mode);
+  }, [mode]);
+
+  useEffect(() => {
+    setSplitRatio(splitRatio);
+  }, [splitRatio]);
+
+  useEffect(() => {
+    // Restore last opened file once on app launch
+    const last = getLastFile();
+    if (last) {
+      // Fire-and-forget; failures are silent (file may have been moved/deleted)
+      invoke<FileData>("read_file", { path: last })
+        .then((fileData) => {
+          setFilePath(fileData.path);
+          setFileName(fileData.name);
+          setContent(fileData.content);
+          setOriginalContent(fileData.content);
+          setFileSize(fileData.size);
+        })
+        .catch(() => {
+          setLastFile(null);
+        });
+    }
+    // Run only once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Load file with unsaved changes protection
   const loadFile = useCallback(async (path: string) => {
@@ -245,9 +287,13 @@ function AppContent() {
     };
   }, [loadFile]);
 
-  // Toggle mode
+  // Toggle between preview and code (skips split — split has its own shortcut)
   const handleToggleMode = useCallback(() => {
-    setMode((prev) => (prev === "preview" ? "code" : "preview"));
+    setMode((prev) => (prev === "code" ? "preview" : "code"));
+  }, []);
+
+  const handleToggleSplit = useCallback(() => {
+    setMode((prev) => (prev === "split" ? "preview" : "split"));
   }, []);
 
   // Toggle file explorer (mutually exclusive with TOC)
@@ -327,18 +373,25 @@ function AppContent() {
           handleSaveFile();
         }
       }
-      // Ctrl+E - Toggle mode (without Shift)
+      // Ctrl+E - Toggle preview/code mode (without Shift)
       if (e.ctrlKey && !e.shiftKey && e.key === "e") {
         e.preventDefault();
         if (hasFile) {
           handleToggleMode();
         }
       }
+      // Ctrl+\ - Toggle split view
+      if (e.ctrlKey && !e.shiftKey && e.key === "\\") {
+        e.preventDefault();
+        if (hasFile) {
+          handleToggleSplit();
+        }
+      }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [handleOpenFile, handleSaveFile, handleToggleMode, handleToggleFileExplorer, handleToggleTOC, hasFile, content]);
+  }, [handleOpenFile, handleSaveFile, handleToggleMode, handleToggleSplit, handleToggleFileExplorer, handleToggleTOC, hasFile, content]);
 
   // Get export HTML from the visible preview on demand (avoids duplicate rendering)
   const getExportHtml = useCallback((): string => {
@@ -363,32 +416,60 @@ function AppContent() {
         <WelcomeScreen onOpenFile={handleOpenFile} onFileDrop={handleFileDrop} />
       ) : (
         <>
-          {/* Both views rendered; toggle via display to preserve scroll/state */}
-          <div className="flex-1 overflow-hidden flex flex-col" style={{ display: mode === "preview" ? "flex" : "none" }}>
-            <MarkdownPreview
-              content={content}
-              fileName={fileName || ""}
-              lineCount={lineCount}
-              fileSize={fileSize}
-              onEditClick={handleToggleMode}
-              onLineChange={(line) => setPreviewLine(line)}
-              filePath={filePath}
-              markdownBodyRef={previewRef}
-              onContentChange={handleContentChange}
-            />
-          </div>
-          <div className="flex-1 overflow-hidden flex flex-col" style={{ display: mode === "code" ? "flex" : "none" }}>
-            <CodeEditor
-              content={content}
-              onChange={handleContentChange}
-              onCursorChange={(line, col) => setCursorPosition({ line, col })}
-              onImagePaste={handleImagePaste}
-              onError={handleError}
-              filePath={filePath}
-            />
+          {/* Split-aware layout. Both views always mounted; CSS toggles their display
+              and width so editor/preview state (scroll, selection) is preserved across
+              mode switches. */}
+          <div ref={splitContainerRef} className="flex-1 overflow-hidden flex flex-row">
+            <div
+              data-split-left
+              className="overflow-hidden flex flex-col"
+              style={{
+                display: mode === "code" || mode === "split" ? "flex" : "none",
+                flexBasis: mode === "split" ? `${splitRatio * 100}%` : "100%",
+                flexGrow: mode === "split" ? 0 : 1,
+                flexShrink: 0,
+                minWidth: 0,
+              }}
+            >
+              <CodeEditor
+                content={content}
+                onChange={handleContentChange}
+                onCursorChange={(line, col) => setCursorPosition({ line, col })}
+                onImagePaste={handleImagePaste}
+                onError={handleError}
+                filePath={filePath}
+              />
+            </div>
+
+            {mode === "split" && (
+              <SplitDivider onDrag={setSplitRatioState} containerRef={splitContainerRef} />
+            )}
+
+            <div
+              className="overflow-hidden flex flex-col"
+              style={{
+                display: mode === "preview" || mode === "split" ? "flex" : "none",
+                flexBasis: mode === "split" ? `${(1 - splitRatio) * 100}%` : "100%",
+                flexGrow: mode === "split" ? 0 : 1,
+                flexShrink: 0,
+                minWidth: 0,
+              }}
+            >
+              <MarkdownPreview
+                content={content}
+                fileName={fileName || ""}
+                lineCount={lineCount}
+                fileSize={fileSize}
+                onEditClick={handleToggleMode}
+                onLineChange={(line) => setPreviewLine(line)}
+                filePath={filePath}
+                markdownBodyRef={previewRef}
+                onContentChange={handleContentChange}
+              />
+            </div>
           </div>
 
-          <ModeToggle mode={mode} onToggle={handleToggleMode} />
+          <ModeToggle mode={mode} onSetMode={setMode} />
 
           {/* Sidebar Panels */}
           <FileExplorer

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,10 @@ function AppContent() {
   const lineCount = useMemo(() => content.split("\n").length, [content]);
   const hasFile = filePath !== null;
   const wordCount = useMemo(() => getWordCount(content), [content]);
+  const charCount = useMemo(() => content.length, [content]);
+  // Average adult reading speed for prose: ~200 wpm. Markdown markup inflates
+  // word count slightly, but the rough number is what users actually want.
+  const readingTimeMin = useMemo(() => wordCount / 200, [wordCount]);
 
   // Show toast helper
   const showToast = useCallback((message: string, type: ToastType = 'success') => {
@@ -526,6 +530,8 @@ function AppContent() {
             onToggleFileExplorer={handleToggleFileExplorer}
             onToggleTOC={handleToggleTOC}
             wordCount={wordCount}
+            charCount={charCount}
+            readingTimeMin={readingTimeMin}
           />
         </>
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,13 +20,19 @@ import { ShortcutCheatsheet } from "./components/ShortcutCheatsheet";
 import {
   addRecentFile,
   getAutoSave,
+  getFocusMode,
   getLastFile,
   getSavedViewMode,
   getSplitRatio,
+  getToolbarEnabled,
+  getTypewriterMode,
   setAutoSave,
+  setFocusMode,
   setLastFile,
   setSavedViewMode,
   setSplitRatio,
+  setToolbarEnabled,
+  setTypewriterMode,
 } from "./utils/persistence";
 
 interface FileData {
@@ -56,6 +62,9 @@ function AppContent() {
   const [showCheatsheet, setShowCheatsheet] = useState(false);
   const [splitRatio, setSplitRatioState] = useState<number>(() => getSplitRatio());
   const [autoSaveEnabled, setAutoSaveEnabled] = useState<boolean>(() => getAutoSave());
+  const [focusModeEnabled, setFocusModeEnabled] = useState<boolean>(() => getFocusMode());
+  const [typewriterModeEnabled, setTypewriterModeEnabled] = useState<boolean>(() => getTypewriterMode());
+  const [toolbarVisible, setToolbarVisible] = useState<boolean>(() => getToolbarEnabled());
   const [cursorPosition, setCursorPosition] = useState({ line: 1, col: 1 });
   const [isLoading, setIsLoading] = useState(false);
 
@@ -151,6 +160,21 @@ function AppContent() {
   useEffect(() => {
     setAutoSave(autoSaveEnabled);
   }, [autoSaveEnabled]);
+
+  useEffect(() => { setFocusMode(focusModeEnabled); }, [focusModeEnabled]);
+  useEffect(() => { setTypewriterMode(typewriterModeEnabled); }, [typewriterModeEnabled]);
+  useEffect(() => { setToolbarEnabled(toolbarVisible); }, [toolbarVisible]);
+
+  // Cross-component event listeners — settings menu and command palette toggle these
+  useEffect(() => {
+    const handlers: Array<[string, (e: Event) => void]> = [
+      ["marklite:focus-toggle", (e) => setFocusModeEnabled(!!(e as CustomEvent).detail?.enabled)],
+      ["marklite:typewriter-toggle", (e) => setTypewriterModeEnabled(!!(e as CustomEvent).detail?.enabled)],
+      ["marklite:toolbar-toggle", (e) => setToolbarVisible(!!(e as CustomEvent).detail?.enabled)],
+    ];
+    handlers.forEach(([k, h]) => window.addEventListener(k, h));
+    return () => handlers.forEach(([k, h]) => window.removeEventListener(k, h));
+  }, []);
 
   // Listen for SettingsMenu toggling auto-save (cross-component event keeps both sides in sync)
   useEffect(() => {
@@ -514,6 +538,9 @@ function AppContent() {
                 filePath={filePath}
                 onScrollFraction={onCodeScrollFraction}
                 registerScroller={registerCodeScroller}
+                focusMode={focusModeEnabled}
+                typewriterMode={typewriterModeEnabled}
+                showToolbar={toolbarVisible}
               />
             </div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { Toast, ToastType } from "./components/Toast";
 import { UnsavedChangesDialog } from "./components/UnsavedChangesDialog";
 import { SplitDivider } from "./components/SplitDivider";
 import { createScrollSync } from "./utils/scrollSync";
+import { ShortcutCheatsheet } from "./components/ShortcutCheatsheet";
 import {
   addRecentFile,
   getAutoSave,
@@ -52,6 +53,7 @@ function AppContent() {
 
   // UI state
   const [mode, setMode] = useState<ViewMode>(() => getSavedViewMode());
+  const [showCheatsheet, setShowCheatsheet] = useState(false);
   const [splitRatio, setSplitRatioState] = useState<number>(() => getSplitRatio());
   const [autoSaveEnabled, setAutoSaveEnabled] = useState<boolean>(() => getAutoSave());
   const [cursorPosition, setCursorPosition] = useState({ line: 1, col: 1 });
@@ -450,6 +452,15 @@ function AppContent() {
           handleToggleSplit();
         }
       }
+      // ? — Show cheatsheet (only when no input is focused)
+      if (e.key === "?" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        const target = e.target as HTMLElement | null;
+        const isTyping = target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable);
+        if (!isTyping) {
+          e.preventDefault();
+          setShowCheatsheet(true);
+        }
+      }
     };
 
     window.addEventListener("keydown", handleKeyDown);
@@ -584,6 +595,8 @@ function AppContent() {
           </div>
         </div>
       )}
+
+      <ShortcutCheatsheet isOpen={showCheatsheet} onClose={() => setShowCheatsheet(false)} />
 
       {/* Toast notifications */}
       <Toast

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,9 +17,11 @@ import { UnsavedChangesDialog } from "./components/UnsavedChangesDialog";
 import { SplitDivider } from "./components/SplitDivider";
 import {
   addRecentFile,
+  getAutoSave,
   getLastFile,
   getSavedViewMode,
   getSplitRatio,
+  setAutoSave,
   setLastFile,
   setSavedViewMode,
   setSplitRatio,
@@ -50,6 +52,7 @@ function AppContent() {
   // UI state
   const [mode, setMode] = useState<ViewMode>(() => getSavedViewMode());
   const [splitRatio, setSplitRatioState] = useState<number>(() => getSplitRatio());
+  const [autoSaveEnabled, setAutoSaveEnabled] = useState<boolean>(() => getAutoSave());
   const [cursorPosition, setCursorPosition] = useState({ line: 1, col: 1 });
   const [isLoading, setIsLoading] = useState(false);
 
@@ -111,6 +114,35 @@ function AppContent() {
   useEffect(() => {
     setSplitRatio(splitRatio);
   }, [splitRatio]);
+
+  useEffect(() => {
+    setAutoSave(autoSaveEnabled);
+  }, [autoSaveEnabled]);
+
+  // Listen for SettingsMenu toggling auto-save (cross-component event keeps both sides in sync)
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (typeof detail?.enabled === "boolean") setAutoSaveEnabled(detail.enabled);
+    };
+    window.addEventListener("marklite:autosave-toggle", handler);
+    return () => window.removeEventListener("marklite:autosave-toggle", handler);
+  }, []);
+
+  // Auto-save: debounced 1.5s after typing stops, only if a file is open and dirty
+  useEffect(() => {
+    if (!autoSaveEnabled) return;
+    if (!filePath) return;
+    if (content === originalContent) return;
+
+    const timer = window.setTimeout(() => {
+      invoke("save_file", { path: filePath, content })
+        .then(() => setOriginalContent(content))
+        .catch((err) => console.error("Auto-save failed:", err));
+    }, 1500);
+
+    return () => window.clearTimeout(timer);
+  }, [autoSaveEnabled, content, originalContent, filePath]);
 
   useEffect(() => {
     // Restore last opened file once on app launch
@@ -413,7 +445,7 @@ function AppContent() {
       />
 
       {!hasFile ? (
-        <WelcomeScreen onOpenFile={handleOpenFile} onFileDrop={handleFileDrop} />
+        <WelcomeScreen onOpenFile={handleOpenFile} onFileDrop={handleFileDrop} onOpenRecent={loadFile} />
       ) : (
         <>
           {/* Split-aware layout. Both views always mounted; CSS toggles their display

--- a/src/components/AIBubble.tsx
+++ b/src/components/AIBubble.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from "react";
+import { runAIAction, type AIAction, type AIConfig } from "../utils/aiAssist";
+
+interface AIBubbleProps {
+    /** Anchor pixel position (top-left of selection or caret). Null hides bubble. */
+    anchor: { x: number; y: number } | null;
+    /** Currently selected text (or empty for "continue"). */
+    selectedText: string;
+    config: AIConfig;
+    /** Replace the selection with `result`. */
+    onReplace: (result: string) => void;
+    /** Insert `result` after the selection without replacing. */
+    onInsert: (result: string) => void;
+    onClose: () => void;
+}
+
+const ACTIONS: Array<{ id: AIAction; label: string; icon: string; needsSelection: boolean }> = [
+    { id: "rewrite", label: "Rewrite", icon: "auto_fix_high", needsSelection: true },
+    { id: "shorten", label: "Shorten", icon: "compress", needsSelection: true },
+    { id: "expand", label: "Expand", icon: "expand", needsSelection: true },
+    { id: "continue", label: "Continue", icon: "play_arrow", needsSelection: false },
+    { id: "translate", label: "Translate → EN", icon: "translate", needsSelection: true },
+];
+
+export function AIBubble({ anchor, selectedText, config, onReplace, onInsert, onClose }: AIBubbleProps) {
+    const [busy, setBusy] = useState<AIAction | null>(null);
+    const [result, setResult] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const abortRef = useRef<AbortController | null>(null);
+
+    useEffect(() => {
+        if (!anchor) {
+            setResult(null);
+            setError(null);
+            setBusy(null);
+            abortRef.current?.abort();
+        }
+    }, [anchor]);
+
+    if (!anchor) return null;
+
+    const run = async (action: AIAction) => {
+        const ctrl = new AbortController();
+        abortRef.current = ctrl;
+        setBusy(action);
+        setError(null);
+        setResult(null);
+        try {
+            const out = await runAIAction(action, selectedText, config, ctrl.signal);
+            setResult(out);
+        } catch (e) {
+            if ((e as Error).name === "AbortError") return;
+            setError((e as Error).message);
+        } finally {
+            setBusy(null);
+        }
+    };
+
+    return (
+        <div
+            role="dialog"
+            aria-label="AI assist"
+            className="fixed z-[90] bg-[var(--bg-secondary)] border border-[var(--border)] rounded-[var(--radius-md)] shadow-2xl animate-fade-in"
+            style={{ left: anchor.x, top: anchor.y, maxWidth: 380 }}
+        >
+            <div className="flex items-center gap-1 px-1 py-1 border-b border-[var(--border-subtle)]">
+                {ACTIONS.filter((a) => !a.needsSelection || selectedText).map((a) => (
+                    <button
+                        key={a.id}
+                        onClick={() => run(a.id)}
+                        disabled={busy !== null}
+                        title={a.label}
+                        className={`flex items-center gap-1 px-2 py-1 text-xs rounded-[var(--radius-sm)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors disabled:opacity-50 ${busy === a.id ? "bg-[var(--bg-hover)]" : ""}`}
+                    >
+                        <span className={`material-symbols-outlined text-[14px] ${busy === a.id ? "animate-spin" : ""}`}>
+                            {busy === a.id ? "progress_activity" : a.icon}
+                        </span>
+                        <span>{a.label}</span>
+                    </button>
+                ))}
+                <button
+                    onClick={onClose}
+                    aria-label="Close AI bubble"
+                    className="ml-auto w-6 h-6 rounded-[var(--radius-sm)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] flex items-center justify-center"
+                >
+                    <span className="material-symbols-outlined text-[14px]">close</span>
+                </button>
+            </div>
+
+            {error && (
+                <div className="px-3 py-2 text-xs text-[var(--danger)] bg-[var(--danger)]/10">
+                    {error}
+                </div>
+            )}
+
+            {result !== null && (
+                <div className="p-2 max-w-[380px]">
+                    <div className="text-[11px] uppercase tracking-wider text-[var(--text-muted)] mb-1">Suggestion</div>
+                    <div className="px-2 py-1.5 text-sm text-[var(--text-primary)] bg-[var(--bg-input)] border border-[var(--border-subtle)] rounded-[var(--radius-sm)] max-h-40 overflow-y-auto whitespace-pre-wrap">
+                        {result}
+                    </div>
+                    <div className="flex gap-1 mt-2 justify-end">
+                        <button
+                            onClick={() => onInsert(result)}
+                            className="px-2 py-1 text-xs rounded-[var(--radius-sm)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)]"
+                        >
+                            Insert below
+                        </button>
+                        <button
+                            onClick={() => onReplace(result)}
+                            className="px-2 py-1 text-xs rounded-[var(--radius-sm)] bg-[var(--accent)] text-[var(--accent-text)] hover:opacity-90"
+                        >
+                            Replace
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -10,6 +10,7 @@ import {
     insertLink,
     type EditorResult,
 } from "../utils/editorActions";
+import { FindReplaceBar } from "./FindReplaceBar";
 
 interface CodeEditorProps {
     content: string;
@@ -50,6 +51,9 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
     const gutterRef = useRef<HTMLDivElement>(null);
     const highlightRef = useRef<HTMLDivElement>(null);
     const [activeLine, setActiveLine] = useState(1);
+    const [findOpen, setFindOpen] = useState(false);
+    const [findMode, setFindMode] = useState<"find" | "replace">("find");
+    const [selStartForFind, setSelStartForFind] = useState(0);
 
     const lines = useMemo(() => content.split("\n"), [content]);
     const lineCount = lines.length;
@@ -79,6 +83,24 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
     const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         const state = getState();
         if (!state) return;
+
+        // Ctrl+F / Ctrl+H — open find / find-and-replace bar
+        if ((e.ctrlKey || e.metaKey) && !e.altKey) {
+            if (e.key === "f" || e.key === "F") {
+                e.preventDefault();
+                setSelStartForFind(state.selStart);
+                setFindMode("find");
+                setFindOpen(true);
+                return;
+            }
+            if (e.key === "h" || e.key === "H") {
+                e.preventDefault();
+                setSelStartForFind(state.selStart);
+                setFindMode("replace");
+                setFindOpen(true);
+                return;
+            }
+        }
 
         // Ctrl/Cmd shortcuts (Bold, Italic, Link). Other Ctrl combos handled at app level.
         if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey) {
@@ -433,6 +455,29 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
         return parts.length > 0 ? <>{parts}</> : <span>{text}</span>;
     }
 
+    const handleFindJump = useCallback((start: number, end: number) => {
+        const t = textareaRef.current;
+        if (!t) return;
+        t.focus();
+        t.selectionStart = start;
+        t.selectionEnd = end;
+        // Scroll the matched line into view (textarea native scrollIntoView is unreliable;
+        // compute by line index instead)
+        const lineIdx = content.slice(0, start).split("\n").length - 1;
+        const desiredTop = lineIdx * EDITOR_LINE_HEIGHT - t.clientHeight / 2;
+        t.scrollTop = Math.max(0, desiredTop);
+    }, [content]);
+
+    const handleFindReplace = useCallback((newContent: string, newCursor: number) => {
+        onChange(newContent);
+        requestAnimationFrame(() => {
+            const t = textareaRef.current;
+            if (!t) return;
+            t.selectionStart = newCursor;
+            t.selectionEnd = newCursor;
+        });
+    }, [onChange]);
+
     return (
         <main className="flex-1 flex overflow-hidden relative">
             {/* Line Numbers Gutter */}
@@ -490,6 +535,19 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                         </div>
                     ))}
                 </div>
+
+                <FindReplaceBar
+                    isOpen={findOpen}
+                    initialMode={findMode}
+                    content={content}
+                    selectionStart={selStartForFind}
+                    onClose={() => {
+                        setFindOpen(false);
+                        textareaRef.current?.focus();
+                    }}
+                    onJumpTo={handleFindJump}
+                    onReplace={handleFindReplace}
+                />
 
                 {/* Actual Editable Textarea — transparent text, real caret */}
                 <textarea

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -1,5 +1,15 @@
 import { useRef, useCallback, useEffect, useMemo, useState } from "react";
 import { getImageFromClipboard, saveImageToFile, createMarkdownImage, insertAtCursor } from "../utils/imageUtils";
+import {
+    handleTab,
+    handleEnter,
+    handleAutoPair,
+    handleSkipCloser,
+    handleBackspace,
+    wrapSelection,
+    insertLink,
+    type EditorResult,
+} from "../utils/editorActions";
 
 interface CodeEditorProps {
     content: string;
@@ -47,6 +57,112 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
     const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         onChange(e.target.value);
     };
+
+    // Apply an EditorResult: update content + restore selection on next frame.
+    // (selection must be set after React flushes the new value to the DOM)
+    const applyResult = useCallback((r: EditorResult) => {
+        onChange(r.text);
+        requestAnimationFrame(() => {
+            const t = textareaRef.current;
+            if (!t) return;
+            t.selectionStart = r.selStart;
+            t.selectionEnd = r.selEnd;
+        });
+    }, [onChange]);
+
+    const getState = useCallback(() => {
+        const t = textareaRef.current;
+        if (!t) return null;
+        return { text: t.value, selStart: t.selectionStart, selEnd: t.selectionEnd };
+    }, []);
+
+    const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        const state = getState();
+        if (!state) return;
+
+        // Ctrl/Cmd shortcuts (Bold, Italic, Link). Other Ctrl combos handled at app level.
+        if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey) {
+            if (e.key === "b" || e.key === "B") {
+                e.preventDefault();
+                applyResult(wrapSelection(state, "**", "**", "bold"));
+                return;
+            }
+            if (e.key === "i" || e.key === "I") {
+                e.preventDefault();
+                applyResult(wrapSelection(state, "*", "*", "italic"));
+                return;
+            }
+            if (e.key === "k" || e.key === "K") {
+                e.preventDefault();
+                applyResult(insertLink(state));
+                return;
+            }
+            // Ctrl+/ — toggle blockquote on the current line
+            if (e.key === "/") {
+                e.preventDefault();
+                const ls = state.text.lastIndexOf("\n", state.selStart - 1) + 1;
+                const lineEnd = state.text.indexOf("\n", state.selStart);
+                const end = lineEnd === -1 ? state.text.length : lineEnd;
+                const line = state.text.slice(ls, end);
+                const quoted = line.startsWith("> ");
+                const newLine = quoted ? line.slice(2) : "> " + line;
+                const delta = newLine.length - line.length;
+                applyResult({
+                    text: state.text.slice(0, ls) + newLine + state.text.slice(end),
+                    selStart: state.selStart + delta,
+                    selEnd: state.selEnd + delta,
+                });
+                return;
+            }
+        }
+
+        if (e.key === "Tab") {
+            const r = handleTab(state, e.shiftKey);
+            if (r) {
+                e.preventDefault();
+                applyResult(r);
+            }
+            return;
+        }
+
+        if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+            const r = handleEnter(state);
+            if (r) {
+                e.preventDefault();
+                applyResult(r);
+            }
+            return;
+        }
+
+        if (e.key === "Backspace" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+            const r = handleBackspace(state);
+            if (r) {
+                e.preventDefault();
+                applyResult(r);
+            }
+            return;
+        }
+
+        // Auto-pair / skip-closer: only for printable single-char keys
+        if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+            const skip = handleSkipCloser(state, e.key);
+            if (skip) {
+                e.preventDefault();
+                const t = textareaRef.current;
+                if (t) {
+                    t.selectionStart = skip.selStart;
+                    t.selectionEnd = skip.selEnd;
+                }
+                return;
+            }
+            const pair = handleAutoPair(state, e.key);
+            if (pair) {
+                e.preventDefault();
+                applyResult(pair);
+                return;
+            }
+        }
+    }, [applyResult, getState]);
 
     // Handle paste events - check for images in clipboard
     const handlePaste = useCallback(async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
@@ -381,6 +497,7 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                     value={content}
                     onChange={handleChange}
                     onPaste={handlePaste}
+                    onKeyDown={onKeyDown}
                     spellCheck={false}
                     autoComplete="off"
                     autoCorrect="off"

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -12,6 +12,7 @@ import {
 } from "../utils/editorActions";
 import { FindReplaceBar } from "./FindReplaceBar";
 import { FormatToolbar } from "./FormatToolbar";
+import { pasteUrlOnSelection, pasteUrlAutolink, pasteTsvAsTable, htmlToMarkdown } from "../utils/smartPaste";
 import type { Scroller } from "../utils/scrollSync";
 
 interface CodeEditorProps {
@@ -195,7 +196,7 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
         }
     }, [applyResult, getState]);
 
-    // Handle paste events - check for images in clipboard
+    // Handle paste events — order: image → smart paste rules → default text.
     const handlePaste = useCallback(async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
         const imageFile = getImageFromClipboard(e.nativeEvent);
 
@@ -229,12 +230,74 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                 });
 
                 onImagePaste?.();
+                return;
             } catch (error) {
                 console.error('Failed to paste image:', error);
                 onError?.('Failed to save image. Please try again.');
+                return;
             }
         }
-    }, [content, onChange, onImagePaste, filePath]);
+
+        // Smart paste rules — run on text/html and text/plain payloads.
+        const t = textareaRef.current;
+        if (!t) return;
+        const cd = e.clipboardData;
+        if (!cd) return;
+        const html = cd.getData("text/html");
+        const text = cd.getData("text/plain");
+
+        const state = { text: t.value, selStart: t.selectionStart, selEnd: t.selectionEnd };
+
+        // 1) URL on selection → [text](url)
+        const urlOnSel = pasteUrlOnSelection(state, text);
+        if (urlOnSel) {
+            e.preventDefault();
+            applyResult(urlOnSel);
+            return;
+        }
+        // 2) Plain URL on empty selection → <url>
+        const autolink = pasteUrlAutolink(state, text);
+        if (autolink) {
+            e.preventDefault();
+            applyResult(autolink);
+            return;
+        }
+        // 3) TSV → table (only when no rich HTML present, so spreadsheet plain
+        //    paste wins, but a webpage with an HTML table goes through turndown)
+        if (!html) {
+            const tsv = pasteTsvAsTable(state, text);
+            if (tsv) {
+                e.preventDefault();
+                applyResult(tsv);
+                return;
+            }
+        }
+        // 4) Rich HTML → markdown via turndown (skipped if it's just a textual
+        //    fragment — heuristic: contains real tags)
+        if (html && /<\w+/.test(html)) {
+            e.preventDefault();
+            try {
+                const md = (await htmlToMarkdown(html)).trim();
+                if (md) {
+                    applyResult({
+                        text: state.text.slice(0, state.selStart) + md + state.text.slice(state.selEnd),
+                        selStart: state.selStart + md.length,
+                        selEnd: state.selStart + md.length,
+                    });
+                    return;
+                }
+            } catch {
+                // fall through to plain paste
+            }
+            // turndown failed or returned empty — paste the text/plain instead
+            applyResult({
+                text: state.text.slice(0, state.selStart) + text + state.text.slice(state.selEnd),
+                selStart: state.selStart + text.length,
+                selEnd: state.selStart + text.length,
+            });
+        }
+        // else: let default paste handle plain text
+    }, [content, onChange, onImagePaste, onError, filePath, applyResult]);
 
     // Calculate cursor position (line and column) and active line for highlight
     const updateCursorPosition = useCallback(() => {

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -12,6 +12,7 @@ import {
 } from "../utils/editorActions";
 import { FindReplaceBar } from "./FindReplaceBar";
 import { FormatToolbar } from "./FormatToolbar";
+import { SlashMenu, type SlashCommand } from "./SlashMenu";
 import { pasteUrlOnSelection, pasteUrlAutolink, pasteTsvAsTable, htmlToMarkdown } from "../utils/smartPaste";
 import type { Scroller } from "../utils/scrollSync";
 
@@ -27,7 +28,6 @@ interface CodeEditorProps {
     focusMode?: boolean;
     typewriterMode?: boolean;
     showToolbar?: boolean;
-    onSlashTrigger?: (textareaEl: HTMLTextAreaElement, caretCoords: { x: number; y: number }) => void;
     aiConfig?: { endpoint: string; model: string; apiKey: string };
 }
 
@@ -56,7 +56,7 @@ const sharedTextStyle: React.CSSProperties = {
     boxSizing: "border-box",
 };
 
-export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath, onScrollFraction, registerScroller, focusMode, typewriterMode, showToolbar, onSlashTrigger }: CodeEditorProps) {
+export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath, onScrollFraction, registerScroller, focusMode, typewriterMode, showToolbar }: CodeEditorProps) {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const gutterRef = useRef<HTMLDivElement>(null);
     const highlightRef = useRef<HTMLDivElement>(null);
@@ -64,6 +64,11 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
     const [findOpen, setFindOpen] = useState(false);
     const [findMode, setFindMode] = useState<"find" | "replace">("find");
     const [selStartForFind, setSelStartForFind] = useState(0);
+
+    // Slash menu state — tracked as the index of the "/" trigger and the live query
+    // (text typed after the slash). Caret movement / blur closes the menu.
+    const [slashState, setSlashState] = useState<{ startIdx: number; pos: { x: number; y: number } } | null>(null);
+    const [slashQuery, setSlashQuery] = useState("");
 
     const lines = useMemo(() => content.split("\n"), [content]);
     const lineCount = lines.length;
@@ -426,33 +431,76 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
         return () => cancelAnimationFrame(raf);
     }, [activeLine, typewriterMode]);
 
-    // Slash-command trigger: when user types "/" at start of line (or after whitespace),
-    // notify parent so it can open the slash menu near the caret.
+    // Slash-command lifecycle. When user types "/" at line start, open the menu
+    // anchored below the caret line. As they keep typing, update the query.
+    // Caret moving outside [startIdx, caretPos] or pressing Escape closes it.
     useEffect(() => {
         const t = textareaRef.current;
-        if (!t || !onSlashTrigger) return;
-        const handler = (e: KeyboardEvent) => {
-            if (e.key !== "/") return;
-            // Only trigger when we're about to type "/" at the start of a line
-            // or after whitespace. Defer to rAF so the textarea has the new value.
-            requestAnimationFrame(() => {
-                const pos = t.selectionStart;
-                const before = t.value.slice(0, pos);
-                const lastNl = before.lastIndexOf("\n");
-                const lineHead = before.slice(lastNl + 1);
-                if (lineHead === "/") {
-                    // Caret coords: roughly cursor line × line-height + padding offset
-                    const lineIdx = before.split("\n").length - 1;
-                    const rect = t.getBoundingClientRect();
-                    const x = rect.left + EDITOR_PADDING;
-                    const y = rect.top + EDITOR_PADDING + (lineIdx * EDITOR_LINE_HEIGHT) - t.scrollTop + EDITOR_LINE_HEIGHT;
-                    onSlashTrigger(t, { x, y });
-                }
-            });
+        if (!t) return;
+
+        const recomputePos = (lineIdx: number) => {
+            const rect = t.getBoundingClientRect();
+            return {
+                x: rect.left + EDITOR_PADDING,
+                y: rect.top + EDITOR_PADDING + lineIdx * EDITOR_LINE_HEIGHT - t.scrollTop + EDITOR_LINE_HEIGHT + 4,
+            };
         };
-        t.addEventListener("keydown", handler);
-        return () => t.removeEventListener("keydown", handler);
-    }, [onSlashTrigger]);
+
+        const onKeyUp = () => {
+            const pos = t.selectionStart;
+            const value = t.value;
+
+            if (slashState) {
+                // Close if caret moved left of start, or to a different line
+                if (pos < slashState.startIdx + 1) {
+                    setSlashState(null);
+                    setSlashQuery("");
+                    return;
+                }
+                const between = value.slice(slashState.startIdx + 1, pos);
+                if (between.includes("\n") || between.includes(" ")) {
+                    setSlashState(null);
+                    setSlashQuery("");
+                    return;
+                }
+                setSlashQuery(between);
+                return;
+            }
+
+            // Maybe open: caret right after a "/" that's at line start or post-whitespace
+            if (pos > 0 && value[pos - 1] === "/") {
+                const before = value.slice(0, pos - 1);
+                const lastNl = before.lastIndexOf("\n");
+                const lineHead = value.slice(lastNl + 1, pos - 1);
+                // Only at start of line, or after a single space (e.g. nested in lists)
+                if (lineHead === "" || /^\s*$/.test(lineHead) || /[\s]$/.test(lineHead)) {
+                    const lineIdx = before.split("\n").length - 1;
+                    setSlashState({ startIdx: pos - 1, pos: recomputePos(lineIdx) });
+                    setSlashQuery("");
+                }
+            }
+        };
+
+        t.addEventListener("keyup", onKeyUp);
+        t.addEventListener("click", onKeyUp);
+        return () => {
+            t.removeEventListener("keyup", onKeyUp);
+            t.removeEventListener("click", onKeyUp);
+        };
+    }, [slashState]);
+
+    const handleSlashSelect = useCallback((cmd: SlashCommand) => {
+        if (!slashState) return;
+        const t = textareaRef.current;
+        if (!t) return;
+        const pos = t.selectionStart;
+        // Replace the "/query" range with the snippet
+        const newText = t.value.slice(0, slashState.startIdx) + cmd.snippet + t.value.slice(pos);
+        const caretAt = slashState.startIdx + (cmd.caretOffset ?? cmd.snippet.length);
+        applyResult({ text: newText, selStart: caretAt, selEnd: caretAt });
+        setSlashState(null);
+        setSlashQuery("");
+    }, [slashState, applyResult]);
 
     // Syntax highlighting for markdown
     function highlightLine(line: string): React.ReactNode {
@@ -720,6 +768,14 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                     }}
                     onJumpTo={handleFindJump}
                     onReplace={handleFindReplace}
+                />
+
+                <SlashMenu
+                    isOpen={!!slashState}
+                    position={slashState?.pos ?? null}
+                    query={slashQuery}
+                    onSelect={handleSlashSelect}
+                    onClose={() => { setSlashState(null); setSlashQuery(""); }}
                 />
 
                 {/* Actual Editable Textarea — transparent text, real caret. */}

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -13,6 +13,7 @@ import {
 import { FindReplaceBar } from "./FindReplaceBar";
 import { FormatToolbar } from "./FormatToolbar";
 import { SlashMenu, type SlashCommand } from "./SlashMenu";
+import { AIBubble } from "./AIBubble";
 import { pasteUrlOnSelection, pasteUrlAutolink, pasteTsvAsTable, htmlToMarkdown } from "../utils/smartPaste";
 import type { Scroller } from "../utils/scrollSync";
 
@@ -56,7 +57,7 @@ const sharedTextStyle: React.CSSProperties = {
     boxSizing: "border-box",
 };
 
-export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath, onScrollFraction, registerScroller, focusMode, typewriterMode, showToolbar }: CodeEditorProps) {
+export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath, onScrollFraction, registerScroller, focusMode, typewriterMode, showToolbar, aiConfig }: CodeEditorProps) {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const gutterRef = useRef<HTMLDivElement>(null);
     const highlightRef = useRef<HTMLDivElement>(null);
@@ -69,6 +70,7 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
     // (text typed after the slash). Caret movement / blur closes the menu.
     const [slashState, setSlashState] = useState<{ startIdx: number; pos: { x: number; y: number } } | null>(null);
     const [slashQuery, setSlashQuery] = useState("");
+    const [aiBubble, setAIBubble] = useState<{ x: number; y: number; selStart: number; selEnd: number; text: string } | null>(null);
 
     const lines = useMemo(() => content.split("\n"), [content]);
     const lineCount = lines.length;
@@ -113,6 +115,19 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                 setSelStartForFind(state.selStart);
                 setFindMode("replace");
                 setFindOpen(true);
+                return;
+            }
+            // Ctrl+J — open AI bubble on selection or current line
+            if (e.key === "j" || e.key === "J") {
+                e.preventDefault();
+                const t = textareaRef.current;
+                if (!t) return;
+                const lineIdx = t.value.slice(0, state.selStart).split("\n").length - 1;
+                const rect = t.getBoundingClientRect();
+                const y = rect.top + EDITOR_PADDING + lineIdx * EDITOR_LINE_HEIGHT - t.scrollTop + EDITOR_LINE_HEIGHT + 4;
+                const x = rect.left + EDITOR_PADDING + 12;
+                const text = state.text.slice(state.selStart, state.selEnd);
+                setAIBubble({ x, y, selStart: state.selStart, selEnd: state.selEnd, text });
                 return;
             }
         }
@@ -777,6 +792,32 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                     onSelect={handleSlashSelect}
                     onClose={() => { setSlashState(null); setSlashQuery(""); }}
                 />
+
+                {aiConfig && aiBubble && (
+                    <AIBubble
+                        anchor={{ x: aiBubble.x, y: aiBubble.y }}
+                        selectedText={aiBubble.text}
+                        config={aiConfig}
+                        onReplace={(out) => {
+                            applyResult({
+                                text: content.slice(0, aiBubble.selStart) + out + content.slice(aiBubble.selEnd),
+                                selStart: aiBubble.selStart + out.length,
+                                selEnd: aiBubble.selStart + out.length,
+                            });
+                            setAIBubble(null);
+                        }}
+                        onInsert={(out) => {
+                            const insertAt = aiBubble.selEnd;
+                            applyResult({
+                                text: content.slice(0, insertAt) + "\n\n" + out + content.slice(insertAt),
+                                selStart: insertAt + 2 + out.length,
+                                selEnd: insertAt + 2 + out.length,
+                            });
+                            setAIBubble(null);
+                        }}
+                        onClose={() => setAIBubble(null)}
+                    />
+                )}
 
                 {/* Actual Editable Textarea — transparent text, real caret. */}
                 <textarea

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useEffect, useMemo } from "react";
+import { useRef, useCallback, useEffect, useMemo, useState } from "react";
 import { getImageFromClipboard, saveImageToFile, createMarkdownImage, insertAtCursor } from "../utils/imageUtils";
 
 interface CodeEditorProps {
@@ -10,51 +10,69 @@ interface CodeEditorProps {
     filePath?: string | null; // Current file path for saving images
 }
 
+// Locked metrics for perfect alignment between textarea and highlight layer.
+// Both layers MUST use these exact values to keep the caret on top of the rendered text.
+const EDITOR_FONT_FAMILY =
+    "'JetBrains Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace";
+const EDITOR_FONT_SIZE = 14; // px
+const EDITOR_LINE_HEIGHT = 24; // px
+const EDITOR_PADDING = 16; // px
+const EDITOR_TAB_SIZE = 4;
+
+const sharedTextStyle: React.CSSProperties = {
+    fontFamily: EDITOR_FONT_FAMILY,
+    fontSize: `${EDITOR_FONT_SIZE}px`,
+    lineHeight: `${EDITOR_LINE_HEIGHT}px`,
+    padding: `${EDITOR_PADDING}px`,
+    tabSize: EDITOR_TAB_SIZE,
+    MozTabSize: EDITOR_TAB_SIZE,
+    fontVariantLigatures: "none",
+    fontKerning: "none",
+    letterSpacing: "0px",
+    whiteSpace: "pre",
+    wordBreak: "normal",
+    overflowWrap: "normal",
+    boxSizing: "border-box",
+};
+
 export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath }: CodeEditorProps) {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const gutterRef = useRef<HTMLDivElement>(null);
     const highlightRef = useRef<HTMLDivElement>(null);
+    const [activeLine, setActiveLine] = useState(1);
 
-    // Calculate line numbers
-    const lines = content.split("\n");
+    const lines = useMemo(() => content.split("\n"), [content]);
     const lineCount = lines.length;
 
-const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         onChange(e.target.value);
     };
 
     // Handle paste events - check for images in clipboard
     const handlePaste = useCallback(async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
         const imageFile = getImageFromClipboard(e.nativeEvent);
-        
+
         if (imageFile) {
-            // Prevent default paste behavior for images
             e.preventDefault();
-            
-            // Check if file is saved (required for image storage)
+
             if (!filePath) {
                 onError?.('Please save your file first before pasting images.');
                 return;
             }
-            
+
             try {
-                // Save image to local file and get relative path
                 const imagePath = await saveImageToFile(imageFile, filePath);
                 const timestamp = Date.now();
                 const altText = `image-${timestamp}`;
                 const markdownImage = createMarkdownImage(imagePath, altText);
-                
-                // Get current cursor position
+
                 const textarea = textareaRef.current;
                 if (!textarea) return;
-                
+
                 const cursorPos = textarea.selectionStart;
-                
-                // Insert markdown image at cursor
                 const { newText, newCursorPosition } = insertAtCursor(content, cursorPos, markdownImage);
                 onChange(newText);
-                
-                // Restore cursor position after state update
+
                 requestAnimationFrame(() => {
                     if (textareaRef.current) {
                         textareaRef.current.selectionStart = newCursorPosition;
@@ -62,20 +80,18 @@ const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
                         textareaRef.current.focus();
                     }
                 });
-                
-                // Notify parent of successful paste
+
                 onImagePaste?.();
             } catch (error) {
                 console.error('Failed to paste image:', error);
                 onError?.('Failed to save image. Please try again.');
             }
         }
-        // If no image, let default paste behavior handle text
     }, [content, onChange, onImagePaste, filePath]);
 
-    // Calculate cursor position (line and column)
+    // Calculate cursor position (line and column) and active line for highlight
     const updateCursorPosition = useCallback(() => {
-        if (!textareaRef.current || !onCursorChange) return;
+        if (!textareaRef.current) return;
 
         const textarea = textareaRef.current;
         const cursorPos = textarea.selectionStart;
@@ -84,67 +100,93 @@ const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         const line = linesBeforeCursor.length;
         const column = linesBeforeCursor[linesBeforeCursor.length - 1].length + 1;
 
-        onCursorChange(line, column);
+        setActiveLine(line);
+        onCursorChange?.(line, column);
     }, [onCursorChange]);
 
-    // Track cursor position on various events
+    // Track cursor on every relevant event (selectionchange catches all caret moves)
     useEffect(() => {
         const textarea = textareaRef.current;
         if (!textarea) return;
 
-        const handleSelectionChange = () => updateCursorPosition();
+        const handler = () => {
+            // selectionchange fires on document; only react if our textarea is focused
+            if (document.activeElement === textarea) {
+                updateCursorPosition();
+            }
+        };
 
-        textarea.addEventListener("keyup", handleSelectionChange);
-        textarea.addEventListener("click", handleSelectionChange);
-        textarea.addEventListener("select", handleSelectionChange);
+        document.addEventListener("selectionchange", handler);
+        textarea.addEventListener("keyup", updateCursorPosition);
+        textarea.addEventListener("click", updateCursorPosition);
+        textarea.addEventListener("focus", updateCursorPosition);
 
-        // Initial position
         updateCursorPosition();
 
         return () => {
-            textarea.removeEventListener("keyup", handleSelectionChange);
-            textarea.removeEventListener("click", handleSelectionChange);
-            textarea.removeEventListener("select", handleSelectionChange);
+            document.removeEventListener("selectionchange", handler);
+            textarea.removeEventListener("keyup", updateCursorPosition);
+            textarea.removeEventListener("click", updateCursorPosition);
+            textarea.removeEventListener("focus", updateCursorPosition);
         };
-    }, [updateCursorPosition, content]);
+    }, [updateCursorPosition]);
 
-    // Sync scroll between textarea, gutter, and highlight layer
-    const handleScroll = useCallback(() => {
-        if (!textareaRef.current) return;
-        const scrollTop = textareaRef.current.scrollTop;
-        const scrollLeft = textareaRef.current.scrollLeft;
+    // Use rAF-based scroll sync for sub-frame accuracy. The native scroll event
+    // can lag the caret by 1 frame; rAF lets us catch up before paint.
+    useEffect(() => {
+        const textarea = textareaRef.current;
+        if (!textarea) return;
 
-        if (gutterRef.current) {
-            gutterRef.current.scrollTop = scrollTop;
-        }
-        if (highlightRef.current) {
-            highlightRef.current.scrollTop = scrollTop;
-            highlightRef.current.scrollLeft = scrollLeft;
-        }
+        let rafId: number | null = null;
+        let lastTop = -1;
+        let lastLeft = -1;
+
+        const sync = () => {
+            const t = textareaRef.current;
+            if (!t) {
+                rafId = null;
+                return;
+            }
+            const top = t.scrollTop;
+            const left = t.scrollLeft;
+            if (top !== lastTop || left !== lastLeft) {
+                if (highlightRef.current) {
+                    highlightRef.current.scrollTop = top;
+                    highlightRef.current.scrollLeft = left;
+                }
+                if (gutterRef.current) {
+                    gutterRef.current.scrollTop = top;
+                }
+                lastTop = top;
+                lastLeft = left;
+            }
+            rafId = requestAnimationFrame(sync);
+        };
+
+        rafId = requestAnimationFrame(sync);
+
+        return () => {
+            if (rafId !== null) cancelAnimationFrame(rafId);
+        };
     }, []);
 
     // Memoize highlighted lines to avoid recalculating on non-content re-renders
-    const highlightedLines = useMemo(() => lines.map((line) => highlightLine(line)), [content]);
+    const highlightedLines = useMemo(() => lines.map((line) => highlightLine(line)), [lines]);
 
     // Syntax highlighting for markdown
     function highlightLine(line: string): React.ReactNode {
-        // H1 headers
         if (line.startsWith("# ")) {
             return <span className="text-[var(--syntax-h1)] font-bold">{line}</span>;
         }
-        // H2 headers
         if (line.startsWith("## ")) {
             return <span className="text-[var(--syntax-h2)] font-bold">{line}</span>;
         }
-        // H3+ headers
         if (line.startsWith("### ") || line.startsWith("#### ")) {
             return <span className="text-[var(--syntax-h3)] font-semibold">{line}</span>;
         }
-        // Code fence
         if (line.startsWith("```")) {
             return <span className="text-[var(--syntax-code)]">{line}</span>;
         }
-        // List items
         if (line.match(/^[\s]*[-*+]\s/)) {
             const marker = line.match(/^[\s]*[-*+]/)?.[0] || "";
             const rest = line.slice(marker.length);
@@ -155,7 +197,6 @@ const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
                 </>
             );
         }
-        // Numbered lists
         if (line.match(/^[\s]*\d+\.\s/)) {
             const match = line.match(/^([\s]*\d+\.)/);
             const marker = match?.[0] || "";
@@ -167,27 +208,25 @@ const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
                 </>
             );
         }
-// Blockquote
         if (line.startsWith(">")) {
             return <span className="text-[var(--syntax-quote)] italic">{line}</span>;
         }
-        // Images ![alt](url) - check before links since images have ! prefix
         if (line.includes("![") && line.includes("](")) {
             return highlightImages(line);
         }
-        // Links [text](url)
         if (line.includes("[") && line.includes("](")) {
             return highlightLinks(line);
         }
-        // Bold **text**
         if (line.includes("**")) {
             return highlightBold(line);
         }
-        // Regular text
-        return <span>{line || "\u00A0"}</span>;
+        // Empty lines must render something with zero width but real height.
+        // Using "" lets the parent line-height (24px) own vertical metrics —
+        // identical to how a textarea renders an empty line. NBSP would shift
+        // baseline metrics on some fonts and desync the caret.
+        return <span>{line}</span>;
     }
 
-    // Highlight images ![alt](url) - shows truncated for data URLs
     function highlightImages(text: string): React.ReactNode {
         const parts: React.ReactNode[] = [];
         const imageRegex = /!\[([^\]]*)\]\(([^)]+)\)/g;
@@ -199,16 +238,15 @@ const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
             if (match.index > lastIndex) {
                 parts.push(<span key={key++}>{text.slice(lastIndex, match.index)}</span>);
             }
-            
+
             const altText = match[1];
             const url = match[2];
-            // Truncate long data URLs for display
-            const displayUrl = url.startsWith('data:') 
-                ? `data:image/...` 
-                : url.length > 40 
-                    ? url.slice(0, 37) + '...' 
+            const displayUrl = url.startsWith('data:')
+                ? `data:image/...`
+                : url.length > 40
+                    ? url.slice(0, 37) + '...'
                     : url;
-            
+
             parts.push(
                 <span key={key++} className="text-[var(--syntax-link)]">
                     <span className="text-[var(--syntax-bold)]">!</span>
@@ -284,48 +322,73 @@ const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
             {/* Line Numbers Gutter */}
             <div
                 ref={gutterRef}
-                className="w-14 shrink-0 bg-[var(--bg-gutter)] border-r border-[var(--border-subtle)] py-4 pr-3 no-select text-xs font-mono text-[var(--text-muted)] overflow-hidden transition-colors"
+                className="w-14 shrink-0 bg-[var(--bg-gutter)] border-r border-[var(--border-subtle)] no-select text-xs text-[var(--text-muted)] overflow-hidden transition-colors"
+                style={{
+                    fontFamily: EDITOR_FONT_FAMILY,
+                    fontSize: `${EDITOR_FONT_SIZE}px`,
+                    lineHeight: `${EDITOR_LINE_HEIGHT}px`,
+                    paddingTop: `${EDITOR_PADDING}px`,
+                    paddingBottom: `${EDITOR_PADDING}px`,
+                    paddingRight: "12px",
+                }}
             >
                 <div className="flex flex-col items-end">
-                    {Array.from({ length: lineCount }, (_, i) => (
-                        <div key={i} className="leading-6 h-6">
-                            {i + 1}
-                        </div>
-                    ))}
+                    {Array.from({ length: lineCount }, (_, i) => {
+                        const isActive = i + 1 === activeLine;
+                        return (
+                            <div
+                                key={i}
+                                className={isActive ? "text-[var(--text-primary)] font-medium" : ""}
+                                style={{ height: `${EDITOR_LINE_HEIGHT}px`, lineHeight: `${EDITOR_LINE_HEIGHT}px` }}
+                            >
+                                {i + 1}
+                            </div>
+                        );
+                    })}
                 </div>
             </div>
 
             {/* Editor Container */}
             <div className="flex-1 relative bg-[var(--bg-editor)] transition-colors">
-                {/* Syntax Highlighted Layer (visual only) */}
+                {/* Syntax Highlighted Layer (visual only).
+                    Active-line band lives inside this scroll container so it tracks
+                    scroll naturally — no JS scrollTop math required. */}
                 <div
                     ref={highlightRef}
-                    className="absolute inset-0 p-4 font-mono text-sm leading-6 text-[var(--text-primary)] pointer-events-none overflow-hidden whitespace-pre"
+                    className="absolute inset-0 text-[var(--text-primary)] pointer-events-none overflow-hidden"
                     aria-hidden="true"
+                    style={sharedTextStyle}
                 >
+                    <div
+                        className="absolute left-0 right-0 pointer-events-none"
+                        style={{
+                            top: `${EDITOR_PADDING + (activeLine - 1) * EDITOR_LINE_HEIGHT}px`,
+                            height: `${EDITOR_LINE_HEIGHT}px`,
+                            background: "var(--bg-hover)",
+                            opacity: 0.45,
+                        }}
+                    />
                     {highlightedLines.map((highlighted, i) => (
-                        <div key={i} className="h-6">
+                        <div key={i} style={{ height: `${EDITOR_LINE_HEIGHT}px`, lineHeight: `${EDITOR_LINE_HEIGHT}px`, position: "relative" }}>
                             {highlighted}
                         </div>
                     ))}
                 </div>
 
-{/* Actual Editable Textarea */}
+                {/* Actual Editable Textarea — transparent text, real caret */}
                 <textarea
                     ref={textareaRef}
                     value={content}
                     onChange={handleChange}
                     onPaste={handlePaste}
-                    onScroll={handleScroll}
                     spellCheck={false}
                     autoComplete="off"
                     autoCorrect="off"
                     autoCapitalize="off"
-                    className="absolute inset-0 w-full h-full p-4 font-mono text-sm leading-6 bg-transparent text-transparent caret-[var(--accent)] resize-none outline-none overflow-auto"
+                    className="absolute inset-0 w-full h-full bg-transparent text-transparent caret-[var(--accent)] resize-none outline-none overflow-auto border-0"
                     style={{
+                        ...sharedTextStyle,
                         caretColor: "var(--accent)",
-                        whiteSpace: "pre",
-                        wordWrap: "normal",
                     }}
                 />
             </div>

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -11,6 +11,7 @@ import {
     type EditorResult,
 } from "../utils/editorActions";
 import { FindReplaceBar } from "./FindReplaceBar";
+import type { Scroller } from "../utils/scrollSync";
 
 interface CodeEditorProps {
     content: string;
@@ -19,6 +20,8 @@ interface CodeEditorProps {
     onImagePaste?: () => void; // Callback when image is successfully pasted
     onError?: (message: string) => void; // Callback for error messages
     filePath?: string | null; // Current file path for saving images
+    onScrollFraction?: (fraction: number) => void;
+    registerScroller?: (scroller: Scroller | null) => void;
 }
 
 // Locked metrics for perfect alignment between textarea and highlight layer.
@@ -46,7 +49,7 @@ const sharedTextStyle: React.CSSProperties = {
     boxSizing: "border-box",
 };
 
-export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath }: CodeEditorProps) {
+export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath, onScrollFraction, registerScroller }: CodeEditorProps) {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const gutterRef = useRef<HTMLDivElement>(null);
     const highlightRef = useRef<HTMLDivElement>(null);
@@ -295,6 +298,10 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                 if (gutterRef.current) {
                     gutterRef.current.scrollTop = top;
                 }
+                if (top !== lastTop && onScrollFraction) {
+                    const max = t.scrollHeight - t.clientHeight;
+                    onScrollFraction(max > 0 ? top / max : 0);
+                }
                 lastTop = top;
                 lastLeft = left;
             }
@@ -306,7 +313,22 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
         return () => {
             if (rafId !== null) cancelAnimationFrame(rafId);
         };
-    }, []);
+    }, [onScrollFraction]);
+
+    // Register an imperative scroller so external code (split-view sync) can
+    // drive our scroll position by fraction without touching internals.
+    useEffect(() => {
+        if (!registerScroller) return;
+        registerScroller({
+            setFraction: (f: number) => {
+                const t = textareaRef.current;
+                if (!t) return;
+                const max = t.scrollHeight - t.clientHeight;
+                if (max > 0) t.scrollTop = max * f;
+            },
+        });
+        return () => registerScroller(null);
+    }, [registerScroller]);
 
     // Memoize highlighted lines to avoid recalculating on non-content re-renders
     const highlightedLines = useMemo(() => lines.map((line) => highlightLine(line)), [lines]);

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -11,6 +11,7 @@ import {
     type EditorResult,
 } from "../utils/editorActions";
 import { FindReplaceBar } from "./FindReplaceBar";
+import { FormatToolbar } from "./FormatToolbar";
 import type { Scroller } from "../utils/scrollSync";
 
 interface CodeEditorProps {
@@ -22,6 +23,11 @@ interface CodeEditorProps {
     filePath?: string | null; // Current file path for saving images
     onScrollFraction?: (fraction: number) => void;
     registerScroller?: (scroller: Scroller | null) => void;
+    focusMode?: boolean;
+    typewriterMode?: boolean;
+    showToolbar?: boolean;
+    onSlashTrigger?: (textareaEl: HTMLTextAreaElement, caretCoords: { x: number; y: number }) => void;
+    aiConfig?: { endpoint: string; model: string; apiKey: string };
 }
 
 // Locked metrics for perfect alignment between textarea and highlight layer.
@@ -49,7 +55,7 @@ const sharedTextStyle: React.CSSProperties = {
     boxSizing: "border-box",
 };
 
-export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath, onScrollFraction, registerScroller }: CodeEditorProps) {
+export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath, onScrollFraction, registerScroller, focusMode, typewriterMode, showToolbar, onSlashTrigger }: CodeEditorProps) {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const gutterRef = useRef<HTMLDivElement>(null);
     const highlightRef = useRef<HTMLDivElement>(null);
@@ -333,6 +339,58 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
     // Memoize highlighted lines to avoid recalculating on non-content re-renders
     const highlightedLines = useMemo(() => lines.map((line) => highlightLine(line)), [lines]);
 
+    // Typewriter mode: keep the active line vertically centered as the caret moves.
+    useEffect(() => {
+        if (!typewriterMode) return;
+        const t = textareaRef.current;
+        if (!t) return;
+        const targetTop = (activeLine - 1) * EDITOR_LINE_HEIGHT - t.clientHeight / 2 + EDITOR_LINE_HEIGHT / 2;
+        // Smooth via rAF for a calmer scroll than scrollTo({behavior:'smooth'}) which
+        // can fight the user's own input on some browsers.
+        const start = t.scrollTop;
+        const distance = Math.max(0, targetTop) - start;
+        if (Math.abs(distance) < 1) return;
+        let raf = 0;
+        const t0 = performance.now();
+        const dur = 120;
+        const step = (now: number) => {
+            const p = Math.min(1, (now - t0) / dur);
+            const eased = 1 - Math.pow(1 - p, 3);
+            t.scrollTop = start + distance * eased;
+            if (p < 1) raf = requestAnimationFrame(step);
+        };
+        raf = requestAnimationFrame(step);
+        return () => cancelAnimationFrame(raf);
+    }, [activeLine, typewriterMode]);
+
+    // Slash-command trigger: when user types "/" at start of line (or after whitespace),
+    // notify parent so it can open the slash menu near the caret.
+    useEffect(() => {
+        const t = textareaRef.current;
+        if (!t || !onSlashTrigger) return;
+        const handler = (e: KeyboardEvent) => {
+            if (e.key !== "/") return;
+            // Only trigger when we're about to type "/" at the start of a line
+            // or after whitespace. Defer to rAF so the textarea has the new value.
+            requestAnimationFrame(() => {
+                const pos = t.selectionStart;
+                const before = t.value.slice(0, pos);
+                const lastNl = before.lastIndexOf("\n");
+                const lineHead = before.slice(lastNl + 1);
+                if (lineHead === "/") {
+                    // Caret coords: roughly cursor line × line-height + padding offset
+                    const lineIdx = before.split("\n").length - 1;
+                    const rect = t.getBoundingClientRect();
+                    const x = rect.left + EDITOR_PADDING;
+                    const y = rect.top + EDITOR_PADDING + (lineIdx * EDITOR_LINE_HEIGHT) - t.scrollTop + EDITOR_LINE_HEIGHT;
+                    onSlashTrigger(t, { x, y });
+                }
+            });
+        };
+        t.addEventListener("keydown", handler);
+        return () => t.removeEventListener("keydown", handler);
+    }, [onSlashTrigger]);
+
     // Syntax highlighting for markdown
     function highlightLine(line: string): React.ReactNode {
         if (line.startsWith("# ")) {
@@ -500,8 +558,26 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
         });
     }, [onChange]);
 
+    const insertAtCaret = useCallback((text: string) => {
+        const t = textareaRef.current;
+        if (!t) return;
+        applyResult({
+            text: t.value.slice(0, t.selectionStart) + text + t.value.slice(t.selectionEnd),
+            selStart: t.selectionStart + text.length,
+            selEnd: t.selectionStart + text.length,
+        });
+    }, [applyResult]);
+
     return (
-        <main className="flex-1 flex overflow-hidden relative">
+        <main className="flex-1 flex flex-col overflow-hidden relative">
+            {showToolbar && (
+                <FormatToolbar
+                    getTextarea={() => textareaRef.current}
+                    apply={applyResult}
+                    insert={insertAtCaret}
+                />
+            )}
+            <div className="flex flex-1 overflow-hidden relative">
             {/* Line Numbers Gutter */}
             <div
                 ref={gutterRef}
@@ -551,11 +627,23 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                             opacity: 0.45,
                         }}
                     />
-                    {highlightedLines.map((highlighted, i) => (
-                        <div key={i} style={{ height: `${EDITOR_LINE_HEIGHT}px`, lineHeight: `${EDITOR_LINE_HEIGHT}px`, position: "relative" }}>
-                            {highlighted}
-                        </div>
-                    ))}
+                    {highlightedLines.map((highlighted, i) => {
+                        const isActive = i + 1 === activeLine;
+                        return (
+                            <div
+                                key={i}
+                                style={{
+                                    height: `${EDITOR_LINE_HEIGHT}px`,
+                                    lineHeight: `${EDITOR_LINE_HEIGHT}px`,
+                                    position: "relative",
+                                    opacity: focusMode && !isActive ? 0.35 : 1,
+                                    transition: focusMode ? "opacity 150ms ease-out" : undefined,
+                                }}
+                            >
+                                {highlighted}
+                            </div>
+                        );
+                    })}
                 </div>
 
                 <FindReplaceBar
@@ -571,7 +659,7 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                     onReplace={handleFindReplace}
                 />
 
-                {/* Actual Editable Textarea — transparent text, real caret */}
+                {/* Actual Editable Textarea — transparent text, real caret. */}
                 <textarea
                     ref={textareaRef}
                     value={content}
@@ -588,6 +676,7 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                         caretColor: "var(--accent)",
                     }}
                 />
+            </div>
             </div>
         </main>
     );

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { attachFocusTrap } from "../utils/focusTrap";
+
+export interface PaletteCommand {
+    id: string;
+    label: string;
+    /** Optional secondary description shown on the right (path, shortcut, etc). */
+    hint?: string;
+    /** Section label — items are grouped by this. */
+    section: string;
+    /** Material symbol icon name. */
+    icon?: string;
+    /** Extra search keywords (not visible). */
+    keywords?: string;
+    run: () => void;
+}
+
+interface CommandPaletteProps {
+    isOpen: boolean;
+    items: PaletteCommand[];
+    onClose: () => void;
+}
+
+/** Tiny fzf-style ranker. Returns -1 for no match, otherwise a score (lower = better). */
+function fuzzyScore(needle: string, haystack: string): number {
+    if (!needle) return 0;
+    const n = needle.toLowerCase();
+    const h = haystack.toLowerCase();
+    if (h.includes(n)) return h.indexOf(n); // substring match — best
+    let hi = 0;
+    let score = 0;
+    let lastIdx = -1;
+    for (let ni = 0; ni < n.length; ni++) {
+        const ch = n[ni];
+        const found = h.indexOf(ch, hi);
+        if (found === -1) return -1;
+        if (lastIdx !== -1) score += (found - lastIdx);
+        lastIdx = found;
+        hi = found + 1;
+    }
+    return 1000 + score; // worse than substring matches
+}
+
+export function CommandPalette({ isOpen, items, onClose }: CommandPaletteProps) {
+    const [query, setQuery] = useState("");
+    const [activeIdx, setActiveIdx] = useState(0);
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const listRef = useRef<HTMLUListElement>(null);
+
+    // Reset state on open
+    useEffect(() => {
+        if (isOpen) {
+            setQuery("");
+            setActiveIdx(0);
+        }
+    }, [isOpen]);
+
+    // Focus input + trap, Escape to close
+    useEffect(() => {
+        if (!isOpen) return;
+        const input = dialogRef.current?.querySelector<HTMLInputElement>("input");
+        input?.focus();
+        const detach = attachFocusTrap(dialogRef.current);
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                e.preventDefault();
+                onClose();
+            }
+        };
+        document.addEventListener("keydown", onKey);
+        return () => {
+            detach();
+            document.removeEventListener("keydown", onKey);
+        };
+    }, [isOpen, onClose]);
+
+    // Filtered + sorted result
+    const ranked = useMemo(() => {
+        if (!isOpen) return [];
+        if (!query.trim()) return items;
+        const scored = items
+            .map((it) => {
+                const candidates = [it.label, it.hint ?? "", it.keywords ?? "", it.section];
+                let best = -1;
+                for (const c of candidates) {
+                    const s = fuzzyScore(query, c);
+                    if (s !== -1 && (best === -1 || s < best)) best = s;
+                }
+                return { item: it, score: best };
+            })
+            .filter((r) => r.score !== -1)
+            .sort((a, b) => a.score - b.score)
+            .map((r) => r.item);
+        return scored;
+    }, [items, query, isOpen]);
+
+    // Group by section preserving order
+    const grouped = useMemo(() => {
+        const out: Array<{ section: string; items: PaletteCommand[] }> = [];
+        const seen = new Map<string, number>();
+        for (const it of ranked) {
+            const idx = seen.get(it.section);
+            if (idx === undefined) {
+                seen.set(it.section, out.length);
+                out.push({ section: it.section, items: [it] });
+            } else {
+                out[idx].items.push(it);
+            }
+        }
+        return out;
+    }, [ranked]);
+
+    // Keep activeIdx valid when results change
+    useEffect(() => {
+        if (activeIdx >= ranked.length) setActiveIdx(0);
+    }, [ranked.length, activeIdx]);
+
+    // Auto-scroll active row into view
+    useEffect(() => {
+        const list = listRef.current;
+        if (!list) return;
+        const active = list.querySelector<HTMLElement>(`[data-idx="${activeIdx}"]`);
+        active?.scrollIntoView({ block: "nearest" });
+    }, [activeIdx]);
+
+    const onKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            setActiveIdx((i) => (ranked.length === 0 ? 0 : (i + 1) % ranked.length));
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            setActiveIdx((i) => (ranked.length === 0 ? 0 : (i - 1 + ranked.length) % ranked.length));
+        } else if (e.key === "Enter") {
+            e.preventDefault();
+            const cmd = ranked[activeIdx];
+            if (cmd) {
+                onClose();
+                cmd.run();
+            }
+        }
+    };
+
+    if (!isOpen) return null;
+
+    let runningIdx = -1;
+
+    return (
+        <div className="fixed inset-0 z-[110] flex items-start justify-center pt-[12vh]" role="dialog" aria-modal="true" aria-label="Command palette">
+            <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} aria-hidden="true" />
+
+            <div
+                ref={dialogRef}
+                className="relative z-10 w-[640px] max-w-[92vw] flex flex-col bg-[var(--bg-secondary)] border border-[var(--border)] rounded-[var(--radius-lg)] shadow-2xl overflow-hidden animate-fade-in"
+                onKeyDown={onKeyDown}
+            >
+                <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--border)]">
+                    <span className="material-symbols-outlined text-[var(--text-secondary)]">search</span>
+                    <input
+                        type="text"
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        placeholder="Type a command, file, or heading…"
+                        aria-label="Search commands"
+                        className="flex-1 bg-transparent text-[var(--text-primary)] outline-none text-sm placeholder:text-[var(--text-muted)]"
+                    />
+                    <kbd className="px-1.5 py-0.5 text-[11px] font-mono rounded border border-[var(--border)] bg-[var(--bg-input)] text-[var(--text-muted)]">Esc</kbd>
+                </div>
+
+                <ul ref={listRef} className="max-h-[420px] overflow-y-auto py-1" role="listbox">
+                    {ranked.length === 0 ? (
+                        <li className="px-4 py-6 text-center text-sm text-[var(--text-secondary)]">No results</li>
+                    ) : grouped.map((g) => (
+                        <li key={g.section}>
+                            <div className="px-4 py-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+                                {g.section}
+                            </div>
+                            <ul>
+                                {g.items.map((cmd) => {
+                                    runningIdx++;
+                                    const idx = runningIdx;
+                                    const active = idx === activeIdx;
+                                    return (
+                                        <li key={cmd.id}>
+                                            <button
+                                                role="option"
+                                                aria-selected={active}
+                                                data-idx={idx}
+                                                onMouseEnter={() => setActiveIdx(idx)}
+                                                onClick={() => { onClose(); cmd.run(); }}
+                                                className={`w-full flex items-center gap-3 px-4 py-2 text-left transition-colors ${active ? "bg-[var(--bg-hover)]" : ""}`}
+                                            >
+                                                <span className={`material-symbols-outlined text-[18px] shrink-0 ${active ? "text-[var(--accent)]" : "text-[var(--text-secondary)]"}`}>
+                                                    {cmd.icon ?? "chevron_right"}
+                                                </span>
+                                                <span className="flex-1 min-w-0 text-sm text-[var(--text-primary)] truncate">{cmd.label}</span>
+                                                {cmd.hint && (
+                                                    <span className="text-[11px] text-[var(--text-muted)] tabular-nums truncate ml-2 shrink-0">
+                                                        {cmd.hint}
+                                                    </span>
+                                                )}
+                                            </button>
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        </li>
+                    ))}
+                </ul>
+
+                <div className="px-4 py-1.5 text-[10px] text-[var(--text-muted)] border-t border-[var(--border-subtle)] bg-[var(--bg-titlebar)] flex items-center gap-3">
+                    <span><kbd className="px-1 font-mono rounded border border-[var(--border)] bg-[var(--bg-input)]">↑↓</kbd> navigate</span>
+                    <span><kbd className="px-1 font-mono rounded border border-[var(--border)] bg-[var(--bg-input)]">↵</kbd> run</span>
+                    <span className="ml-auto">{ranked.length} {ranked.length === 1 ? "result" : "results"}</span>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -5,11 +5,13 @@ import { exportToHTML, exportToPDF } from '../utils/exportUtils';
 interface ExportMenuProps {
     fileName: string;
     getExportHtml?: () => string;
+    onSuccess?: (format: string) => void;
+    onError?: (format: string) => void;
 }
 
 type ExportFormat = 'html' | 'pdf';
 
-export function ExportMenu({ fileName, getExportHtml }: ExportMenuProps) {
+export function ExportMenu({ fileName, getExportHtml, onSuccess, onError }: ExportMenuProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [isExporting, setIsExporting] = useState(false);
     const { theme, font, fontSize } = useTheme();
@@ -48,8 +50,10 @@ export function ExportMenu({ fileName, getExportHtml }: ExportMenuProps) {
             } else {
                 await exportToPDF(htmlContent, fileName, theme, font, fontSize);
             }
+            onSuccess?.(format.toUpperCase());
         } catch (error) {
             console.error(`Failed to export ${format}:`, error);
+            onError?.(format.toUpperCase());
         } finally {
             setIsExporting(false);
         }

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { attachFocusTrap } from "../utils/focusTrap";
 
 interface FileEntry {
     name: string;
@@ -41,7 +42,7 @@ export function FileExplorer({
         }
     }, [isOpen, currentFilePath]);
 
-    // Escape key to close and focus management
+    // Escape key to close and focus management + focus trap
     useEffect(() => {
         if (!isOpen) return;
 
@@ -53,11 +54,13 @@ export function FileExplorer({
         };
 
         document.addEventListener("keydown", handleKeyDown);
-
-        // Focus the panel when opened
         panelRef.current?.focus();
+        const detachTrap = attachFocusTrap(panelRef.current);
 
-        return () => document.removeEventListener("keydown", handleKeyDown);
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+            detachTrap();
+        };
     }, [isOpen, onClose]);
 
     const loadFiles = async (directory: string) => {

--- a/src/components/FindReplaceBar.tsx
+++ b/src/components/FindReplaceBar.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+
+interface FindReplaceBarProps {
+    isOpen: boolean;
+    initialMode?: "find" | "replace";
+    content: string;
+    selectionStart: number;
+    onClose: () => void;
+    onReplace: (newContent: string, newCursor: number) => void;
+    onJumpTo: (start: number, end: number) => void;
+}
+
+interface MatchResult {
+    matches: number[];
+    activeIdx: number;
+}
+
+const findAll = (haystack: string, needle: string, caseSensitive: boolean, regex: boolean): number[] => {
+    if (!needle) return [];
+    const result: number[] = [];
+    if (regex) {
+        try {
+            const re = new RegExp(needle, caseSensitive ? "g" : "gi");
+            let m;
+            while ((m = re.exec(haystack)) !== null) {
+                result.push(m.index);
+                if (m.index === re.lastIndex) re.lastIndex++; // avoid zero-width loops
+            }
+        } catch {
+            return [];
+        }
+        return result;
+    }
+    const h = caseSensitive ? haystack : haystack.toLowerCase();
+    const n = caseSensitive ? needle : needle.toLowerCase();
+    let i = h.indexOf(n);
+    while (i !== -1) {
+        result.push(i);
+        i = h.indexOf(n, i + Math.max(1, n.length));
+    }
+    return result;
+};
+
+const matchLength = (haystack: string, idx: number, needle: string, caseSensitive: boolean, regex: boolean): number => {
+    if (regex) {
+        try {
+            const re = new RegExp(needle, caseSensitive ? "g" : "gi");
+            re.lastIndex = idx;
+            const m = re.exec(haystack);
+            return m && m.index === idx ? m[0].length : 0;
+        } catch {
+            return 0;
+        }
+    }
+    return needle.length;
+};
+
+export function FindReplaceBar({
+    isOpen,
+    initialMode = "find",
+    content,
+    selectionStart,
+    onClose,
+    onReplace,
+    onJumpTo,
+}: FindReplaceBarProps) {
+    const [query, setQuery] = useState("");
+    const [replacement, setReplacement] = useState("");
+    const [showReplace, setShowReplace] = useState(initialMode === "replace");
+    const [caseSensitive, setCaseSensitive] = useState(false);
+    const [regex, setRegex] = useState(false);
+    const [match, setMatch] = useState<MatchResult>({ matches: [], activeIdx: -1 });
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (isOpen) {
+            inputRef.current?.focus();
+            inputRef.current?.select();
+            setShowReplace(initialMode === "replace");
+        }
+    }, [isOpen, initialMode]);
+
+    // Recompute matches when query or content changes
+    useEffect(() => {
+        const m = findAll(content, query, caseSensitive, regex);
+        setMatch((prev) => {
+            // Try to keep activeIdx pointing to a position near the selection
+            let active = -1;
+            if (m.length > 0) {
+                active = m.findIndex((pos) => pos >= selectionStart);
+                if (active === -1) active = 0;
+                if (prev.activeIdx >= 0 && prev.activeIdx < m.length && prev.matches[prev.activeIdx] === m[prev.activeIdx]) {
+                    active = prev.activeIdx;
+                }
+            }
+            return { matches: m, activeIdx: active };
+        });
+    }, [content, query, caseSensitive, regex, selectionStart]);
+
+    // Auto-jump to active match
+    useEffect(() => {
+        if (match.activeIdx === -1) return;
+        const start = match.matches[match.activeIdx];
+        const len = matchLength(content, start, query, caseSensitive, regex);
+        if (len > 0) onJumpTo(start, start + len);
+        // We intentionally don't depend on onJumpTo to avoid loops
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [match.activeIdx, match.matches]);
+
+    const next = useCallback(() => {
+        setMatch((prev) => {
+            if (prev.matches.length === 0) return prev;
+            return { ...prev, activeIdx: (prev.activeIdx + 1) % prev.matches.length };
+        });
+    }, []);
+
+    const prev = useCallback(() => {
+        setMatch((prevState) => {
+            if (prevState.matches.length === 0) return prevState;
+            const next = prevState.activeIdx <= 0 ? prevState.matches.length - 1 : prevState.activeIdx - 1;
+            return { ...prevState, activeIdx: next };
+        });
+    }, []);
+
+    const replaceCurrent = useCallback(() => {
+        if (match.activeIdx === -1) return;
+        const start = match.matches[match.activeIdx];
+        const len = matchLength(content, start, query, caseSensitive, regex);
+        if (len === 0) return;
+        const newContent = content.slice(0, start) + replacement + content.slice(start + len);
+        onReplace(newContent, start + replacement.length);
+    }, [match, content, query, replacement, caseSensitive, regex, onReplace]);
+
+    const replaceAll = useCallback(() => {
+        if (match.matches.length === 0) return;
+        // Walk in reverse so indices stay valid as we splice
+        let updated = content;
+        for (let i = match.matches.length - 1; i >= 0; i--) {
+            const start = match.matches[i];
+            const len = matchLength(updated, start, query, caseSensitive, regex);
+            if (len === 0) continue;
+            updated = updated.slice(0, start) + replacement + updated.slice(start + len);
+        }
+        onReplace(updated, content.length === updated.length ? selectionStart : updated.length);
+    }, [match, content, query, replacement, caseSensitive, regex, onReplace, selectionStart]);
+
+    const handleKey = (e: React.KeyboardEvent) => {
+        if (e.key === "Escape") {
+            e.preventDefault();
+            onClose();
+        } else if (e.key === "Enter") {
+            e.preventDefault();
+            if (e.shiftKey) prev();
+            else next();
+        }
+    };
+
+    if (!isOpen) return null;
+
+    const totalLabel = match.matches.length === 0
+        ? "No results"
+        : `${match.activeIdx + 1} of ${match.matches.length}`;
+
+    return (
+        <div
+            role="dialog"
+            aria-label="Find and replace"
+            className="absolute top-2 right-4 z-40 bg-[var(--bg-secondary)] border border-[var(--border)] rounded-lg shadow-xl px-2 py-2 flex flex-col gap-2 animate-fade-in-down"
+            style={{ minWidth: 360 }}
+            onKeyDown={handleKey}
+        >
+            <div className="flex items-center gap-2">
+                <button
+                    type="button"
+                    onClick={() => setShowReplace((v) => !v)}
+                    aria-label={showReplace ? "Hide replace" : "Show replace"}
+                    className="flex items-center justify-center w-6 h-6 rounded hover:bg-[var(--bg-hover)] text-[var(--text-secondary)]"
+                >
+                    <span className="material-symbols-outlined text-[16px]">
+                        {showReplace ? "expand_less" : "expand_more"}
+                    </span>
+                </button>
+                <input
+                    ref={inputRef}
+                    type="text"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="Find"
+                    className="flex-1 px-2 py-1 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+                    aria-label="Find text"
+                />
+                <span className="text-[11px] text-[var(--text-secondary)] tabular-nums whitespace-nowrap min-w-[80px] text-right">
+                    {totalLabel}
+                </span>
+                <button onClick={prev} title="Previous (Shift+Enter)" aria-label="Previous match" className="w-6 h-6 rounded hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] flex items-center justify-center">
+                    <span className="material-symbols-outlined text-[16px]">keyboard_arrow_up</span>
+                </button>
+                <button onClick={next} title="Next (Enter)" aria-label="Next match" className="w-6 h-6 rounded hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] flex items-center justify-center">
+                    <span className="material-symbols-outlined text-[16px]">keyboard_arrow_down</span>
+                </button>
+                <button
+                    onClick={() => setCaseSensitive((v) => !v)}
+                    aria-pressed={caseSensitive}
+                    title="Match case"
+                    className={`w-6 h-6 rounded text-[12px] font-bold flex items-center justify-center ${caseSensitive ? "bg-[var(--accent)] text-[var(--accent-text)]" : "hover:bg-[var(--bg-hover)] text-[var(--text-secondary)]"}`}
+                >
+                    Aa
+                </button>
+                <button
+                    onClick={() => setRegex((v) => !v)}
+                    aria-pressed={regex}
+                    title="Regex"
+                    className={`w-6 h-6 rounded text-[12px] font-mono flex items-center justify-center ${regex ? "bg-[var(--accent)] text-[var(--accent-text)]" : "hover:bg-[var(--bg-hover)] text-[var(--text-secondary)]"}`}
+                >
+                    .*
+                </button>
+                <button onClick={onClose} title="Close (Esc)" aria-label="Close find" className="w-6 h-6 rounded hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] flex items-center justify-center">
+                    <span className="material-symbols-outlined text-[16px]">close</span>
+                </button>
+            </div>
+
+            {showReplace && (
+                <div className="flex items-center gap-2 pl-8">
+                    <input
+                        type="text"
+                        value={replacement}
+                        onChange={(e) => setReplacement(e.target.value)}
+                        placeholder="Replace"
+                        className="flex-1 px-2 py-1 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+                        aria-label="Replace with"
+                    />
+                    <button
+                        onClick={replaceCurrent}
+                        disabled={match.activeIdx === -1}
+                        className="px-2 py-1 text-xs rounded bg-[var(--bg-input)] border border-[var(--border)] hover:bg-[var(--bg-hover)] text-[var(--text-primary)] disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                        Replace
+                    </button>
+                    <button
+                        onClick={replaceAll}
+                        disabled={match.matches.length === 0}
+                        className="px-2 py-1 text-xs rounded bg-[var(--bg-input)] border border-[var(--border)] hover:bg-[var(--bg-hover)] text-[var(--text-primary)] disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                        Replace All
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/FormatToolbar.tsx
+++ b/src/components/FormatToolbar.tsx
@@ -1,0 +1,127 @@
+import type { EditorResult } from "../utils/editorActions";
+import { wrapSelection, insertLink } from "../utils/editorActions";
+
+interface FormatToolbarProps {
+    /** Returns the textarea so we can read selection. Null while editor not mounted. */
+    getTextarea: () => HTMLTextAreaElement | null;
+    /** Apply an EditorResult: parent updates content + restores selection. */
+    apply: (r: EditorResult) => void;
+    /** Insert plain text at the caret. */
+    insert: (text: string) => void;
+}
+
+interface ToolButtonProps {
+    icon: string;
+    title: string;
+    onClick: () => void;
+}
+
+function ToolButton({ icon, title, onClick }: ToolButtonProps) {
+    return (
+        <button
+            type="button"
+            onMouseDown={(e) => e.preventDefault()} // keep textarea focus
+            onClick={onClick}
+            title={title}
+            aria-label={title}
+            className="w-8 h-8 flex items-center justify-center rounded-[var(--radius-sm)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors"
+        >
+            <span className="material-symbols-outlined text-[18px]">{icon}</span>
+        </button>
+    );
+}
+
+const Sep = () => <div className="w-px h-5 bg-[var(--border)] mx-0.5" />;
+
+export function FormatToolbar({ getTextarea, apply, insert }: FormatToolbarProps) {
+    const wrap = (left: string, right: string, ph: string) => () => {
+        const t = getTextarea();
+        if (!t) return;
+        apply(wrapSelection({ text: t.value, selStart: t.selectionStart, selEnd: t.selectionEnd }, left, right, ph));
+    };
+
+    const link = () => {
+        const t = getTextarea();
+        if (!t) return;
+        apply(insertLink({ text: t.value, selStart: t.selectionStart, selEnd: t.selectionEnd }));
+    };
+
+    const heading = (level: number) => () => {
+        const t = getTextarea();
+        if (!t) return;
+        const pos = t.selectionStart;
+        const before = t.value.slice(0, pos);
+        const ls = before.lastIndexOf("\n") + 1;
+        const lineEnd = t.value.indexOf("\n", pos);
+        const end = lineEnd === -1 ? t.value.length : lineEnd;
+        const line = t.value.slice(ls, end);
+        // Strip existing heading markers, then re-add
+        const stripped = line.replace(/^#{1,6}\s+/, "");
+        const newLine = `${"#".repeat(level)} ${stripped}`;
+        apply({
+            text: t.value.slice(0, ls) + newLine + t.value.slice(end),
+            selStart: ls + newLine.length,
+            selEnd: ls + newLine.length,
+        });
+    };
+
+    const block = (prefix: string) => () => {
+        const t = getTextarea();
+        if (!t) return;
+        const pos = t.selectionStart;
+        const before = t.value.slice(0, pos);
+        const ls = before.lastIndexOf("\n") + 1;
+        const lineEnd = t.value.indexOf("\n", pos);
+        const end = lineEnd === -1 ? t.value.length : lineEnd;
+        const line = t.value.slice(ls, end);
+        const newLine = line.startsWith(prefix) ? line.slice(prefix.length) : prefix + line;
+        const delta = newLine.length - line.length;
+        apply({
+            text: t.value.slice(0, ls) + newLine + t.value.slice(end),
+            selStart: pos + delta,
+            selEnd: pos + delta,
+        });
+    };
+
+    const codeBlock = () => {
+        const t = getTextarea();
+        if (!t) return;
+        const sel = t.value.slice(t.selectionStart, t.selectionEnd) || "code";
+        const inserted = `\n\`\`\`\n${sel}\n\`\`\`\n`;
+        apply({
+            text: t.value.slice(0, t.selectionStart) + inserted + t.value.slice(t.selectionEnd),
+            selStart: t.selectionStart + 4, // place caret after opening fence
+            selEnd: t.selectionStart + 4 + sel.length,
+        });
+    };
+
+    const insertTable = () => {
+        const tpl = "\n| Header 1 | Header 2 |\n| --- | --- |\n| Cell | Cell |\n";
+        insert(tpl);
+    };
+
+    const insertHr = () => insert("\n\n---\n\n");
+
+    return (
+        <div className="flex items-center gap-0.5 px-2 h-9 bg-[var(--bg-secondary)] border-b border-[var(--border-subtle)] no-select shrink-0">
+            <ToolButton icon="format_h1" title="Heading 1" onClick={heading(1)} />
+            <ToolButton icon="format_h2" title="Heading 2" onClick={heading(2)} />
+            <ToolButton icon="format_h3" title="Heading 3" onClick={heading(3)} />
+            <Sep />
+            <ToolButton icon="format_bold" title="Bold (Ctrl+B)" onClick={wrap("**", "**", "bold")} />
+            <ToolButton icon="format_italic" title="Italic (Ctrl+I)" onClick={wrap("*", "*", "italic")} />
+            <ToolButton icon="strikethrough_s" title="Strikethrough" onClick={wrap("~~", "~~", "text")} />
+            <ToolButton icon="code" title="Inline code" onClick={wrap("`", "`", "code")} />
+            <Sep />
+            <ToolButton icon="format_list_bulleted" title="Bullet list" onClick={block("- ")} />
+            <ToolButton icon="format_list_numbered" title="Numbered list" onClick={block("1. ")} />
+            <ToolButton icon="check_box" title="Task list" onClick={block("- [ ] ")} />
+            <ToolButton icon="format_quote" title="Blockquote (Ctrl+/)" onClick={block("> ")} />
+            <Sep />
+            <ToolButton icon="link" title="Link (Ctrl+K)" onClick={link} />
+            <ToolButton icon="data_object" title="Code block" onClick={codeBlock} />
+            <ToolButton icon="table_chart" title="Insert table" onClick={insertTable} />
+            <ToolButton icon="horizontal_rule" title="Horizontal rule" onClick={insertHr} />
+        </div>
+    );
+}

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -13,6 +13,28 @@ interface MarkdownPreviewProps {
     onLineChange?: (line: number) => void;
     filePath?: string | null;
     markdownBodyRef?: React.RefObject<HTMLDivElement | null>;
+    onContentChange?: (newContent: string) => void;
+}
+
+/** Slugify heading text into a stable, URL-safe id (GitHub-style). */
+const slugify = (text: string): string =>
+    text
+        .toLowerCase()
+        .trim()
+        .replace(/[^\w\s-]/g, "")
+        .replace(/\s+/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, "");
+
+/** Extract the plain-text label from a React node tree (for slug + anchor link). */
+function nodeText(node: React.ReactNode): string {
+    if (typeof node === "string" || typeof node === "number") return String(node);
+    if (Array.isArray(node)) return node.map(nodeText).join("");
+    if (node && typeof node === "object" && "props" in node) {
+        // @ts-expect-error - children may exist on element
+        return nodeText(node.props?.children);
+    }
+    return "";
 }
 
 // MIME type lookup for image extensions
@@ -95,13 +117,107 @@ function LocalImage({ src, alt, baseDir, ...props }: { src: string; alt: string;
     }
 
     return (
-        <img 
-            src={imageSrc} 
-            alt={alt || 'image'} 
+        <img
+            src={imageSrc}
+            alt={alt || 'image'}
             {...props}
-            className="max-w-full h-auto rounded-lg my-4"
+            loading="lazy"
+            className="max-w-full h-auto rounded-lg my-4 cursor-zoom-in transition-transform hover:scale-[1.01]"
+            onClick={() => {
+                const evt = new CustomEvent("marklite:zoom", { detail: { src: imageSrc, alt } });
+                window.dispatchEvent(evt);
+            }}
         />
     );
+}
+
+/** Code block with a copy-to-clipboard button. */
+function CodeBlock({ children, ...rest }: React.HTMLAttributes<HTMLPreElement>) {
+    const ref = useRef<HTMLPreElement>(null);
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = async () => {
+        const text = ref.current?.innerText ?? "";
+        try {
+            await navigator.clipboard.writeText(text);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1400);
+        } catch {
+            // ignore — clipboard may be unavailable in some webviews
+        }
+    };
+
+    return (
+        <div className="relative group">
+            <button
+                type="button"
+                onClick={handleCopy}
+                aria-label="Copy code"
+                className="absolute top-2 right-2 z-10 px-2 py-1 text-[11px] rounded bg-[var(--bg-secondary)] border border-[var(--border)] text-[var(--text-secondary)] opacity-0 group-hover:opacity-100 hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-opacity"
+            >
+                {copied ? "Copied!" : "Copy"}
+            </button>
+            <pre ref={ref} {...rest}>{children}</pre>
+        </div>
+    );
+}
+
+/** Interactive task checkbox — local optimistic state, parent writes to source. */
+function InteractiveTaskCheckbox({ initialChecked, onToggle }: { initialChecked: boolean; onToggle: (checked: boolean) => void }) {
+    const [checked, setChecked] = useState(initialChecked);
+    useEffect(() => setChecked(initialChecked), [initialChecked]);
+    return (
+        <input
+            type="checkbox"
+            checked={checked}
+            onChange={(e) => {
+                const next = e.target.checked;
+                setChecked(next);
+                onToggle(next);
+            }}
+            className="mr-2 cursor-pointer accent-[var(--accent)]"
+        />
+    );
+}
+
+/** Heading with click-to-copy permalink (GitHub-style). */
+function HeadingWithAnchor(
+    props: { level: 1 | 2 | 3 | 4 | 5 | 6 } & React.HTMLAttributes<HTMLHeadingElement>
+) {
+    const { level, children, className, ...rest } = props;
+    const text = nodeText(children);
+    const id = slugify(text);
+    const handleClick = () => {
+        const el = document.getElementById(id);
+        el?.scrollIntoView({ behavior: "smooth", block: "start" });
+    };
+    const inner = (
+        <>
+            <span>{children}</span>
+            <button
+                type="button"
+                onClick={handleClick}
+                aria-label={`Jump to ${text}`}
+                className="opacity-0 group-hover/heading:opacity-60 hover:!opacity-100 text-[var(--text-muted)] hover:text-[var(--accent)] transition-opacity"
+                tabIndex={-1}
+            >
+                <span className="material-symbols-outlined" style={{ fontSize: "0.7em", verticalAlign: "middle" }}>link</span>
+            </button>
+        </>
+    );
+    const sharedProps = {
+        id,
+        ...rest,
+        className: `${className ?? ""} group/heading flex items-baseline gap-2`,
+    };
+    switch (level) {
+        case 1: return <h1 {...sharedProps}>{inner}</h1>;
+        case 2: return <h2 {...sharedProps}>{inner}</h2>;
+        case 3: return <h3 {...sharedProps}>{inner}</h3>;
+        case 4: return <h4 {...sharedProps}>{inner}</h4>;
+        case 5: return <h5 {...sharedProps}>{inner}</h5>;
+        case 6: return <h6 {...sharedProps}>{inner}</h6>;
+    }
 }
 
 export function MarkdownPreview({
@@ -110,23 +226,85 @@ export function MarkdownPreview({
     onLineChange,
     filePath,
     markdownBodyRef,
+    onContentChange,
 }: MarkdownPreviewProps) {
     const mainRef = useRef<HTMLElement>(null);
+    const [zoomImage, setZoomImage] = useState<{ src: string; alt: string } | null>(null);
+
+    // Listen for zoom requests from LocalImage clicks
+    useEffect(() => {
+        const handler = (e: Event) => {
+            const detail = (e as CustomEvent).detail;
+            if (detail?.src) setZoomImage({ src: detail.src, alt: detail.alt || "" });
+        };
+        window.addEventListener("marklite:zoom", handler);
+        return () => window.removeEventListener("marklite:zoom", handler);
+    }, []);
+
+    // Esc closes lightbox
+    useEffect(() => {
+        if (!zoomImage) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setZoomImage(null);
+        };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [zoomImage]);
 
     // Get the directory containing the markdown file
     const baseDir = useMemo(() => {
         if (!filePath) return null;
-        // Handle both Windows and Unix paths
         const lastSep = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
         return lastSep > 0 ? filePath.slice(0, lastSep) : null;
     }, [filePath]);
 
-    // Custom image component to handle relative paths
-    const components = useMemo(() => ({
-        img: ({ src, alt, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) => {
-            return <LocalImage src={src || ''} alt={alt || 'image'} baseDir={baseDir} {...props} />;
+    // Toggle a task list checkbox by index — write back to the source markdown.
+    // Counts task items in document order; toggles the Nth one.
+    const handleTaskToggle = useCallback((index: number, checked: boolean) => {
+        if (!onContentChange) return;
+        const lines = content.split("\n");
+        let count = 0;
+        const taskRe = /^(\s*[-*+]\s+\[)([ xX])(\]\s+)/;
+        for (let i = 0; i < lines.length; i++) {
+            const m = lines[i].match(taskRe);
+            if (m) {
+                if (count === index) {
+                    lines[i] = lines[i].replace(taskRe, `$1${checked ? "x" : " "}$3`);
+                    onContentChange(lines.join("\n"));
+                    return;
+                }
+                count++;
+            }
         }
-    }), [baseDir]);
+    }, [content, onContentChange]);
+
+    const components = useMemo(() => ({
+        img: ({ src, alt, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+            <LocalImage src={src || ''} alt={alt || 'image'} baseDir={baseDir} {...props} />
+        ),
+        pre: (props: React.HTMLAttributes<HTMLPreElement>) => <CodeBlock {...props} />,
+        h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => <HeadingWithAnchor level={1} {...props} />,
+        h2: (props: React.HTMLAttributes<HTMLHeadingElement>) => <HeadingWithAnchor level={2} {...props} />,
+        h3: (props: React.HTMLAttributes<HTMLHeadingElement>) => <HeadingWithAnchor level={3} {...props} />,
+        h4: (props: React.HTMLAttributes<HTMLHeadingElement>) => <HeadingWithAnchor level={4} {...props} />,
+        h5: (props: React.HTMLAttributes<HTMLHeadingElement>) => <HeadingWithAnchor level={5} {...props} />,
+        h6: (props: React.HTMLAttributes<HTMLHeadingElement>) => <HeadingWithAnchor level={6} {...props} />,
+        // Interactive task checkbox: react-markdown + remarkGfm renders <input type="checkbox" disabled />
+        input: ({ type, checked, ...rest }: React.InputHTMLAttributes<HTMLInputElement>) => {
+            if (type !== "checkbox") return <input type={type} checked={checked} {...rest} />;
+            return (
+                <InteractiveTaskCheckbox
+                    initialChecked={!!checked}
+                    onToggle={(c) => handleTaskToggle(taskCheckboxCounter.current++, c)}
+                />
+            );
+        },
+    }), [baseDir, handleTaskToggle]);
+
+    // Reset the task index counter on every render so the next render starts at 0.
+    // (react-markdown renders synchronously top-to-bottom, so order matches doc order)
+    const taskCheckboxCounter = useRef(0);
+    taskCheckboxCounter.current = 0;
 
     // Calculate current line based on scroll position
     const handleScroll = useCallback(() => {
@@ -163,21 +341,47 @@ export function MarkdownPreview({
     }, [handleScroll]);
 
     return (
-        <main
-            ref={mainRef}
-            className="flex-1 overflow-y-auto bg-[var(--bg-primary)] transition-colors"
-        >
-            <div className="max-w-[800px] mx-auto px-8 py-12">
-<div className="markdown-body" ref={markdownBodyRef}>
-                    <Markdown
-                        remarkPlugins={[remarkGfm]}
-                        rehypePlugins={[rehypeHighlight]}
-                        components={components}
-                    >
-                        {content}
-                    </Markdown>
+        <>
+            <main
+                ref={mainRef}
+                className="flex-1 overflow-y-auto bg-[var(--bg-primary)] transition-colors"
+            >
+                <div className="max-w-[800px] mx-auto px-8 py-12">
+                    <div className="markdown-body" ref={markdownBodyRef}>
+                        <Markdown
+                            remarkPlugins={[remarkGfm]}
+                            rehypePlugins={[rehypeHighlight]}
+                            components={components}
+                        >
+                            {content}
+                        </Markdown>
+                    </div>
                 </div>
-            </div>
-        </main>
+            </main>
+
+            {zoomImage && (
+                <div
+                    role="dialog"
+                    aria-label={`Image: ${zoomImage.alt || "preview"}`}
+                    className="fixed inset-0 z-[100] flex items-center justify-center bg-black/90 backdrop-blur-sm cursor-zoom-out animate-fade-in"
+                    onClick={() => setZoomImage(null)}
+                >
+                    <img
+                        src={zoomImage.src}
+                        alt={zoomImage.alt}
+                        className="max-w-[95vw] max-h-[95vh] object-contain rounded-lg shadow-2xl"
+                        onClick={(e) => e.stopPropagation()}
+                    />
+                    <button
+                        type="button"
+                        onClick={() => setZoomImage(null)}
+                        aria-label="Close image"
+                        className="absolute top-4 right-4 w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 text-white flex items-center justify-center backdrop-blur"
+                    >
+                        <span className="material-symbols-outlined text-[20px]">close</span>
+                    </button>
+                </div>
+            )}
+        </>
     );
 }

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -5,6 +5,31 @@ import rehypeHighlight from "rehype-highlight";
 import { readFile } from "@tauri-apps/plugin-fs";
 import { parseFrontmatter } from "../utils/frontmatter";
 import type { Scroller } from "../utils/scrollSync";
+import { MermaidBlock, isMermaidLanguage } from "./MermaidBlock";
+
+// Detect KaTeX-style math so we only load the heavy katex bundle when needed.
+// $$...$$ for block math, $...$ for inline math (not preceded/followed by digit
+// to avoid false positives like "$5 and $10").
+const MATH_DETECTION_REGEX = /(\$\$[\s\S]+?\$\$)|((?:^|[^\d$])\$[^\s$][^\n$]*?[^\s$]\$(?!\d))/m;
+const hasMath = (s: string): boolean => MATH_DETECTION_REGEX.test(s);
+
+type PluginPair = { remark: unknown; rehype: unknown };
+let mathPluginsCache: PluginPair | null = null;
+let mathLoadPromise: Promise<PluginPair> | null = null;
+
+const loadMathPlugins = (): Promise<PluginPair> => {
+    if (mathPluginsCache) return Promise.resolve(mathPluginsCache);
+    if (mathLoadPromise) return mathLoadPromise;
+    mathLoadPromise = Promise.all([
+        import("remark-math"),
+        import("rehype-katex"),
+        import("katex/dist/katex.min.css"),
+    ]).then(([rm, rk]) => {
+        mathPluginsCache = { remark: rm.default, rehype: rk.default };
+        return mathPluginsCache;
+    });
+    return mathLoadPromise;
+};
 
 interface MarkdownPreviewProps {
     content: string;
@@ -135,10 +160,32 @@ function LocalImage({ src, alt, baseDir, ...props }: { src: string; alt: string;
     );
 }
 
-/** Code block with a copy-to-clipboard button. */
+/** Pull className + raw text out of a react-markdown <pre><code>...</code></pre> child. */
+function extractCodeChild(children: React.ReactNode): { className?: string; text: string } | null {
+    // <pre>'s child is the <code> element React node
+    if (!children || typeof children !== "object") return null;
+    const arr = Array.isArray(children) ? children : [children];
+    for (const child of arr) {
+        if (child && typeof child === "object" && "props" in child) {
+            const props = (child as { props: { className?: string; children?: React.ReactNode } }).props;
+            return {
+                className: props.className,
+                text: nodeText(props.children),
+            };
+        }
+    }
+    return null;
+}
+
+/** Code block with a copy-to-clipboard button — also intercepts mermaid blocks. */
 function CodeBlock({ children, ...rest }: React.HTMLAttributes<HTMLPreElement>) {
     const ref = useRef<HTMLPreElement>(null);
     const [copied, setCopied] = useState(false);
+
+    const codeInfo = extractCodeChild(children);
+    if (codeInfo && isMermaidLanguage(codeInfo.className)) {
+        return <MermaidBlock code={codeInfo.text} />;
+    }
 
     const handleCopy = async () => {
         const text = ref.current?.innerText ?? "";
@@ -376,6 +423,28 @@ export function MarkdownPreview({
         [content]
     );
 
+    // Lazy-load KaTeX only when the document actually contains math.
+    // Heavy (~280kb) — keeping it out of the initial bundle is a real win.
+    const [mathPlugins, setMathPlugins] = useState<PluginPair | null>(mathPluginsCache);
+    useEffect(() => {
+        if (mathPlugins) return;
+        if (!hasMath(renderBody)) return;
+        let cancelled = false;
+        loadMathPlugins().then((p) => {
+            if (!cancelled) setMathPlugins(p);
+        });
+        return () => { cancelled = true; };
+    }, [renderBody, mathPlugins]);
+
+    const remarkPlugins = useMemo(
+        () => (mathPlugins ? [remarkGfm, mathPlugins.remark] : [remarkGfm]),
+        [mathPlugins]
+    );
+    const rehypePlugins = useMemo(
+        () => (mathPlugins ? [rehypeHighlight, mathPlugins.rehype] : [rehypeHighlight]),
+        [mathPlugins]
+    );
+
     // Track scroll: update active-line indicator + report fraction for split-sync.
     const handleScroll = useCallback(() => {
         const element = mainRef.current;
@@ -429,8 +498,10 @@ export function MarkdownPreview({
                     {hasFrontmatter && <FrontmatterCard data={frontmatter} />}
                     <div className="markdown-body" ref={markdownBodyRef}>
                         <Markdown
-                            remarkPlugins={[remarkGfm]}
-                            rehypePlugins={[rehypeHighlight]}
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            remarkPlugins={remarkPlugins as any}
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            rehypePlugins={rehypePlugins as any}
                             components={components}
                         >
                             {renderBody}

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -4,6 +4,7 @@ import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { readFile } from "@tauri-apps/plugin-fs";
 import { parseFrontmatter } from "../utils/frontmatter";
+import type { Scroller } from "../utils/scrollSync";
 
 interface MarkdownPreviewProps {
     content: string;
@@ -15,6 +16,8 @@ interface MarkdownPreviewProps {
     filePath?: string | null;
     markdownBodyRef?: React.RefObject<HTMLDivElement | null>;
     onContentChange?: (newContent: string) => void;
+    onScrollFraction?: (fraction: number) => void;
+    registerScroller?: (scroller: Scroller | null) => void;
 }
 
 /** Slugify heading text into a stable, URL-safe id (GitHub-style). */
@@ -284,6 +287,8 @@ export function MarkdownPreview({
     filePath,
     markdownBodyRef,
     onContentChange,
+    onScrollFraction,
+    registerScroller,
 }: MarkdownPreviewProps) {
     const mainRef = useRef<HTMLElement>(null);
     const [zoomImage, setZoomImage] = useState<{ src: string; alt: string } | null>(null);
@@ -371,25 +376,21 @@ export function MarkdownPreview({
         [content]
     );
 
-    // Calculate current line based on scroll position
+    // Track scroll: update active-line indicator + report fraction for split-sync.
     const handleScroll = useCallback(() => {
-        if (!mainRef.current || !onLineChange) return;
-
         const element = mainRef.current;
+        if (!element) return;
+
         const scrollTop = element.scrollTop;
         const scrollHeight = element.scrollHeight - element.clientHeight;
+        const fraction = scrollHeight > 0 ? scrollTop / scrollHeight : 0;
 
-        if (scrollHeight <= 0) {
-            onLineChange(1);
-            return;
+        if (onLineChange) {
+            const currentLine = scrollHeight <= 0 ? 1 : Math.max(1, Math.ceil(fraction * lineCount));
+            onLineChange(currentLine);
         }
-
-        // Calculate approximate line based on scroll percentage
-        const scrollPercentage = scrollTop / scrollHeight;
-        const currentLine = Math.max(1, Math.ceil(scrollPercentage * lineCount));
-
-        onLineChange(currentLine);
-    }, [lineCount, onLineChange]);
+        onScrollFraction?.(fraction);
+    }, [lineCount, onLineChange, onScrollFraction]);
 
     // Set up scroll listener
     useEffect(() => {
@@ -397,13 +398,26 @@ export function MarkdownPreview({
         if (!element) return;
 
         element.addEventListener("scroll", handleScroll);
-        // Initial line
         handleScroll();
 
         return () => {
             element.removeEventListener("scroll", handleScroll);
         };
     }, [handleScroll]);
+
+    // Register imperative scroller for split-view sync
+    useEffect(() => {
+        if (!registerScroller) return;
+        registerScroller({
+            setFraction: (f: number) => {
+                const el = mainRef.current;
+                if (!el) return;
+                const max = el.scrollHeight - el.clientHeight;
+                if (max > 0) el.scrollTop = max * f;
+            },
+        });
+        return () => registerScroller(null);
+    }, [registerScroller]);
 
     return (
         <>

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -3,7 +3,7 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { readFile } from "@tauri-apps/plugin-fs";
-import { parseFrontmatter } from "../utils/frontmatter";
+import { parseFrontmatter, serializeFrontmatter, type FrontmatterValue } from "../utils/frontmatter";
 import type { Scroller } from "../utils/scrollSync";
 import { MermaidBlock, isMermaidLanguage } from "./MermaidBlock";
 
@@ -43,6 +43,7 @@ interface MarkdownPreviewProps {
     onContentChange?: (newContent: string) => void;
     onScrollFraction?: (fraction: number) => void;
     registerScroller?: (scroller: Scroller | null) => void;
+    onWikilinkClick?: (target: string) => void;
 }
 
 /** Slugify heading text into a stable, URL-safe id (GitHub-style). */
@@ -213,32 +214,94 @@ function CodeBlock({ children, ...rest }: React.HTMLAttributes<HTMLPreElement>) 
     );
 }
 
-/** Render YAML frontmatter as a collapsible metadata card. */
-function FrontmatterCard({ data }: { data: Record<string, string | number | boolean | string[]> }) {
+/** Render YAML frontmatter as a collapsible, editable metadata card. */
+function FrontmatterCard({
+    data,
+    editable,
+    onChange,
+}: {
+    data: Record<string, FrontmatterValue>;
+    editable: boolean;
+    onChange?: (next: Record<string, FrontmatterValue>) => void;
+}) {
     const [collapsed, setCollapsed] = useState(false);
     const entries = Object.entries(data);
     if (entries.length === 0) return null;
 
-    const renderValue = (v: string | number | boolean | string[]) => {
+    const updateKey = (k: string, v: FrontmatterValue) => onChange?.({ ...data, [k]: v });
+
+    const renderValue = (k: string, v: FrontmatterValue) => {
         if (Array.isArray(v)) {
             return (
-                <div className="flex flex-wrap gap-1">
+                <div className="flex flex-wrap gap-1 items-center">
                     {v.map((item, i) => (
-                        <span key={i} className="px-2 py-0.5 text-xs bg-[var(--bg-hover)] rounded border border-[var(--border-subtle)] text-[var(--text-primary)]">
+                        <span key={i} className="px-2 py-0.5 text-xs bg-[var(--bg-hover)] rounded-[var(--radius-sm)] border border-[var(--border-subtle)] text-[var(--text-primary)] flex items-center gap-1">
                             {item}
+                            {editable && (
+                                <button
+                                    type="button"
+                                    onClick={() => updateKey(k, v.filter((_, idx) => idx !== i))}
+                                    aria-label={`Remove ${item}`}
+                                    className="opacity-50 hover:opacity-100"
+                                >
+                                    <span className="material-symbols-outlined text-[12px]">close</span>
+                                </button>
+                            )}
                         </span>
                     ))}
+                    {editable && (
+                        <input
+                            type="text"
+                            placeholder="+ add"
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                    const val = e.currentTarget.value.trim();
+                                    if (val) {
+                                        updateKey(k, [...v, val]);
+                                        e.currentTarget.value = "";
+                                    }
+                                }
+                            }}
+                            className="px-1.5 py-0.5 text-xs bg-transparent border border-dashed border-[var(--border)] rounded-[var(--radius-sm)] text-[var(--text-secondary)] outline-none focus:border-[var(--accent)] w-20"
+                        />
+                    )}
                 </div>
             );
         }
         if (typeof v === "boolean") {
+            if (editable) {
+                return (
+                    <button
+                        type="button"
+                        onClick={() => updateKey(k, !v)}
+                        className={`relative inline-block w-9 h-5 rounded-full transition-colors ${v ? "bg-[var(--accent)]" : "bg-[var(--border)]"}`}
+                        aria-pressed={v}
+                    >
+                        <span className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${v ? "translate-x-4" : ""}`} />
+                    </button>
+                );
+            }
             return <span className="text-xs font-mono">{v ? "true" : "false"}</span>;
+        }
+        if (editable) {
+            return (
+                <input
+                    type={typeof v === "number" ? "number" : "text"}
+                    defaultValue={String(v)}
+                    onBlur={(e) => {
+                        const raw = e.target.value;
+                        const next: FrontmatterValue = typeof v === "number" ? Number(raw) : raw;
+                        if (next !== v) updateKey(k, next);
+                    }}
+                    className="w-full px-2 py-0.5 text-sm bg-transparent border-b border-transparent hover:border-[var(--border)] focus:border-[var(--accent)] outline-none text-[var(--text-primary)]"
+                />
+            );
         }
         return <span className="text-sm">{String(v)}</span>;
     };
 
     return (
-        <div className="mb-6 border border-[var(--border)] rounded-lg overflow-hidden bg-[var(--bg-secondary)]">
+        <div className="mb-6 border border-[var(--border)] rounded-[var(--radius-md)] overflow-hidden bg-[var(--bg-secondary)]">
             <button
                 type="button"
                 onClick={() => setCollapsed((c) => !c)}
@@ -247,7 +310,7 @@ function FrontmatterCard({ data }: { data: Record<string, string | number | bool
             >
                 <span className="flex items-center gap-2">
                     <span className="material-symbols-outlined text-[16px]">tune</span>
-                    Frontmatter
+                    Properties
                 </span>
                 <span className="material-symbols-outlined text-[18px]">
                     {collapsed ? "expand_more" : "expand_less"}
@@ -255,11 +318,11 @@ function FrontmatterCard({ data }: { data: Record<string, string | number | bool
             </button>
             {!collapsed && (
                 <div className="px-4 py-3 border-t border-[var(--border-subtle)]">
-                    <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm">
+                    <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm items-center">
                         {entries.map(([k, v]) => (
                             <div key={k} className="contents">
-                                <dt className="font-mono text-xs text-[var(--text-muted)] pt-0.5">{k}</dt>
-                                <dd className="text-[var(--text-primary)]">{renderValue(v)}</dd>
+                                <dt className="font-mono text-xs text-[var(--text-muted)]">{k}</dt>
+                                <dd className="text-[var(--text-primary)]">{renderValue(k, v)}</dd>
                             </div>
                         ))}
                     </dl>
@@ -336,6 +399,7 @@ export function MarkdownPreview({
     onContentChange,
     onScrollFraction,
     registerScroller,
+    onWikilinkClick,
 }: MarkdownPreviewProps) {
     const mainRef = useRef<HTMLElement>(null);
     const [zoomImage, setZoomImage] = useState<{ src: string; alt: string } | null>(null);
@@ -391,6 +455,27 @@ export function MarkdownPreview({
         img: ({ src, alt, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) => (
             <LocalImage src={src || ''} alt={alt || 'image'} baseDir={baseDir} {...props} />
         ),
+        a: ({ href, children, ...rest }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
+            // Wikilink: open same-folder file via callback
+            if (href && href.startsWith("wikilink:")) {
+                const target = decodeURIComponent(href.slice("wikilink:".length));
+                return (
+                    <a
+                        {...rest}
+                        href="#"
+                        onClick={(e) => {
+                            e.preventDefault();
+                            onWikilinkClick?.(target);
+                        }}
+                        className="text-[var(--syntax-link)] border-b border-dashed border-[var(--syntax-link)] hover:opacity-80"
+                        title={`Wikilink: ${target}`}
+                    >
+                        {children}
+                    </a>
+                );
+            }
+            return <a href={href} {...rest}>{children}</a>;
+        },
         pre: (props: React.HTMLAttributes<HTMLPreElement>) => <CodeBlock {...props} />,
         h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => <HeadingWithAnchor level={1} {...props} />,
         h2: (props: React.HTMLAttributes<HTMLHeadingElement>) => <HeadingWithAnchor level={2} {...props} />,
@@ -408,7 +493,7 @@ export function MarkdownPreview({
                 />
             );
         },
-    }), [baseDir, handleTaskToggle]);
+    }), [baseDir, handleTaskToggle, onWikilinkClick]);
 
     // Reset the task index counter on every render so the next render starts at 0.
     // (react-markdown renders synchronously top-to-bottom, so order matches doc order)
@@ -418,10 +503,22 @@ export function MarkdownPreview({
     // Parse YAML frontmatter once per content change. We render it as a
     // metadata card and pass the *body* (without the --- block) to react-markdown
     // so the raw YAML doesn't appear as a thematic break + heading.
-    const { body: renderBody, data: frontmatter, hasFrontmatter } = useMemo(
+    const { body: parsedBody, data: frontmatter, hasFrontmatter } = useMemo(
         () => parseFrontmatter(content),
         [content]
     );
+
+    // Pre-process wikilinks: [[Foo]] and [[Foo|alias]] → [alias](wikilink:Foo).
+    // We use a custom href scheme so the link click handler can detect them
+    // and load the target file, while keeping the source markdown portable
+    // (the source still has [[Foo]] — only the rendered output uses the scheme).
+    const renderBody = useMemo(() => {
+        return parsedBody.replace(/\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]/g, (_m, target: string, alias?: string) => {
+            const t = target.trim();
+            const a = (alias ?? target).trim();
+            return `[${a}](wikilink:${encodeURIComponent(t)})`;
+        });
+    }, [parsedBody]);
 
     // Lazy-load KaTeX only when the document actually contains math.
     // Heavy (~280kb) — keeping it out of the initial bundle is a real win.
@@ -495,7 +592,16 @@ export function MarkdownPreview({
                 className="flex-1 overflow-y-auto bg-[var(--bg-primary)] transition-colors"
             >
                 <div className="max-w-[800px] mx-auto px-8 py-12">
-                    {hasFrontmatter && <FrontmatterCard data={frontmatter} />}
+                    {hasFrontmatter && (
+                        <FrontmatterCard
+                            data={frontmatter}
+                            editable={!!onContentChange}
+                            onChange={(next) => {
+                                if (!onContentChange) return;
+                                onContentChange(serializeFrontmatter(next, parsedBody));
+                            }}
+                        />
+                    )}
                     <div className="markdown-body" ref={markdownBodyRef}>
                         <Markdown
                             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -3,6 +3,7 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { readFile } from "@tauri-apps/plugin-fs";
+import { parseFrontmatter } from "../utils/frontmatter";
 
 interface MarkdownPreviewProps {
     content: string;
@@ -162,6 +163,62 @@ function CodeBlock({ children, ...rest }: React.HTMLAttributes<HTMLPreElement>) 
     );
 }
 
+/** Render YAML frontmatter as a collapsible metadata card. */
+function FrontmatterCard({ data }: { data: Record<string, string | number | boolean | string[]> }) {
+    const [collapsed, setCollapsed] = useState(false);
+    const entries = Object.entries(data);
+    if (entries.length === 0) return null;
+
+    const renderValue = (v: string | number | boolean | string[]) => {
+        if (Array.isArray(v)) {
+            return (
+                <div className="flex flex-wrap gap-1">
+                    {v.map((item, i) => (
+                        <span key={i} className="px-2 py-0.5 text-xs bg-[var(--bg-hover)] rounded border border-[var(--border-subtle)] text-[var(--text-primary)]">
+                            {item}
+                        </span>
+                    ))}
+                </div>
+            );
+        }
+        if (typeof v === "boolean") {
+            return <span className="text-xs font-mono">{v ? "true" : "false"}</span>;
+        }
+        return <span className="text-sm">{String(v)}</span>;
+    };
+
+    return (
+        <div className="mb-6 border border-[var(--border)] rounded-lg overflow-hidden bg-[var(--bg-secondary)]">
+            <button
+                type="button"
+                onClick={() => setCollapsed((c) => !c)}
+                className="w-full flex items-center justify-between px-4 py-2 text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider hover:bg-[var(--bg-hover)] transition-colors"
+                aria-expanded={!collapsed}
+            >
+                <span className="flex items-center gap-2">
+                    <span className="material-symbols-outlined text-[16px]">tune</span>
+                    Frontmatter
+                </span>
+                <span className="material-symbols-outlined text-[18px]">
+                    {collapsed ? "expand_more" : "expand_less"}
+                </span>
+            </button>
+            {!collapsed && (
+                <div className="px-4 py-3 border-t border-[var(--border-subtle)]">
+                    <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm">
+                        {entries.map(([k, v]) => (
+                            <div key={k} className="contents">
+                                <dt className="font-mono text-xs text-[var(--text-muted)] pt-0.5">{k}</dt>
+                                <dd className="text-[var(--text-primary)]">{renderValue(v)}</dd>
+                            </div>
+                        ))}
+                    </dl>
+                </div>
+            )}
+        </div>
+    );
+}
+
 /** Interactive task checkbox — local optimistic state, parent writes to source. */
 function InteractiveTaskCheckbox({ initialChecked, onToggle }: { initialChecked: boolean; onToggle: (checked: boolean) => void }) {
     const [checked, setChecked] = useState(initialChecked);
@@ -306,6 +363,14 @@ export function MarkdownPreview({
     const taskCheckboxCounter = useRef(0);
     taskCheckboxCounter.current = 0;
 
+    // Parse YAML frontmatter once per content change. We render it as a
+    // metadata card and pass the *body* (without the --- block) to react-markdown
+    // so the raw YAML doesn't appear as a thematic break + heading.
+    const { body: renderBody, data: frontmatter, hasFrontmatter } = useMemo(
+        () => parseFrontmatter(content),
+        [content]
+    );
+
     // Calculate current line based on scroll position
     const handleScroll = useCallback(() => {
         if (!mainRef.current || !onLineChange) return;
@@ -347,13 +412,14 @@ export function MarkdownPreview({
                 className="flex-1 overflow-y-auto bg-[var(--bg-primary)] transition-colors"
             >
                 <div className="max-w-[800px] mx-auto px-8 py-12">
+                    {hasFrontmatter && <FrontmatterCard data={frontmatter} />}
                     <div className="markdown-body" ref={markdownBodyRef}>
                         <Markdown
                             remarkPlugins={[remarkGfm]}
                             rehypePlugins={[rehypeHighlight]}
                             components={components}
                         >
-                            {content}
+                            {renderBody}
                         </Markdown>
                     </div>
                 </div>

--- a/src/components/MermaidBlock.tsx
+++ b/src/components/MermaidBlock.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef, useState } from "react";
+
+// Single shared mermaid module promise — loaded only on first use.
+let mermaidPromise: Promise<typeof import("mermaid")["default"]> | null = null;
+
+const loadMermaid = (): Promise<typeof import("mermaid")["default"]> => {
+    if (mermaidPromise) return mermaidPromise;
+    mermaidPromise = import("mermaid").then((m) => {
+        const mermaid = m.default;
+        mermaid.initialize({
+            startOnLoad: false,
+            securityLevel: "strict", // disallow embedded scripts
+            theme: getMermaidTheme(),
+            fontFamily: "var(--font-body)",
+        });
+        return mermaid;
+    });
+    return mermaidPromise;
+};
+
+const getMermaidTheme = (): "default" | "dark" => {
+    const dataTheme = document.documentElement.getAttribute("data-theme");
+    if (dataTheme === "light" || dataTheme === "github" || dataTheme === "paper") return "default";
+    return "dark";
+};
+
+let nextMermaidId = 0;
+
+interface MermaidBlockProps {
+    code: string;
+}
+
+export function MermaidBlock({ code }: MermaidBlockProps) {
+    const [svg, setSvg] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const idRef = useRef<string>(`marklite-mermaid-${++nextMermaidId}`);
+
+    useEffect(() => {
+        let cancelled = false;
+        setError(null);
+        loadMermaid()
+            .then((mermaid) => mermaid.render(idRef.current, code))
+            .then((result) => {
+                if (cancelled) return;
+                setSvg(result.svg);
+            })
+            .catch((err: unknown) => {
+                if (cancelled) return;
+                const msg = err instanceof Error ? err.message : "Diagram failed to render";
+                setError(msg);
+            });
+        return () => { cancelled = true; };
+    }, [code]);
+
+    if (error) {
+        return (
+            <div className="my-4 p-4 border border-[var(--danger)] rounded-lg bg-[var(--bg-secondary)]">
+                <div className="text-sm font-semibold text-[var(--danger)] mb-1">Mermaid error</div>
+                <div className="text-xs font-mono text-[var(--text-secondary)] whitespace-pre-wrap">{error}</div>
+                <pre className="mt-2 text-xs opacity-70 overflow-x-auto">{code}</pre>
+            </div>
+        );
+    }
+
+    if (!svg) {
+        return (
+            <div className="my-4 p-4 border border-[var(--border-subtle)] rounded-lg bg-[var(--bg-secondary)] animate-pulse text-xs text-[var(--text-muted)] text-center">
+                Rendering diagram…
+            </div>
+        );
+    }
+
+    return (
+        <div
+            className="my-4 flex justify-center mermaid-rendered overflow-x-auto"
+            // mermaid output is from our own module — safe to inject as HTML
+            dangerouslySetInnerHTML={{ __html: svg }}
+        />
+    );
+}
+
+/** Quick check used in the components map to short-circuit normal code rendering. */
+export const isMermaidLanguage = (className: string | undefined): boolean =>
+    typeof className === "string" && /\blanguage-mermaid\b/.test(className);

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -1,18 +1,23 @@
+export type ViewMode = "preview" | "code" | "split";
+
 interface ModeToggleProps {
-    mode: "preview" | "code";
-    onToggle: () => void;
+    mode: ViewMode;
+    onSetMode: (mode: ViewMode) => void;
 }
 
-export function ModeToggle({ mode, onToggle }: ModeToggleProps) {
+const buttonBase =
+    "btn-press flex items-center gap-2 px-3 py-2 rounded-full transition-all duration-200";
+
+export function ModeToggle({ mode, onSetMode }: ModeToggleProps) {
     return (
         <div className="fixed bottom-8 right-8 z-50" role="group" aria-label="View mode toggle">
             <div className="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-full p-1.5 flex items-center shadow-2xl backdrop-blur-sm transition-colors animate-fade-in">
-                {/* Preview/Reader Button */}
                 <button
-                    onClick={mode === "code" ? onToggle : undefined}
-                    aria-label="Switch to reader mode"
+                    onClick={() => onSetMode("preview")}
+                    aria-label="Reader mode"
                     aria-pressed={mode === "preview"}
-                    className={`btn-press flex items-center gap-2 px-4 py-2 rounded-full transition-all duration-200 ${mode === "preview"
+                    title="Reader (Ctrl+E)"
+                    className={`${buttonBase} ${mode === "preview"
                         ? "bg-[var(--accent)] text-[var(--accent-text)] shadow-md"
                         : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
                         }`}
@@ -21,12 +26,26 @@ export function ModeToggle({ mode, onToggle }: ModeToggleProps) {
                     {mode === "preview" && <span className="text-sm font-bold">Reader</span>}
                 </button>
 
-                {/* Code/Edit Button */}
                 <button
-                    onClick={mode === "preview" ? onToggle : undefined}
-                    aria-label="Switch to code editor"
+                    onClick={() => onSetMode("split")}
+                    aria-label="Split view"
+                    aria-pressed={mode === "split"}
+                    title="Split view (Ctrl+\\)"
+                    className={`${buttonBase} ${mode === "split"
+                        ? "bg-[var(--accent)] text-[var(--accent-text)] shadow-md"
+                        : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                        }`}
+                >
+                    <span className="material-symbols-outlined text-[20px]">vertical_split</span>
+                    {mode === "split" && <span className="text-sm font-bold">Split</span>}
+                </button>
+
+                <button
+                    onClick={() => onSetMode("code")}
+                    aria-label="Code editor"
                     aria-pressed={mode === "code"}
-                    className={`btn-press flex items-center gap-2 px-4 py-2 rounded-full transition-all duration-200 group ${mode === "code"
+                    title="Code (Ctrl+E)"
+                    className={`${buttonBase} ${mode === "code"
                         ? "bg-[var(--accent)] text-[var(--accent-text)] shadow-md"
                         : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
                         }`}
@@ -34,11 +53,6 @@ export function ModeToggle({ mode, onToggle }: ModeToggleProps) {
                     {mode === "code" && <span className="text-sm font-bold">Code</span>}
                     <span className="material-symbols-outlined text-[20px]">code</span>
                 </button>
-            </div>
-
-            {/* Keyboard Shortcut Hint */}
-            <div className="absolute -top-8 left-1/2 transform -translate-x-1/2 text-xs text-[var(--text-secondary)] opacity-0 hover:opacity-100 transition-opacity bg-[var(--bg-primary)]/90 px-2 py-1 rounded whitespace-nowrap pointer-events-none">
-                Ctrl + E
             </div>
         </div>
     );

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTheme, Theme, FontFamily, FontSize } from '../context/ThemeContext';
+import { getAutoSave, setAutoSave } from '../utils/persistence';
 
 const themes: { id: Theme; name: string; colors: [string, string]; textColor: string; icon?: string }[] = [
     { id: 'dark', name: 'Dark', colors: ['#0a0a0a', '#141414'], textColor: '#ffffff' },
@@ -24,8 +25,17 @@ const fontSizes: { id: FontSize; name: string; size: string }[] = [
 
 export function SettingsMenu() {
     const [isOpen, setIsOpen] = useState(false);
+    const [autoSave, setAutoSaveState] = useState(() => getAutoSave());
     const { theme, setTheme, font, setFont, fontSize, setFontSize } = useTheme();
     const menuRef = useRef<HTMLDivElement>(null);
+
+    const toggleAutoSave = () => {
+        const next = !autoSave;
+        setAutoSaveState(next);
+        setAutoSave(next);
+        // Notify the app so the auto-save effect picks up the new setting
+        window.dispatchEvent(new CustomEvent("marklite:autosave-toggle", { detail: { enabled: next } }));
+    };
 
     // Close menu when clicking outside
     useEffect(() => {
@@ -125,7 +135,7 @@ export function SettingsMenu() {
                     </div>
 
                     {/* Font Size Section */}
-                    <div className="p-4">
+                    <div className="p-4 border-b border-[var(--border)]">
                         <div className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider mb-3">
                             Font Size
                         </div>
@@ -143,6 +153,31 @@ export function SettingsMenu() {
                                 </button>
                             ))}
                         </div>
+                    </div>
+
+                    {/* Editor Section */}
+                    <div className="p-4">
+                        <div className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider mb-3">
+                            Editor
+                        </div>
+                        <button
+                            onClick={toggleAutoSave}
+                            role="switch"
+                            aria-checked={autoSave}
+                            className="w-full flex items-center justify-between px-3 py-2 rounded-lg hover:bg-[var(--bg-hover)] text-sm text-[var(--text-primary)]"
+                        >
+                            <span className="flex flex-col items-start">
+                                <span>Auto-save</span>
+                                <span className="text-[11px] text-[var(--text-muted)]">Save 1.5s after typing stops</span>
+                            </span>
+                            <span
+                                className={`relative inline-block w-9 h-5 rounded-full transition-colors ${autoSave ? "bg-[var(--accent)]" : "bg-[var(--border)]"}`}
+                            >
+                                <span
+                                    className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${autoSave ? "translate-x-4" : ""}`}
+                                />
+                            </span>
+                        </button>
                     </div>
                 </div>
             )}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,313 @@
+import { useEffect, useRef, useState } from "react";
+import { useTheme, type Theme, type FontFamily, type FontSize } from "../context/ThemeContext";
+import {
+    getAutoSave, setAutoSave,
+    getFocusMode, setFocusMode,
+    getTypewriterMode, setTypewriterMode,
+    getToolbarEnabled, setToolbarEnabled,
+    getAIConfig, setAIConfig,
+} from "../utils/persistence";
+import { attachFocusTrap } from "../utils/focusTrap";
+
+interface SettingsModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+type Section = "appearance" | "editor" | "ai" | "about";
+
+const sections: Array<{ id: Section; label: string; icon: string }> = [
+    { id: "appearance", label: "Appearance", icon: "palette" },
+    { id: "editor", label: "Editor", icon: "edit" },
+    { id: "ai", label: "AI", icon: "auto_awesome" },
+    { id: "about", label: "About", icon: "info" },
+];
+
+const themes: Array<{ id: Theme; name: string; colors: [string, string]; textColor: string; icon?: string }> = [
+    { id: "dark", name: "Dark", colors: ["#0a0a0a", "#141414"], textColor: "#ffffff" },
+    { id: "light", name: "Light", colors: ["#ffffff", "#f5f5f5"], textColor: "#171717" },
+    { id: "paper", name: "Paper", colors: ["#f5f0e6", "#ebe5d8"], textColor: "#3d3d3d" },
+    { id: "github", name: "GitHub", colors: ["#ffffff", "#f6f8fa"], textColor: "#1f2328", icon: "github" },
+];
+
+const fonts: Array<{ id: FontFamily; name: string }> = [
+    { id: "inter", name: "Inter" },
+    { id: "merriweather", name: "Merriweather" },
+    { id: "lora", name: "Lora" },
+    { id: "source-serif", name: "Source Serif" },
+    { id: "fira-sans", name: "Fira Sans" },
+];
+
+const fontSizes: Array<{ id: FontSize; name: string }> = [
+    { id: "small", name: "Small" },
+    { id: "medium", name: "Medium" },
+    { id: "large", name: "Large" },
+];
+
+interface ToggleRowProps {
+    label: string;
+    description: string;
+    checked: boolean;
+    onChange: (v: boolean) => void;
+}
+
+function ToggleRow({ label, description, checked, onChange }: ToggleRowProps) {
+    return (
+        <button
+            type="button"
+            role="switch"
+            aria-checked={checked}
+            onClick={() => onChange(!checked)}
+            className="w-full flex items-center justify-between gap-4 px-3 py-2.5 rounded-[var(--radius-md)] hover:bg-[var(--bg-hover)] transition-colors text-left"
+        >
+            <div className="flex flex-col items-start min-w-0">
+                <span className="text-sm text-[var(--text-primary)]">{label}</span>
+                <span className="text-[11px] text-[var(--text-muted)]">{description}</span>
+            </div>
+            <span className={`relative inline-block w-9 h-5 rounded-full shrink-0 transition-colors ${checked ? "bg-[var(--accent)]" : "bg-[var(--border)]"}`}>
+                <span className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${checked ? "translate-x-4" : ""}`} />
+            </span>
+        </button>
+    );
+}
+
+export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const [section, setSection] = useState<Section>("appearance");
+    const [filter, setFilter] = useState("");
+    const { theme, setTheme, font, setFont, fontSize, setFontSize } = useTheme();
+
+    const [autoSave, setAutoSaveLocal] = useState(getAutoSave);
+    const [focus, setFocusLocal] = useState(getFocusMode);
+    const [typewriter, setTypewriterLocal] = useState(getTypewriterMode);
+    const [toolbar, setToolbarLocal] = useState(getToolbarEnabled);
+
+    const [ai, setAi] = useState(getAIConfig);
+
+    const fire = (event: string, enabled: boolean) =>
+        window.dispatchEvent(new CustomEvent(event, { detail: { enabled } }));
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                e.preventDefault();
+                onClose();
+            }
+        };
+        document.addEventListener("keydown", onKey);
+        const detach = attachFocusTrap(dialogRef.current);
+        return () => {
+            document.removeEventListener("keydown", onKey);
+            detach();
+        };
+    }, [isOpen, onClose]);
+
+    if (!isOpen) return null;
+
+    const matches = (text: string) => !filter || text.toLowerCase().includes(filter.toLowerCase());
+
+    return (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center" role="dialog" aria-modal="true" aria-label="Settings">
+            <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} aria-hidden="true" />
+
+            <div
+                ref={dialogRef}
+                className="relative z-10 w-[820px] max-w-[95vw] h-[600px] max-h-[90vh] flex bg-[var(--bg-primary)] border border-[var(--border)] rounded-[var(--radius-lg)] shadow-2xl overflow-hidden animate-fade-in"
+            >
+                {/* Sidebar */}
+                <aside className="w-48 shrink-0 bg-[var(--bg-secondary)] border-r border-[var(--border)] flex flex-col">
+                    <div className="px-4 py-3 border-b border-[var(--border)]">
+                        <input
+                            type="text"
+                            value={filter}
+                            onChange={(e) => setFilter(e.target.value)}
+                            placeholder="Search…"
+                            aria-label="Search settings"
+                            className="w-full px-2 py-1 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-md)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+                        />
+                    </div>
+                    <nav className="flex-1 py-2">
+                        {sections.map((s) => (
+                            <button
+                                key={s.id}
+                                onClick={() => setSection(s.id)}
+                                className={`w-full flex items-center gap-2 px-4 py-2 text-sm text-left transition-colors ${section === s.id
+                                    ? "bg-[var(--bg-hover)] text-[var(--text-primary)] font-medium"
+                                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+                                    }`}
+                            >
+                                <span className="material-symbols-outlined text-[18px]">{s.icon}</span>
+                                {s.label}
+                            </button>
+                        ))}
+                    </nav>
+                </aside>
+
+                {/* Body */}
+                <div className="flex-1 flex flex-col min-w-0">
+                    <header className="flex items-center justify-between px-6 py-3 border-b border-[var(--border)]">
+                        <h2 className="text-base font-semibold text-[var(--text-primary)]">
+                            {sections.find((s) => s.id === section)?.label ?? "Settings"}
+                        </h2>
+                        <button onClick={onClose} aria-label="Close settings" className="w-7 h-7 rounded-[var(--radius-sm)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] flex items-center justify-center transition-colors">
+                            <span className="material-symbols-outlined text-[18px]">close</span>
+                        </button>
+                    </header>
+
+                    <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6">
+                        {section === "appearance" && (
+                            <>
+                                {matches("theme") && (
+                                    <section>
+                                        <h3 className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider mb-2">Theme</h3>
+                                        <div className="grid grid-cols-4 gap-2">
+                                            {themes.map((t) => (
+                                                <button
+                                                    key={t.id}
+                                                    onClick={() => setTheme(t.id)}
+                                                    className={`flex flex-col items-center gap-2 p-3 rounded-[var(--radius-md)] transition-all ${theme === t.id
+                                                        ? "ring-2 ring-[var(--accent)] bg-[var(--bg-hover)]"
+                                                        : "hover:bg-[var(--bg-hover)]"
+                                                        }`}
+                                                    title={t.name}
+                                                >
+                                                    <div className="w-12 h-12 rounded-[var(--radius-md)] overflow-hidden border border-[var(--border)] flex items-center justify-center" style={{ backgroundColor: t.colors[0] }}>
+                                                        {t.icon === "github" ? (
+                                                            <svg className="w-6 h-6" fill={t.textColor} viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" /></svg>
+                                                        ) : (
+                                                            <>
+                                                                <div className="w-1/2 h-full" style={{ backgroundColor: t.colors[0] }}></div>
+                                                                <div className="w-1/2 h-full" style={{ backgroundColor: t.colors[1] }}></div>
+                                                            </>
+                                                        )}
+                                                    </div>
+                                                    <span className="text-[11px] text-[var(--text-primary)]">{t.name}</span>
+                                                </button>
+                                            ))}
+                                        </div>
+                                    </section>
+                                )}
+                                {matches("font") && (
+                                    <section>
+                                        <h3 className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider mb-2">Font</h3>
+                                        <div className="grid grid-cols-2 gap-2">
+                                            {fonts.map((f) => (
+                                                <button
+                                                    key={f.id}
+                                                    onClick={() => setFont(f.id)}
+                                                    className={`px-3 py-2 rounded-[var(--radius-md)] text-sm text-left transition-colors ${font === f.id
+                                                        ? "bg-[var(--accent)] text-[var(--accent-text)]"
+                                                        : "hover:bg-[var(--bg-hover)] text-[var(--text-primary)]"
+                                                        }`}
+                                                >{f.name}</button>
+                                            ))}
+                                        </div>
+                                    </section>
+                                )}
+                                {matches("size") && (
+                                    <section>
+                                        <h3 className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider mb-2">Font size</h3>
+                                        <div className="flex gap-2">
+                                            {fontSizes.map((s) => (
+                                                <button
+                                                    key={s.id}
+                                                    onClick={() => setFontSize(s.id)}
+                                                    className={`flex-1 px-3 py-2 rounded-[var(--radius-md)] text-sm transition-colors ${fontSize === s.id
+                                                        ? "bg-[var(--accent)] text-[var(--accent-text)]"
+                                                        : "hover:bg-[var(--bg-hover)] text-[var(--text-primary)]"
+                                                        }`}
+                                                >{s.name}</button>
+                                            ))}
+                                        </div>
+                                    </section>
+                                )}
+                            </>
+                        )}
+
+                        {section === "editor" && (
+                            <>
+                                {matches("focus") && (
+                                    <ToggleRow label="Focus mode" description="Dim non-active lines" checked={focus}
+                                        onChange={(v) => { setFocusLocal(v); setFocusMode(v); fire("marklite:focus-toggle", v); }} />
+                                )}
+                                {matches("typewriter") && (
+                                    <ToggleRow label="Typewriter mode" description="Keep caret vertically centered" checked={typewriter}
+                                        onChange={(v) => { setTypewriterLocal(v); setTypewriterMode(v); fire("marklite:typewriter-toggle", v); }} />
+                                )}
+                                {matches("toolbar") && (
+                                    <ToggleRow label="Show formatting toolbar" description="Toolbar above the editor" checked={toolbar}
+                                        onChange={(v) => { setToolbarLocal(v); setToolbarEnabled(v); fire("marklite:toolbar-toggle", v); }} />
+                                )}
+                                {matches("auto-save") && (
+                                    <ToggleRow label="Auto-save" description="Save 1.5s after typing stops" checked={autoSave}
+                                        onChange={(v) => { setAutoSaveLocal(v); setAutoSave(v); fire("marklite:autosave-toggle", v); }} />
+                                )}
+                            </>
+                        )}
+
+                        {section === "ai" && (
+                            <>
+                                <p className="text-sm text-[var(--text-secondary)]">
+                                    Configure an OpenAI-compatible endpoint to enable inline AI assist (Rewrite / Expand / Continue) in the editor.
+                                </p>
+                                <div className="space-y-3">
+                                    <label className="block">
+                                        <span className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider">Endpoint URL</span>
+                                        <input
+                                            type="url"
+                                            value={ai.endpoint}
+                                            onChange={(e) => setAi({ ...ai, endpoint: e.target.value })}
+                                            onBlur={() => setAIConfig(ai)}
+                                            placeholder="https://api.openai.com/v1/chat/completions"
+                                            className="mt-1 w-full px-3 py-2 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-md)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)] font-mono"
+                                        />
+                                    </label>
+                                    <label className="block">
+                                        <span className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider">Model</span>
+                                        <input
+                                            type="text"
+                                            value={ai.model}
+                                            onChange={(e) => setAi({ ...ai, model: e.target.value })}
+                                            onBlur={() => setAIConfig(ai)}
+                                            placeholder="gpt-4o-mini, claude-haiku-4-5, llama3, …"
+                                            className="mt-1 w-full px-3 py-2 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-md)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)] font-mono"
+                                        />
+                                    </label>
+                                    <label className="block">
+                                        <span className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider">API key</span>
+                                        <input
+                                            type="password"
+                                            value={ai.apiKey}
+                                            onChange={(e) => setAi({ ...ai, apiKey: e.target.value })}
+                                            onBlur={() => setAIConfig(ai)}
+                                            placeholder="(stored locally)"
+                                            className="mt-1 w-full px-3 py-2 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-md)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)] font-mono"
+                                        />
+                                    </label>
+                                    <p className="text-[11px] text-[var(--text-muted)]">
+                                        Stored in localStorage on this machine only. Use a local provider (e.g. Ollama at <code>http://localhost:11434/v1</code>) for full privacy.
+                                    </p>
+                                </div>
+                            </>
+                        )}
+
+                        {section === "about" && (
+                            <div className="text-sm text-[var(--text-secondary)] space-y-2">
+                                <div className="flex items-center gap-3">
+                                    <img src="/icon.svg" alt="MarkLite" className="w-10 h-10" />
+                                    <div>
+                                        <div className="text-[var(--text-primary)] font-semibold">MarkLite</div>
+                                        <div className="text-[11px]">A minimal markdown editor</div>
+                                    </div>
+                                </div>
+                                <p>Built with Tauri + React + TypeScript.</p>
+                                <p>Press <kbd className="px-1 font-mono rounded border border-[var(--border)] bg-[var(--bg-input)]">?</kbd> to view all keyboard shortcuts.</p>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -37,6 +37,8 @@ const groups: ShortcutGroup[] = [
             { keys: `${cmd}+Shift+E`, description: "Toggle file explorer" },
             { keys: `${cmd}+Shift+O`, description: "Toggle outline" },
             { keys: `${cmd}+P`, description: "Command palette" },
+            { keys: `${cmd}+,`, description: "Open settings" },
+            { keys: `${cmd}+J`, description: "AI assist on selection" },
             { keys: "?", description: "Show this cheatsheet" },
         ],
     },

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useRef, useState } from "react";
+import { attachFocusTrap } from "../utils/focusTrap";
+
+interface ShortcutCheatsheetProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+interface Shortcut {
+    keys: string;
+    description: string;
+}
+
+interface ShortcutGroup {
+    title: string;
+    items: Shortcut[];
+}
+
+const isMac = typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+const cmd = isMac ? "⌘" : "Ctrl";
+
+const groups: ShortcutGroup[] = [
+    {
+        title: "File",
+        items: [
+            { keys: `${cmd}+O`, description: "Open file" },
+            { keys: `${cmd}+N`, description: "New file" },
+            { keys: `${cmd}+S`, description: "Save" },
+            { keys: `${cmd}+Shift+S`, description: "Save As…" },
+        ],
+    },
+    {
+        title: "View",
+        items: [
+            { keys: `${cmd}+E`, description: "Toggle Reader / Code" },
+            { keys: `${cmd}+\\`, description: "Toggle split view" },
+            { keys: `${cmd}+Shift+E`, description: "Toggle file explorer" },
+            { keys: `${cmd}+Shift+O`, description: "Toggle outline" },
+            { keys: `${cmd}+P`, description: "Command palette" },
+            { keys: "?", description: "Show this cheatsheet" },
+        ],
+    },
+    {
+        title: "Editor — Formatting",
+        items: [
+            { keys: `${cmd}+B`, description: "Bold (toggle)" },
+            { keys: `${cmd}+I`, description: "Italic (toggle)" },
+            { keys: `${cmd}+K`, description: "Insert link" },
+            { keys: `${cmd}+/`, description: "Toggle blockquote on line" },
+        ],
+    },
+    {
+        title: "Editor — Navigation",
+        items: [
+            { keys: "Tab", description: "Indent line / selection" },
+            { keys: "Shift+Tab", description: "Outdent line / selection" },
+            { keys: "Enter", description: "Continue list, blockquote, or task item" },
+            { keys: `${cmd}+F`, description: "Find" },
+            { keys: `${cmd}+H`, description: "Find and replace" },
+        ],
+    },
+    {
+        title: "Editor — Auto-pair",
+        items: [
+            { keys: "( [ { ` \" '", description: "Wrap selection or insert pair" },
+            { keys: ") ] } ` \" '", description: "Type past matching closer" },
+            { keys: "Backspace", description: "Removes empty pair atomically" },
+        ],
+    },
+    {
+        title: "Slash & Smart Paste",
+        items: [
+            { keys: "/", description: "Slash menu (at line start)" },
+            { keys: "Paste URL on selection", description: "Wraps selection as link" },
+            { keys: "Paste rich HTML", description: "Converts to markdown" },
+            { keys: "Paste tab-separated", description: "Converts to GFM table" },
+        ],
+    },
+];
+
+const renderKey = (k: string): React.ReactNode => {
+    return k.split(/\s+/).map((part, i) => (
+        <span key={i} className="inline-flex items-center">
+            {i > 0 && <span className="mx-0.5 text-[var(--text-muted)]">+</span>}
+            <kbd className="px-1.5 py-0.5 text-[11px] font-mono rounded border border-[var(--border)] bg-[var(--bg-input)] text-[var(--text-primary)] shadow-sm">
+                {part}
+            </kbd>
+        </span>
+    ));
+};
+
+export function ShortcutCheatsheet({ isOpen, onClose }: ShortcutCheatsheetProps) {
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const [filter, setFilter] = useState("");
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const handleKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                e.preventDefault();
+                onClose();
+            }
+        };
+        document.addEventListener("keydown", handleKey);
+        // Focus the search input
+        const input = dialogRef.current?.querySelector<HTMLInputElement>("input");
+        input?.focus();
+        const detach = attachFocusTrap(dialogRef.current);
+        return () => {
+            document.removeEventListener("keydown", handleKey);
+            detach();
+        };
+    }, [isOpen, onClose]);
+
+    if (!isOpen) return null;
+
+    const q = filter.trim().toLowerCase();
+    const filtered = q
+        ? groups
+            .map((g) => ({
+                ...g,
+                items: g.items.filter((it) => it.description.toLowerCase().includes(q) || it.keys.toLowerCase().includes(q)),
+            }))
+            .filter((g) => g.items.length > 0)
+        : groups;
+
+    return (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center" role="dialog" aria-modal="true" aria-labelledby="cheatsheet-title">
+            <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} aria-hidden="true" />
+
+            <div
+                ref={dialogRef}
+                className="relative z-10 w-[640px] max-h-[80vh] flex flex-col bg-[var(--bg-primary)] border border-[var(--border)] rounded-[var(--radius-lg)] shadow-2xl overflow-hidden animate-fade-in"
+            >
+                <div className="flex items-center gap-3 px-5 py-4 border-b border-[var(--border)]">
+                    <span className="material-symbols-outlined text-[var(--accent)]">keyboard</span>
+                    <h2 id="cheatsheet-title" className="text-base font-semibold text-[var(--text-primary)]">Keyboard Shortcuts</h2>
+                    <input
+                        type="text"
+                        value={filter}
+                        onChange={(e) => setFilter(e.target.value)}
+                        placeholder="Filter shortcuts…"
+                        aria-label="Filter shortcuts"
+                        className="ml-auto px-2 py-1 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-md)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)] w-48"
+                    />
+                    <button
+                        onClick={onClose}
+                        aria-label="Close cheatsheet"
+                        className="w-7 h-7 rounded-[var(--radius-sm)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] flex items-center justify-center transition-colors"
+                    >
+                        <span className="material-symbols-outlined text-[18px]">close</span>
+                    </button>
+                </div>
+
+                <div className="flex-1 overflow-y-auto px-5 py-4 grid grid-cols-2 gap-x-6 gap-y-5">
+                    {filtered.length === 0 ? (
+                        <div className="col-span-2 text-center text-[var(--text-secondary)] py-8 text-sm">
+                            No shortcuts match "{filter}"
+                        </div>
+                    ) : filtered.map((g) => (
+                        <section key={g.title}>
+                            <h3 className="text-xs font-semibold uppercase tracking-wider text-[var(--text-secondary)] mb-2">
+                                {g.title}
+                            </h3>
+                            <ul className="space-y-1.5">
+                                {g.items.map((it, i) => (
+                                    <li key={i} className="flex items-center justify-between gap-3">
+                                        <span className="text-sm text-[var(--text-primary)]">{it.description}</span>
+                                        <span className="flex items-center gap-1 shrink-0">{renderKey(it.keys)}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </section>
+                    ))}
+                </div>
+
+                <div className="px-5 py-2 text-[11px] text-[var(--text-muted)] border-t border-[var(--border-subtle)] bg-[var(--bg-secondary)]">
+                    Press <kbd className="px-1 py-0.5 font-mono rounded border border-[var(--border)] bg-[var(--bg-input)]">Esc</kbd> to close
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/SlashMenu.tsx
+++ b/src/components/SlashMenu.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from "react";
+
+export interface SlashCommand {
+    id: string;
+    label: string;
+    description: string;
+    /** Markdown the command inserts when chosen. */
+    snippet: string;
+    /** Caret offset inside `snippet` after insertion (0 = beginning). */
+    caretOffset?: number;
+    icon: string;
+}
+
+const commands: SlashCommand[] = [
+    { id: "h1", label: "Heading 1", description: "# Heading", snippet: "# ", caretOffset: 2, icon: "format_h1" },
+    { id: "h2", label: "Heading 2", description: "## Heading", snippet: "## ", caretOffset: 3, icon: "format_h2" },
+    { id: "h3", label: "Heading 3", description: "### Heading", snippet: "### ", caretOffset: 4, icon: "format_h3" },
+    { id: "ul", label: "Bullet list", description: "- item", snippet: "- ", caretOffset: 2, icon: "format_list_bulleted" },
+    { id: "ol", label: "Numbered list", description: "1. item", snippet: "1. ", caretOffset: 3, icon: "format_list_numbered" },
+    { id: "task", label: "Task list", description: "- [ ] todo", snippet: "- [ ] ", caretOffset: 6, icon: "check_box" },
+    { id: "quote", label: "Quote", description: "> blockquote", snippet: "> ", caretOffset: 2, icon: "format_quote" },
+    { id: "code", label: "Code block", description: "```\\ncode\\n```", snippet: "```\n\n```\n", caretOffset: 4, icon: "code" },
+    { id: "table", label: "Table", description: "| h | h |\\n| - | - |", snippet: "| Header 1 | Header 2 |\n| --- | --- |\n| Cell | Cell |\n", caretOffset: 11, icon: "table_chart" },
+    { id: "hr", label: "Divider", description: "Horizontal rule", snippet: "\n---\n\n", caretOffset: 6, icon: "horizontal_rule" },
+    { id: "math", label: "Math block", description: "$$ ... $$", snippet: "$$\n\n$$\n", caretOffset: 3, icon: "function" },
+    { id: "mermaid", label: "Mermaid diagram", description: "```mermaid", snippet: "```mermaid\ngraph LR\n  A --> B\n```\n", caretOffset: 11, icon: "schema" },
+    { id: "callout", label: "Callout", description: "> [!NOTE]", snippet: "> [!NOTE]\n> ", caretOffset: 12, icon: "info" },
+];
+
+export interface SlashMenuPosition {
+    x: number;
+    y: number;
+}
+
+interface SlashMenuProps {
+    isOpen: boolean;
+    position: SlashMenuPosition | null;
+    query: string;
+    onSelect: (cmd: SlashCommand) => void;
+    onClose: () => void;
+}
+
+export function SlashMenu({ isOpen, position, query, onSelect, onClose }: SlashMenuProps) {
+    const [activeIdx, setActiveIdx] = useState(0);
+    const listRef = useRef<HTMLUListElement>(null);
+
+    const filtered = query
+        ? commands.filter((c) =>
+            c.label.toLowerCase().includes(query.toLowerCase()) ||
+            c.id.toLowerCase().includes(query.toLowerCase())
+        )
+        : commands;
+
+    useEffect(() => { setActiveIdx(0); }, [query, isOpen]);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === "ArrowDown") {
+                e.preventDefault();
+                setActiveIdx((i) => (i + 1) % filtered.length);
+            } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setActiveIdx((i) => (i - 1 + filtered.length) % filtered.length);
+            } else if (e.key === "Enter" || e.key === "Tab") {
+                if (filtered[activeIdx]) {
+                    e.preventDefault();
+                    onSelect(filtered[activeIdx]);
+                }
+            } else if (e.key === "Escape") {
+                e.preventDefault();
+                onClose();
+            }
+        };
+        document.addEventListener("keydown", handler, true);
+        return () => document.removeEventListener("keydown", handler, true);
+    }, [isOpen, activeIdx, filtered, onSelect, onClose]);
+
+    if (!isOpen || !position || filtered.length === 0) return null;
+
+    return (
+        <div
+            role="listbox"
+            aria-label="Slash commands"
+            className="fixed z-[80] w-72 max-h-72 overflow-y-auto bg-[var(--bg-secondary)] border border-[var(--border)] rounded-[var(--radius-md)] shadow-2xl animate-fade-in"
+            style={{ left: position.x, top: position.y }}
+        >
+            <ul ref={listRef} className="py-1">
+                {filtered.map((cmd, i) => {
+                    const active = i === activeIdx;
+                    return (
+                        <li key={cmd.id}>
+                            <button
+                                role="option"
+                                aria-selected={active}
+                                onMouseDown={(e) => e.preventDefault()}
+                                onClick={() => onSelect(cmd)}
+                                onMouseEnter={() => setActiveIdx(i)}
+                                className={`w-full flex items-center gap-3 px-3 py-2 text-left transition-colors ${active ? "bg-[var(--bg-hover)]" : ""}`}
+                            >
+                                <span className={`material-symbols-outlined text-[18px] shrink-0 ${active ? "text-[var(--accent)]" : "text-[var(--text-secondary)]"}`}>
+                                    {cmd.icon}
+                                </span>
+                                <span className="flex-1 min-w-0">
+                                    <span className="text-sm text-[var(--text-primary)] block">{cmd.label}</span>
+                                    <span className="text-[11px] text-[var(--text-muted)] font-mono truncate block">{cmd.description}</span>
+                                </span>
+                            </button>
+                        </li>
+                    );
+                })}
+            </ul>
+        </div>
+    );
+}

--- a/src/components/SplitDivider.tsx
+++ b/src/components/SplitDivider.tsx
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef } from "react";
+
+interface SplitDividerProps {
+    onDrag: (ratio: number) => void;
+    containerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const MIN_RATIO = 0.2;
+const MAX_RATIO = 0.8;
+
+export function SplitDivider({ onDrag, containerRef }: SplitDividerProps) {
+    const draggingRef = useRef(false);
+
+    const computeRatio = useCallback((clientX: number) => {
+        const c = containerRef.current;
+        if (!c) return 0.5;
+        const rect = c.getBoundingClientRect();
+        const x = clientX - rect.left;
+        const r = x / rect.width;
+        return Math.min(MAX_RATIO, Math.max(MIN_RATIO, r));
+    }, [containerRef]);
+
+    const onPointerDown = useCallback((e: React.PointerEvent) => {
+        draggingRef.current = true;
+        (e.target as HTMLElement).setPointerCapture(e.pointerId);
+        document.body.style.cursor = "col-resize";
+        document.body.style.userSelect = "none";
+    }, []);
+
+    const onPointerMove = useCallback((e: React.PointerEvent) => {
+        if (!draggingRef.current) return;
+        onDrag(computeRatio(e.clientX));
+    }, [computeRatio, onDrag]);
+
+    const onPointerUp = useCallback((e: React.PointerEvent) => {
+        draggingRef.current = false;
+        try { (e.target as HTMLElement).releasePointerCapture(e.pointerId); } catch { /* noop */ }
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+    }, []);
+
+    // Keyboard accessibility: arrow keys nudge the divider
+    const onKeyDown = useCallback((e: React.KeyboardEvent) => {
+        if (e.key === "ArrowLeft") {
+            e.preventDefault();
+            const c = containerRef.current;
+            if (c) {
+                const current = (c.querySelector("[data-split-left]") as HTMLElement)?.getBoundingClientRect().width ?? 0;
+                const total = c.getBoundingClientRect().width;
+                onDrag(Math.max(MIN_RATIO, current / total - 0.02));
+            }
+        } else if (e.key === "ArrowRight") {
+            e.preventDefault();
+            const c = containerRef.current;
+            if (c) {
+                const current = (c.querySelector("[data-split-left]") as HTMLElement)?.getBoundingClientRect().width ?? 0;
+                const total = c.getBoundingClientRect().width;
+                onDrag(Math.min(MAX_RATIO, current / total + 0.02));
+            }
+        }
+    }, [containerRef, onDrag]);
+
+    useEffect(() => {
+        return () => {
+            document.body.style.cursor = "";
+            document.body.style.userSelect = "";
+        };
+    }, []);
+
+    return (
+        <div
+            role="separator"
+            aria-label="Resize editor and preview panes"
+            aria-orientation="vertical"
+            tabIndex={0}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+            onKeyDown={onKeyDown}
+            className="w-1 shrink-0 bg-[var(--border)] hover:bg-[var(--accent)] active:bg-[var(--accent)] cursor-col-resize transition-colors relative group"
+        >
+            <div className="absolute inset-y-0 -left-1 -right-1 group-hover:bg-[var(--accent)]/10" />
+        </div>
+    );
+}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -2,7 +2,7 @@ interface StatusBarProps {
     isSaved: boolean;
     lineNumber: number;
     columnNumber: number;
-    mode?: "preview" | "code";
+    mode?: "preview" | "code" | "split";
     showFileExplorer?: boolean;
     showTOC?: boolean;
     onToggleFileExplorer?: () => void;
@@ -69,7 +69,7 @@ export function StatusBar({
                     ></span>
                     <span className="transition-colors">{isSaved ? "Saved" : "Unsaved"}</span>
                 </div>
-                {mode === "code" && (
+                {(mode === "code" || mode === "split") && (
                     <div className="hover:text-[var(--text-primary)] cursor-default transition-colors">
                         Ln {lineNumber}, Col {columnNumber}
                     </div>

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -10,6 +10,7 @@ interface StatusBarProps {
     wordCount?: number;
     charCount?: number;
     readingTimeMin?: number;
+    autoSaveStatus?: "idle" | "saving" | "saved" | "error";
 }
 
 const formatReadingTime = (min: number): string => {
@@ -32,7 +33,15 @@ export function StatusBar({
     wordCount,
     charCount,
     readingTimeMin,
+    autoSaveStatus = "idle",
 }: StatusBarProps) {
+    const autoSaveLabel: Record<string, { text: string; icon: string; color: string }> = {
+        idle: { text: "", icon: "", color: "" },
+        saving: { text: "Saving…", icon: "sync", color: "var(--text-secondary)" },
+        saved: { text: "Auto-saved", icon: "check", color: "var(--status-saved)" },
+        error: { text: "Save failed", icon: "error", color: "var(--danger)" },
+    };
+    const autoChip = autoSaveLabel[autoSaveStatus];
     return (
         <footer
             role="status"
@@ -72,6 +81,14 @@ export function StatusBar({
                 </button>
             </div>
             <div className="flex items-center gap-4">
+                {autoChip.text && (
+                    <div className="flex items-center gap-1 transition-opacity" style={{ color: autoChip.color }}>
+                        <span className={`material-symbols-outlined text-[13px] ${autoSaveStatus === "saving" ? "animate-spin" : ""}`}>
+                            {autoChip.icon}
+                        </span>
+                        <span>{autoChip.text}</span>
+                    </div>
+                )}
                 <div className="flex items-center gap-1.5" aria-label={isSaved ? "File saved" : "File has unsaved changes"}>
                     <span
                         className={`w-2 h-2 rounded-full transition-all ${isSaved

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -87,18 +87,23 @@ export function StatusBar({
                     </div>
                 )}
                 {wordCount !== undefined && (
-                    <div className="hover:text-[var(--text-primary)] cursor-default transition-colors" title={charCount !== undefined ? `${charCount.toLocaleString()} characters` : undefined}>
+                    <div
+                        className="flex items-center gap-1 hover:text-[var(--text-primary)] cursor-default transition-colors"
+                        title={charCount !== undefined ? `${charCount.toLocaleString()} characters` : undefined}
+                    >
+                        <span className="material-symbols-outlined text-[14px] opacity-70">text_fields</span>
                         {wordCount.toLocaleString()} words
                     </div>
                 )}
                 {readingTimeMin !== undefined && readingTimeMin > 0 && (
-                    <div className="hover:text-[var(--text-primary)] cursor-default transition-colors" title="Estimated reading time at 200 wpm">
+                    <div
+                        className="flex items-center gap-1 hover:text-[var(--text-primary)] cursor-default transition-colors"
+                        title="Estimated reading time at 200 wpm"
+                    >
+                        <span className="material-symbols-outlined text-[14px] opacity-70">schedule</span>
                         {formatReadingTime(readingTimeMin)}
                     </div>
                 )}
-                <div className="hover:text-[var(--text-primary)] cursor-default transition-colors">
-                    UTF-8
-                </div>
             </div>
         </footer>
     );

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -8,7 +8,17 @@ interface StatusBarProps {
     onToggleFileExplorer?: () => void;
     onToggleTOC?: () => void;
     wordCount?: number;
+    charCount?: number;
+    readingTimeMin?: number;
 }
+
+const formatReadingTime = (min: number): string => {
+    if (min < 1) return "< 1 min read";
+    if (min < 60) return `${Math.round(min)} min read`;
+    const hours = Math.floor(min / 60);
+    const rem = Math.round(min % 60);
+    return rem === 0 ? `${hours}h read` : `${hours}h ${rem}m read`;
+};
 
 export function StatusBar({
     isSaved,
@@ -20,6 +30,8 @@ export function StatusBar({
     onToggleFileExplorer,
     onToggleTOC,
     wordCount,
+    charCount,
+    readingTimeMin,
 }: StatusBarProps) {
     return (
         <footer
@@ -75,8 +87,13 @@ export function StatusBar({
                     </div>
                 )}
                 {wordCount !== undefined && (
-                    <div className="hover:text-[var(--text-primary)] cursor-default transition-colors">
+                    <div className="hover:text-[var(--text-primary)] cursor-default transition-colors" title={charCount !== undefined ? `${charCount.toLocaleString()} characters` : undefined}>
                         {wordCount.toLocaleString()} words
+                    </div>
+                )}
+                {readingTimeMin !== undefined && readingTimeMin > 0 && (
+                    <div className="hover:text-[var(--text-primary)] cursor-default transition-colors" title="Estimated reading time at 200 wpm">
+                        {formatReadingTime(readingTimeMin)}
                     </div>
                 )}
                 <div className="hover:text-[var(--text-primary)] cursor-default transition-colors">

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useEffect, useRef } from "react";
+import { attachFocusTrap } from "../utils/focusTrap";
 
 interface TocItem {
     id: string;
@@ -59,8 +60,12 @@ export function TableOfContents({
 
         document.addEventListener("keydown", handleKeyDown);
         panelRef.current?.focus();
+        const detachTrap = attachFocusTrap(panelRef.current);
 
-        return () => document.removeEventListener("keydown", handleKeyDown);
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+            detachTrap();
+        };
     }, [isOpen, onClose]);
 
     const handleHeadingClick = (text: string, level: number) => {

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -1,37 +1,39 @@
-import { useMemo, useEffect, useRef } from "react";
+import { useMemo, useEffect, useRef, useState } from "react";
 import { attachFocusTrap } from "../utils/focusTrap";
 
 interface TocItem {
     id: string;
     text: string;
     level: number;
+    line: number;
 }
 
 interface TableOfContentsProps {
     isOpen: boolean;
     content: string;
     onClose: () => void;
+    /** Current cursor line in code mode, or top-of-viewport line in preview. */
+    activeLine?: number;
 }
 
 export function TableOfContents({
     isOpen,
     content,
     onClose,
+    activeLine = 1,
 }: TableOfContentsProps) {
     const panelRef = useRef<HTMLElement>(null);
+    const [filter, setFilter] = useState("");
 
-    // Parse headings from markdown content
     const headings = useMemo((): TocItem[] => {
         if (!content) return [];
-
-        // Normalize line endings (handle Windows \r\n)
-        const normalizedContent = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-        const lines = normalizedContent.split("\n");
+        const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+        const lines = normalized.split("\n");
         const items: TocItem[] = [];
 
         lines.forEach((line, index) => {
-            const trimmedLine = line.trim();
-            const match = trimmedLine.match(/^(#{1,6})\s+(.+)$/);
+            const trimmed = line.trim();
+            const match = trimmed.match(/^(#{1,6})\s+(.+)$/);
             if (match) {
                 const level = match[1].length;
                 const text = match[2].trim();
@@ -39,13 +41,35 @@ export function TableOfContents({
                     .toLowerCase()
                     .replace(/[^a-z0-9]+/g, "-")
                     .replace(/^-|-$/g, "")}`;
-
-                items.push({ id, text, level });
+                items.push({ id, text, level, line: index + 1 });
             }
         });
-
         return items;
     }, [content]);
+
+    // Active heading: the last one whose source line is at-or-above the active line
+    const activeHeadingIdx = useMemo(() => {
+        let idx = -1;
+        for (let i = 0; i < headings.length; i++) {
+            if (headings[i].line <= activeLine) idx = i;
+            else break;
+        }
+        return idx;
+    }, [headings, activeLine]);
+
+    // Filtered list (filter by text only — keeps stable indexes)
+    const visible = useMemo(() => {
+        if (!filter.trim()) return headings.map((h, i) => ({ h, i }));
+        const q = filter.toLowerCase();
+        return headings.map((h, i) => ({ h, i })).filter(({ h }) => h.text.toLowerCase().includes(q));
+    }, [headings, filter]);
+
+    // Keep the active row in view when activeHeadingIdx changes
+    useEffect(() => {
+        if (activeHeadingIdx === -1) return;
+        const el = panelRef.current?.querySelector<HTMLElement>(`[data-toc-idx="${activeHeadingIdx}"]`);
+        el?.scrollIntoView({ block: "nearest" });
+    }, [activeHeadingIdx]);
 
     // Escape key to close and focus management
     useEffect(() => {
@@ -125,65 +149,69 @@ export function TableOfContents({
             {/* Header */}
             <div className="h-10 px-4 flex items-center justify-between border-b border-[var(--border)] bg-[var(--bg-titlebar)]">
                 <div className="flex items-center gap-2 text-sm font-semibold text-[var(--text-primary)] no-select">
-                    <span className="material-symbols-outlined text-[18px]">
-                        format_list_bulleted
-                    </span>
-                    <span>Table of Contents</span>
+                    <span className="material-symbols-outlined text-[18px]">format_list_bulleted</span>
+                    <span>Outline</span>
                 </div>
                 <button
                     onClick={onClose}
-                    aria-label="Close table of contents"
-                    className="btn-press flex items-center justify-center w-7 h-7 rounded-lg hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                    aria-label="Close outline"
+                    className="btn-press flex items-center justify-center w-7 h-7 rounded-[var(--radius-sm)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
                 >
-                    <span className="material-symbols-outlined text-[18px]">
-                        close
-                    </span>
+                    <span className="material-symbols-outlined text-[18px]">close</span>
                 </button>
             </div>
 
+            {/* Filter (only shown when there are >5 headings to keep it clean) */}
+            {headings.length > 5 && (
+                <div className="px-3 py-2 border-b border-[var(--border-subtle)]">
+                    <input
+                        type="text"
+                        value={filter}
+                        onChange={(e) => setFilter(e.target.value)}
+                        placeholder="Filter headings…"
+                        aria-label="Filter headings"
+                        className="w-full px-2 py-1 text-xs bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-sm)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+                    />
+                </div>
+            )}
+
             {/* Content */}
-            <nav className="flex-1 overflow-y-auto h-[calc(100%-2.5rem)]" aria-label="Document headings">
+            <nav className="flex-1 overflow-y-auto" aria-label="Document headings">
                 {headings.length === 0 ? (
-                    <div className="flex flex-col items-center justify-center h-32 text-[var(--text-secondary)] text-sm gap-2">
-                        <span className="material-symbols-outlined text-[32px] opacity-40">
-                            format_list_bulleted
-                        </span>
-                        <span>No headings found</span>
+                    <div className="flex flex-col items-center justify-center h-32 text-[var(--text-secondary)] text-sm gap-2 px-4 text-center">
+                        <span className="material-symbols-outlined text-[32px] opacity-40">format_list_bulleted</span>
+                        <span>No headings yet.</span>
+                        <span className="text-[11px] text-[var(--text-muted)]">Type <code className="font-mono">#</code> to add one.</span>
+                    </div>
+                ) : visible.length === 0 ? (
+                    <div className="flex items-center justify-center h-32 text-[var(--text-secondary)] text-sm">
+                        No matches
                     </div>
                 ) : (
                     <ul className="py-2">
-                        {headings.map((heading, index) => (
-                            <li key={`${heading.id}-${index}`} className="stagger-item" style={{ animationDelay: `${index * 0.03}s` }}>
+                        {visible.map(({ h: heading, i: index }) => {
+                            const isActive = index === activeHeadingIdx;
+                            return (
+                            <li key={`${heading.id}-${index}`} data-toc-idx={index}>
                                 <button
-                                    onClick={() =>
-                                        handleHeadingClick(heading.text, heading.level)
-                                    }
+                                    onClick={() => handleHeadingClick(heading.text, heading.level)}
                                     aria-label={`Go to heading: ${heading.text}`}
-                                    className={`btn-press w-full px-4 py-2 text-left text-sm flex items-center gap-2 transition-colors text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] ${getIndent(
-                                        heading.level
-                                    )}`}
+                                    aria-current={isActive ? "location" : undefined}
+                                    className={`btn-press w-full px-4 py-1.5 text-left text-sm flex items-center gap-2 transition-colors ${getIndent(heading.level)} ${isActive
+                                        ? "bg-[var(--bg-hover)] text-[var(--text-primary)] border-l-2 border-[var(--accent)] -ml-px"
+                                        : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+                                        }`}
                                 >
-                                    <span
-                                        className={`material-symbols-outlined text-[14px] ${heading.level === 1
-                                            ? "text-[var(--text-primary)]"
-                                            : "opacity-60"
-                                            }`}
-                                    >
+                                    <span className={`material-symbols-outlined text-[14px] ${heading.level === 1 ? "text-[var(--text-primary)]" : "opacity-60"}`}>
                                         {getIcon(heading.level)}
                                     </span>
-                                    <span
-                                        className={`truncate ${heading.level === 1
-                                            ? "font-semibold text-[var(--text-primary)]"
-                                            : heading.level === 2
-                                                ? "font-medium"
-                                                : ""
-                                            }`}
-                                    >
+                                    <span className={`truncate ${heading.level === 1 ? "font-semibold" : heading.level === 2 ? "font-medium" : ""}`}>
                                         {heading.text}
                                     </span>
                                 </button>
                             </li>
-                        ))}
+                            );
+                        })}
                     </ul>
                 )}
             </nav>

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -9,11 +9,14 @@ interface TitleBarProps {
     isDirty?: boolean;
     filePath?: string;
     onOpenFile?: () => void;
+    onNewFile?: () => void;
     onSaveFile?: () => Promise<void>;
     getExportHtml?: () => string;
+    onExportSuccess?: (format: string) => void;
+    onExportError?: (format: string) => void;
 }
 
-export function TitleBar({ fileName, isDirty, filePath, onOpenFile, onSaveFile, getExportHtml }: TitleBarProps) {
+export function TitleBar({ fileName, isDirty, filePath, onOpenFile, onNewFile, onSaveFile, getExportHtml, onExportSuccess, onExportError }: TitleBarProps) {
     const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
 
     const handleMinimize = async () => {
@@ -107,14 +110,25 @@ export function TitleBar({ fileName, isDirty, filePath, onOpenFile, onSaveFile, 
                         )}
                     </div>
 
-                    {/* Open File Button - shown when a file is already open */}
+                    {/* Open File / New Button - shown when a file is already open */}
                     {hasFile && onOpenFile && (
                         <>
                             <div className="w-[1px] h-4 bg-[var(--border)] ml-2"></div>
+                            {onNewFile && (
+                                <button
+                                    onClick={onNewFile}
+                                    aria-label="New file"
+                                    className="flex items-center gap-1 px-2 py-1 rounded-[var(--radius-md)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors text-xs"
+                                    title="New File (Ctrl+N)"
+                                >
+                                    <span className="material-symbols-outlined text-[16px]">edit_note</span>
+                                    <span>New</span>
+                                </button>
+                            )}
                             <button
                                 onClick={onOpenFile}
                                 aria-label="Open file"
-                                className="flex items-center gap-1 px-2 py-1 rounded-lg hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors text-xs"
+                                className="flex items-center gap-1 px-2 py-1 rounded-[var(--radius-md)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors text-xs"
                                 title="Open File (Ctrl+O)"
                             >
                                 <span className="material-symbols-outlined text-[16px]">folder_open</span>
@@ -123,6 +137,8 @@ export function TitleBar({ fileName, isDirty, filePath, onOpenFile, onSaveFile, 
                             <ExportMenu
                                 fileName={fileName || 'document.md'}
                                 getExportHtml={getExportHtml}
+                                onSuccess={onExportSuccess}
+                                onError={onExportError}
                             />
                         </>
                     )}

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -99,6 +99,9 @@ export function TitleBar({ fileName, isDirty, filePath, onOpenFile, onSaveFile, 
                         <span className="text-[var(--text-primary)] font-semibold tracking-tight">
                             {fileName || "MarkLite"}
                         </span>
+                        {!fileName && (
+                            <span className="text-[var(--text-muted)] text-xs ml-1 hidden sm:inline">— drop a .md file or Ctrl+O</span>
+                        )}
                         {isDirty && (
                             <span className="text-[var(--status-unsaved)] ml-1 italic text-xs">— Edited</span>
                         )}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -49,8 +49,8 @@ export function Toast({ message, isVisible, onHide, duration = 2000, type = 'suc
 
     return (
         <div
-            role="status"
-            aria-live="polite"
+            role={type === "error" ? "alert" : "status"}
+            aria-live={type === "error" ? "assertive" : "polite"}
             aria-atomic="true"
             className={`fixed bottom-20 left-1/2 -translate-x-1/2 z-50 px-4 py-2 rounded-lg
                 bg-[var(--bg-secondary)] border border-[var(--border-subtle)]

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
+import { stat } from "@tauri-apps/plugin-fs";
 import { getRecentFiles, removeRecentFile, type RecentFile } from "../utils/persistence";
 
 interface WelcomeScreenProps {
     onOpenFile: () => void;
+    onNewFile?: () => void;
     onFileDrop: (path: string) => void;
     onOpenRecent?: (path: string) => void;
 }
@@ -23,11 +25,29 @@ const parentFolderOf = (path: string): string => {
     return segs.slice(-2).join("/") || segs.join("/");
 };
 
-export function WelcomeScreen({ onOpenFile, onFileDrop, onOpenRecent }: WelcomeScreenProps) {
+export function WelcomeScreen({ onOpenFile, onNewFile, onFileDrop, onOpenRecent }: WelcomeScreenProps) {
     const [recents, setRecents] = useState<RecentFile[]>([]);
+    const [missing, setMissing] = useState<Set<string>>(new Set());
 
     useEffect(() => {
-        setRecents(getRecentFiles());
+        const list = getRecentFiles();
+        setRecents(list);
+        // Quick existence check for each — gray out missing entries
+        let cancelled = false;
+        Promise.all(
+            list.map(async (f) => {
+                try {
+                    await stat(f.path);
+                    return null;
+                } catch {
+                    return f.path;
+                }
+            })
+        ).then((results) => {
+            if (cancelled) return;
+            setMissing(new Set(results.filter((p): p is string => !!p)));
+        });
+        return () => { cancelled = true; };
     }, []);
 
     const handleDragOver = (e: React.DragEvent) => {
@@ -75,16 +95,27 @@ export function WelcomeScreen({ onOpenFile, onFileDrop, onOpenRecent }: WelcomeS
                     </p>
                 </div>
 
-                <button
-                    onClick={onOpenFile}
-                    className="btn-press flex items-center gap-2 bg-[var(--accent)] hover:opacity-90 text-[var(--accent-text)] font-medium text-sm px-6 py-2.5 rounded-lg transition-all duration-200"
-                >
-                    <span className="material-symbols-outlined text-[20px]">folder_open</span>
-                    <span>Open File</span>
-                </button>
+                <div className="flex gap-2">
+                    <button
+                        onClick={onOpenFile}
+                        className="btn-press flex items-center gap-2 bg-[var(--accent)] hover:opacity-90 text-[var(--accent-text)] font-medium text-sm px-5 py-2.5 rounded-[var(--radius-md)] transition-all duration-200"
+                    >
+                        <span className="material-symbols-outlined text-[20px]">folder_open</span>
+                        <span>Open File</span>
+                    </button>
+                    {onNewFile && (
+                        <button
+                            onClick={onNewFile}
+                            className="btn-press flex items-center gap-2 bg-[var(--bg-secondary)] hover:bg-[var(--bg-hover)] text-[var(--text-primary)] border border-[var(--border)] font-medium text-sm px-5 py-2.5 rounded-[var(--radius-md)] transition-all duration-200"
+                        >
+                            <span className="material-symbols-outlined text-[20px]">edit_note</span>
+                            <span>New File</span>
+                        </button>
+                    )}
+                </div>
 
                 <p className="text-xs text-[var(--text-muted)]">
-                    or drag and drop a <code className="bg-[var(--bg-secondary)] px-1.5 py-0.5 rounded text-[var(--text-secondary)] border border-[var(--border)]">.md</code> file
+                    drag a <code className="bg-[var(--bg-secondary)] px-1.5 py-0.5 rounded text-[var(--text-secondary)] border border-[var(--border)]">.md</code> file · press <kbd className="px-1 py-0.5 font-mono rounded border border-[var(--border)] bg-[var(--bg-secondary)] text-[var(--text-secondary)]">Ctrl+P</kbd> for commands · <kbd className="px-1 py-0.5 font-mono rounded border border-[var(--border)] bg-[var(--bg-secondary)] text-[var(--text-secondary)]">?</kbd> for shortcuts
                 </p>
 
                 {recents.length > 0 && onOpenRecent && (
@@ -93,19 +124,24 @@ export function WelcomeScreen({ onOpenFile, onFileDrop, onOpenRecent }: WelcomeS
                             Recent
                         </div>
                         <ul className="flex flex-col">
-                            {recents.map((f) => (
+                            {recents.map((f) => {
+                                const isMissing = missing.has(f.path);
+                                return (
                                 <li key={f.path} className="group">
                                     <button
-                                        onClick={() => onOpenRecent(f.path)}
-                                        className="btn-press w-full flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-[var(--bg-hover)] transition-colors text-left"
-                                        title={f.path}
+                                        onClick={() => !isMissing && onOpenRecent(f.path)}
+                                        disabled={isMissing}
+                                        className={`btn-press w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] transition-colors text-left ${isMissing ? "opacity-50 cursor-not-allowed" : "hover:bg-[var(--bg-hover)]"}`}
+                                        title={isMissing ? `${f.path} (missing)` : f.path}
                                     >
-                                        <span className="material-symbols-outlined text-[18px] text-[var(--text-secondary)] shrink-0">description</span>
+                                        <span className="material-symbols-outlined text-[18px] text-[var(--text-secondary)] shrink-0">
+                                            {isMissing ? "broken_image" : "description"}
+                                        </span>
                                         <div className="flex-1 min-w-0">
-                                            <div className="text-sm text-[var(--text-primary)] truncate">{f.name}</div>
+                                            <div className={`text-sm truncate ${isMissing ? "line-through text-[var(--text-muted)]" : "text-[var(--text-primary)]"}`}>{f.name}</div>
                                             <div className="text-[11px] text-[var(--text-muted)] truncate">{parentFolderOf(f.path)}</div>
                                         </div>
-                                        <span className="text-[11px] text-[var(--text-muted)] tabular-nums shrink-0">{formatRelative(f.openedAt)}</span>
+                                        <span className="text-[11px] text-[var(--text-muted)] tabular-nums shrink-0">{isMissing ? "missing" : formatRelative(f.openedAt)}</span>
                                         <span
                                             role="button"
                                             tabIndex={0}
@@ -118,7 +154,8 @@ export function WelcomeScreen({ onOpenFile, onFileDrop, onOpenRecent }: WelcomeS
                                         </span>
                                     </button>
                                 </li>
-                            ))}
+                                );
+                            })}
                         </ul>
                     </div>
                 )}

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -1,9 +1,35 @@
+import { useEffect, useState } from "react";
+import { getRecentFiles, removeRecentFile, type RecentFile } from "../utils/persistence";
+
 interface WelcomeScreenProps {
     onOpenFile: () => void;
     onFileDrop: (path: string) => void;
+    onOpenRecent?: (path: string) => void;
 }
 
-export function WelcomeScreen({ onOpenFile, onFileDrop }: WelcomeScreenProps) {
+const formatRelative = (ts: number): string => {
+    const diff = Date.now() - ts;
+    const min = 60_000, hr = 60 * min, day = 24 * hr;
+    if (diff < min) return "just now";
+    if (diff < hr) return `${Math.floor(diff / min)}m ago`;
+    if (diff < day) return `${Math.floor(diff / hr)}h ago`;
+    if (diff < 7 * day) return `${Math.floor(diff / day)}d ago`;
+    return new Date(ts).toLocaleDateString();
+};
+
+const parentFolderOf = (path: string): string => {
+    const norm = path.replace(/\\/g, "/");
+    const segs = norm.split("/").slice(0, -1);
+    return segs.slice(-2).join("/") || segs.join("/");
+};
+
+export function WelcomeScreen({ onOpenFile, onFileDrop, onOpenRecent }: WelcomeScreenProps) {
+    const [recents, setRecents] = useState<RecentFile[]>([]);
+
+    useEffect(() => {
+        setRecents(getRecentFiles());
+    }, []);
+
     const handleDragOver = (e: React.DragEvent) => {
         e.preventDefault();
         e.stopPropagation();
@@ -24,19 +50,22 @@ export function WelcomeScreen({ onOpenFile, onFileDrop }: WelcomeScreenProps) {
         }
     };
 
+    const handleRemoveRecent = (e: React.MouseEvent, path: string) => {
+        e.stopPropagation();
+        setRecents(removeRecentFile(path));
+    };
+
     return (
         <main
             onDragOver={handleDragOver}
             onDrop={handleDrop}
-            className="flex-1 flex flex-col items-center justify-center p-6 no-select"
+            className="flex-1 flex flex-col items-center justify-center p-6 no-select overflow-y-auto"
         >
-            <div className="flex flex-col items-center gap-8 max-w-sm text-center animate-fade-in-up">
-                {/* Logo */}
+            <div className="flex flex-col items-center gap-8 max-w-md w-full text-center animate-fade-in-up">
                 <div className="flex items-center justify-center w-20 h-20">
                     <img src="/icon.svg" alt="MarkLite" className="w-full h-full" />
                 </div>
 
-                {/* App Name */}
                 <div className="flex flex-col gap-2">
                     <h1 className="text-2xl font-bold tracking-tight text-[var(--text-primary)]">
                         MarkLite
@@ -46,7 +75,6 @@ export function WelcomeScreen({ onOpenFile, onFileDrop }: WelcomeScreenProps) {
                     </p>
                 </div>
 
-                {/* Action */}
                 <button
                     onClick={onOpenFile}
                     className="btn-press flex items-center gap-2 bg-[var(--accent)] hover:opacity-90 text-[var(--accent-text)] font-medium text-sm px-6 py-2.5 rounded-lg transition-all duration-200"
@@ -55,12 +83,46 @@ export function WelcomeScreen({ onOpenFile, onFileDrop }: WelcomeScreenProps) {
                     <span>Open File</span>
                 </button>
 
-                {/* Hint */}
                 <p className="text-xs text-[var(--text-muted)]">
                     or drag and drop a <code className="bg-[var(--bg-secondary)] px-1.5 py-0.5 rounded text-[var(--text-secondary)] border border-[var(--border)]">.md</code> file
                 </p>
-            </div>
 
+                {recents.length > 0 && onOpenRecent && (
+                    <div className="w-full mt-4 text-left">
+                        <div className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider mb-2 px-1">
+                            Recent
+                        </div>
+                        <ul className="flex flex-col">
+                            {recents.map((f) => (
+                                <li key={f.path} className="group">
+                                    <button
+                                        onClick={() => onOpenRecent(f.path)}
+                                        className="btn-press w-full flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-[var(--bg-hover)] transition-colors text-left"
+                                        title={f.path}
+                                    >
+                                        <span className="material-symbols-outlined text-[18px] text-[var(--text-secondary)] shrink-0">description</span>
+                                        <div className="flex-1 min-w-0">
+                                            <div className="text-sm text-[var(--text-primary)] truncate">{f.name}</div>
+                                            <div className="text-[11px] text-[var(--text-muted)] truncate">{parentFolderOf(f.path)}</div>
+                                        </div>
+                                        <span className="text-[11px] text-[var(--text-muted)] tabular-nums shrink-0">{formatRelative(f.openedAt)}</span>
+                                        <span
+                                            role="button"
+                                            tabIndex={0}
+                                            aria-label={`Remove ${f.name} from recents`}
+                                            onClick={(e) => handleRemoveRecent(e, f.path)}
+                                            onKeyDown={(e) => { if (e.key === "Enter") handleRemoveRecent(e as unknown as React.MouseEvent, f.path); }}
+                                            className="opacity-0 group-hover:opacity-100 w-5 h-5 rounded hover:bg-[var(--bg-hover)] text-[var(--text-muted)] hover:text-[var(--danger)] transition-opacity flex items-center justify-center"
+                                        >
+                                            <span className="material-symbols-outlined text-[14px]">close</span>
+                                        </span>
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+            </div>
         </main>
     );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -108,8 +108,8 @@
   --bg-input: #ebe5d8;
 
   --text-primary: #3d3d3d;
-  --text-secondary: #6b6352;
-  --text-muted: #9a8f7a;
+  --text-secondary: #5a5340;
+  --text-muted: #7a7160; /* WCAG AA pass on bg-primary (~4.6:1) — was #9a8f7a (~2.7:1, fail) */
 
   --accent: #5c4033;
   --accent-hover: rgba(92, 64, 51, 0.9);
@@ -191,6 +191,23 @@
   --selection-text: #ffffff;
 }
 
+/* ===== Design Tokens ===== */
+:root {
+  /* Radius scale — replace ad-hoc rounded-{lg,xl,full} usage with these */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-pill: 9999px;
+
+  /* Spacing scale */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+}
+
 /* ===== Font Family Variables ===== */
 /* Default font - must come BEFORE attribute selectors */
 :root {
@@ -269,6 +286,41 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+/* ===== Accessibility ===== */
+
+/* Visible keyboard focus ring on every interactive element. Only fires on
+   keyboard focus (focus-visible), so mouse clicks don't show the ring. */
+*:focus {
+  outline: none;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+[role="button"]:focus-visible,
+[role="menuitem"]:focus-visible,
+[role="option"]:focus-visible,
+[tabindex]:not([tabindex="-1"]):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* Respect users who set "reduce motion" at the OS level. */
+@media (prefers-reduced-motion: reduce) {
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /* ===== Desktop App Styles ===== */

--- a/src/utils/aiAssist.ts
+++ b/src/utils/aiAssist.ts
@@ -1,0 +1,69 @@
+/**
+ * AI assist — minimal OpenAI-compatible client.
+ *
+ * Calls the user-configured endpoint with a system prompt and the selected
+ * text. Supports endpoints that follow the OpenAI Chat Completions schema:
+ *   POST /chat/completions
+ *   { model, messages: [{role, content}] }
+ *   → { choices: [{ message: { content } }] }
+ *
+ * Local providers like Ollama (with /v1 prefix) and llama.cpp expose the same
+ * shape, so this works for fully-local setups too.
+ */
+
+export type AIAction = "rewrite" | "shorten" | "expand" | "continue" | "translate";
+
+const SYSTEM_PROMPTS: Record<AIAction, string> = {
+    rewrite: "Rewrite the user's text for clarity and flow. Output the rewritten text only — no preface, no quotes, no explanation.",
+    shorten: "Shorten the user's text to about half the length while keeping the meaning. Output the shortened text only.",
+    expand: "Expand the user's text with more detail and context. Output the expanded text only.",
+    continue: "Continue writing in the same style and tone. Output only the continuation, not the original.",
+    translate: "Translate the user's text to English. Output the translation only.",
+};
+
+export interface AIConfig {
+    endpoint: string;
+    model: string;
+    apiKey: string;
+}
+
+export async function runAIAction(
+    action: AIAction,
+    text: string,
+    cfg: AIConfig,
+    signal?: AbortSignal
+): Promise<string> {
+    if (!cfg.endpoint) throw new Error("AI endpoint not configured. Open Settings → AI to set one up.");
+    if (!cfg.model) throw new Error("AI model not configured.");
+
+    const res = await fetch(cfg.endpoint, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            ...(cfg.apiKey ? { Authorization: `Bearer ${cfg.apiKey}` } : {}),
+        },
+        body: JSON.stringify({
+            model: cfg.model,
+            messages: [
+                { role: "system", content: SYSTEM_PROMPTS[action] },
+                { role: "user", content: text },
+            ],
+            temperature: 0.7,
+            stream: false,
+        }),
+        signal,
+    });
+
+    if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`AI request failed (${res.status}): ${body.slice(0, 200)}`);
+    }
+
+    const data = await res.json();
+    const content =
+        data?.choices?.[0]?.message?.content ??
+        data?.message?.content ?? // ollama native shape, also handled
+        "";
+    if (!content) throw new Error("AI returned an empty response.");
+    return String(content).trim();
+}

--- a/src/utils/editorActions.ts
+++ b/src/utils/editorActions.ts
@@ -1,0 +1,292 @@
+/**
+ * Editor key-handling helpers for MarkLite's CodeEditor.
+ *
+ * All functions are pure: they take the current text + selection and return the
+ * new text + selection, or `null` if the key is not handled (so the textarea
+ * default behavior runs).
+ */
+
+export interface EditorState {
+    text: string;
+    selStart: number;
+    selEnd: number;
+}
+
+export interface EditorResult {
+    text: string;
+    selStart: number;
+    selEnd: number;
+}
+
+const INDENT = "  "; // 2 spaces — markdown-friendly nested lists
+
+/* ---------- Selection / line helpers ---------- */
+
+const lineStartIndex = (text: string, pos: number): number => {
+    const before = text.slice(0, pos);
+    const nl = before.lastIndexOf("\n");
+    return nl === -1 ? 0 : nl + 1;
+};
+
+const lineEndIndex = (text: string, pos: number): number => {
+    const idx = text.indexOf("\n", pos);
+    return idx === -1 ? text.length : idx;
+};
+
+/* ---------- Tab / Shift+Tab ---------- */
+
+export function handleTab(state: EditorState, shift: boolean): EditorResult | null {
+    const { text, selStart, selEnd } = state;
+
+    // Multi-line: indent or outdent each line in the selection
+    const hasNewline = text.slice(selStart, selEnd).includes("\n");
+    if (selStart !== selEnd && hasNewline) {
+        const blockStart = lineStartIndex(text, selStart);
+        const blockEnd = lineEndIndex(text, selEnd);
+        const block = text.slice(blockStart, blockEnd);
+        const lines = block.split("\n");
+
+        let newBlock: string;
+        if (shift) {
+            newBlock = lines.map((l) => l.startsWith(INDENT) ? l.slice(INDENT.length) : l.startsWith(" ") ? l.slice(1) : l).join("\n");
+        } else {
+            newBlock = lines.map((l) => INDENT + l).join("\n");
+        }
+
+        const newText = text.slice(0, blockStart) + newBlock + text.slice(blockEnd);
+        const delta = newBlock.length - block.length;
+        return {
+            text: newText,
+            selStart: blockStart,
+            selEnd: blockEnd + delta,
+        };
+    }
+
+    // Single-line: insert / remove indent at cursor
+    if (shift) {
+        const ls = lineStartIndex(text, selStart);
+        const head = text.slice(ls, ls + INDENT.length);
+        if (head === INDENT) {
+            return {
+                text: text.slice(0, ls) + text.slice(ls + INDENT.length),
+                selStart: Math.max(ls, selStart - INDENT.length),
+                selEnd: Math.max(ls, selEnd - INDENT.length),
+            };
+        }
+        return null;
+    }
+
+    return {
+        text: text.slice(0, selStart) + INDENT + text.slice(selEnd),
+        selStart: selStart + INDENT.length,
+        selEnd: selStart + INDENT.length,
+    };
+}
+
+/* ---------- Enter: list continuation ---------- */
+
+const LIST_PATTERN = /^(\s*)([-*+]|\d+\.)\s+(\[[ xX]\]\s+)?/;
+const QUOTE_PATTERN = /^(\s*>\s+)/;
+
+export function handleEnter(state: EditorState): EditorResult | null {
+    const { text, selStart, selEnd } = state;
+    if (selStart !== selEnd) return null;
+
+    const ls = lineStartIndex(text, selStart);
+    const currentLine = text.slice(ls, selStart);
+
+    // Blockquote continuation
+    const qm = currentLine.match(QUOTE_PATTERN);
+    if (qm) {
+        // If only the quote prefix is on the line, terminate the quote
+        if (currentLine.trim() === ">") {
+            return {
+                text: text.slice(0, ls) + "\n" + text.slice(selStart),
+                selStart: ls + 1,
+                selEnd: ls + 1,
+            };
+        }
+        const insert = "\n" + qm[1];
+        return {
+            text: text.slice(0, selStart) + insert + text.slice(selEnd),
+            selStart: selStart + insert.length,
+            selEnd: selStart + insert.length,
+        };
+    }
+
+    // List continuation
+    const lm = currentLine.match(LIST_PATTERN);
+    if (lm) {
+        const indent = lm[1];
+        const marker = lm[2];
+        const taskBox = lm[3] ? "[ ] " : "";
+        const restAfterPrefix = currentLine.slice(lm[0].length);
+
+        // Empty list item — terminate the list
+        if (restAfterPrefix.trim() === "") {
+            return {
+                text: text.slice(0, ls) + "\n" + text.slice(selStart),
+                selStart: ls + 1,
+                selEnd: ls + 1,
+            };
+        }
+
+        // Numbered list: increment
+        let nextMarker = marker;
+        const numMatch = marker.match(/^(\d+)\.$/);
+        if (numMatch) {
+            nextMarker = `${parseInt(numMatch[1], 10) + 1}.`;
+        }
+
+        const insert = `\n${indent}${nextMarker} ${taskBox}`;
+        return {
+            text: text.slice(0, selStart) + insert + text.slice(selEnd),
+            selStart: selStart + insert.length,
+            selEnd: selStart + insert.length,
+        };
+    }
+
+    return null;
+}
+
+/* ---------- Auto-pair ---------- */
+
+const AUTO_PAIRS: Record<string, string> = {
+    "(": ")",
+    "[": "]",
+    "{": "}",
+    "`": "`",
+    '"': '"',
+    "'": "'",
+};
+
+const WRAP_PAIRS: Record<string, string> = {
+    "(": ")",
+    "[": "]",
+    "{": "}",
+    "`": "`",
+    "*": "*",
+    "_": "_",
+    '"': '"',
+};
+
+export function handleAutoPair(state: EditorState, ch: string): EditorResult | null {
+    const { text, selStart, selEnd } = state;
+
+    // Wrap selection
+    if (selStart !== selEnd && WRAP_PAIRS[ch]) {
+        const close = WRAP_PAIRS[ch];
+        const selected = text.slice(selStart, selEnd);
+        const wrapped = ch + selected + close;
+        return {
+            text: text.slice(0, selStart) + wrapped + text.slice(selEnd),
+            selStart: selStart + 1,
+            selEnd: selEnd + 1,
+        };
+    }
+
+    // Empty selection: insert pair, place caret in middle
+    if (selStart === selEnd && AUTO_PAIRS[ch]) {
+        const close = AUTO_PAIRS[ch];
+        const nextChar = text[selStart] ?? "";
+        // Don't auto-pair quotes when next to a word char (likely an apostrophe)
+        if ((ch === "'" || ch === '"') && /\w/.test(text[selStart - 1] ?? "")) return null;
+        // Don't double-up if the close char is already there (let the user "type past" it)
+        if (nextChar === close && (ch === ")" || ch === "]" || ch === "}" || ch === "`" || ch === '"' || ch === "'")) return null;
+
+        const inserted = ch + close;
+        return {
+            text: text.slice(0, selStart) + inserted + text.slice(selEnd),
+            selStart: selStart + 1,
+            selEnd: selStart + 1,
+        };
+    }
+
+    return null;
+}
+
+/** "Type past" closer when caret is right before a matching closer that we just inserted. */
+export function handleSkipCloser(state: EditorState, ch: string): EditorResult | null {
+    const { text, selStart, selEnd } = state;
+    if (selStart !== selEnd) return null;
+    if (![")", "]", "}", "`", '"', "'"].includes(ch)) return null;
+    if (text[selStart] !== ch) return null;
+    return {
+        text,
+        selStart: selStart + 1,
+        selEnd: selStart + 1,
+    };
+}
+
+/* ---------- Bold / Italic / Link ---------- */
+
+export function wrapSelection(
+    state: EditorState,
+    left: string,
+    right: string = left,
+    placeholder: string = ""
+): EditorResult {
+    const { text, selStart, selEnd } = state;
+    const selected = text.slice(selStart, selEnd) || placeholder;
+
+    // Toggle: if selection is already wrapped, unwrap
+    const beforeSel = text.slice(Math.max(0, selStart - left.length), selStart);
+    const afterSel = text.slice(selEnd, selEnd + right.length);
+    if (selStart !== selEnd && beforeSel === left && afterSel === right) {
+        return {
+            text: text.slice(0, selStart - left.length) + selected + text.slice(selEnd + right.length),
+            selStart: selStart - left.length,
+            selEnd: selEnd - left.length,
+        };
+    }
+
+    const wrapped = left + selected + right;
+    return {
+        text: text.slice(0, selStart) + wrapped + text.slice(selEnd),
+        selStart: selStart + left.length,
+        selEnd: selStart + left.length + selected.length,
+    };
+}
+
+export function insertLink(state: EditorState): EditorResult {
+    const { text, selStart, selEnd } = state;
+    const selected = text.slice(selStart, selEnd);
+    const isUrl = /^https?:\/\//i.test(selected);
+    const linkText = isUrl ? "" : selected;
+    const url = isUrl ? selected : "url";
+    const inserted = `[${linkText}](${url})`;
+    const newText = text.slice(0, selStart) + inserted + text.slice(selEnd);
+    // Place caret inside whichever part is empty
+    const caret = isUrl
+        ? selStart + 1 // inside [|]
+        : selStart + linkText.length + 3; // inside (|)
+    return {
+        text: newText,
+        selStart: caret,
+        selEnd: isUrl ? caret : caret + url.length,
+    };
+}
+
+/* ---------- Backspace: erase auto-pair ---------- */
+
+export function handleBackspace(state: EditorState): EditorResult | null {
+    const { text, selStart, selEnd } = state;
+    if (selStart !== selEnd || selStart === 0) return null;
+    const prev = text[selStart - 1];
+    const next = text[selStart];
+    if (
+        (prev === "(" && next === ")") ||
+        (prev === "[" && next === "]") ||
+        (prev === "{" && next === "}") ||
+        (prev === "`" && next === "`") ||
+        (prev === '"' && next === '"') ||
+        (prev === "'" && next === "'")
+    ) {
+        return {
+            text: text.slice(0, selStart - 1) + text.slice(selStart + 1),
+            selStart: selStart - 1,
+            selEnd: selStart - 1,
+        };
+    }
+    return null;
+}

--- a/src/utils/editorActions.ts
+++ b/src/utils/editorActions.ts
@@ -33,9 +33,110 @@ const lineEndIndex = (text: string, pos: number): number => {
     return idx === -1 ? text.length : idx;
 };
 
+/* ---------- Table cell navigation ---------- */
+
+const isTableLine = (line: string): boolean => {
+    const t = line.trim();
+    return t.startsWith("|") && t.endsWith("|") && t.length > 1;
+};
+
+/**
+ * Tab inside a markdown table moves to the next cell (skipping the separator
+ * `| --- |` row). At the last cell of a row, jumps to row 1 of next row.
+ * At the last cell of the last row, creates a new row.
+ */
+export function handleTableTab(state: EditorState, shift: boolean): EditorResult | null {
+    const { text, selStart, selEnd } = state;
+    if (selStart !== selEnd) return null;
+
+    const ls = lineStartIndex(text, selStart);
+    const le = lineEndIndex(text, selStart);
+    const line = text.slice(ls, le);
+    if (!isTableLine(line)) return null;
+
+    // Find pipe positions on the current line
+    const pipes: number[] = [];
+    for (let i = 0; i < line.length; i++) if (line[i] === "|") pipes.push(i);
+    if (pipes.length < 2) return null;
+
+    const localPos = selStart - ls;
+    let cellIdx = 0;
+    for (let i = 0; i < pipes.length - 1; i++) {
+        if (localPos >= pipes[i] && localPos <= pipes[i + 1]) {
+            cellIdx = i;
+            break;
+        }
+    }
+
+    if (!shift) {
+        if (cellIdx < pipes.length - 2) {
+            // Next cell, place caret at content start
+            const target = ls + pipes[cellIdx + 1] + 2;
+            return { text, selStart: target, selEnd: target };
+        }
+        // Last cell — go to next row's first cell, skipping separator rows
+        let nextLs = le + 1;
+        while (nextLs < text.length) {
+            const nle = lineEndIndex(text, nextLs);
+            const nextLine = text.slice(nextLs, nle);
+            if (!isTableLine(nextLine)) {
+                // Not a table — create a new row matching the column count
+                const cols = pipes.length - 1;
+                const blank = "| " + Array(cols).fill("").join(" | ") + " |";
+                const inserted = "\n" + blank;
+                const target = le + 3; // after first "| "
+                return {
+                    text: text.slice(0, le) + inserted + text.slice(le),
+                    selStart: target,
+                    selEnd: target,
+                };
+            }
+            // Skip separator rows
+            if (/^\|\s*:?-+:?\s*(\|\s*:?-+:?\s*)*\|$/.test(nextLine.trim())) {
+                nextLs = nle + 1;
+                continue;
+            }
+            // Found a body row — go to its first cell
+            const firstPipe = nextLs + nextLine.indexOf("|");
+            const target = firstPipe + 2;
+            return { text, selStart: target, selEnd: target };
+        }
+        return null;
+    }
+
+    // Shift+Tab — previous cell
+    if (cellIdx > 0) {
+        const target = ls + pipes[cellIdx - 1] + 2;
+        return { text, selStart: target, selEnd: target };
+    }
+    // First cell — try previous row
+    if (ls > 0) {
+        let prevLe = ls - 1;
+        while (prevLe > 0) {
+            const prevLs = lineStartIndex(text, prevLe - 1);
+            const prevLine = text.slice(prevLs, prevLe);
+            if (!isTableLine(prevLine)) break;
+            if (/^\|\s*:?-+:?\s*(\|\s*:?-+:?\s*)*\|$/.test(prevLine.trim())) {
+                prevLe = prevLs - 1;
+                continue;
+            }
+            // Last cell of prev row
+            const prevPipes: number[] = [];
+            for (let i = 0; i < prevLine.length; i++) if (prevLine[i] === "|") prevPipes.push(i);
+            const target = prevLs + prevPipes[prevPipes.length - 2] + 2;
+            return { text, selStart: target, selEnd: target };
+        }
+    }
+    return null;
+}
+
 /* ---------- Tab / Shift+Tab ---------- */
 
 export function handleTab(state: EditorState, shift: boolean): EditorResult | null {
+    // Try table-tab first; falls through to indent if not in a table.
+    const tableResult = handleTableTab(state, shift);
+    if (tableResult) return tableResult;
+
     const { text, selStart, selEnd } = state;
 
     // Multi-line: indent or outdent each line in the selection

--- a/src/utils/focusTrap.ts
+++ b/src/utils/focusTrap.ts
@@ -1,0 +1,37 @@
+/**
+ * Focus trap helper — when active, Tab/Shift+Tab cycles within the container
+ * instead of escaping. Used by sidebar panels and dialogs.
+ */
+
+const FOCUSABLE = [
+    "button:not([disabled])",
+    "[href]",
+    "input:not([disabled])",
+    "select:not([disabled])",
+    "textarea:not([disabled])",
+    '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+export function attachFocusTrap(container: HTMLElement | null): () => void {
+    if (!container) return () => { };
+
+    const handler = (e: KeyboardEvent) => {
+        if (e.key !== "Tab") return;
+        const focusable = container.querySelectorAll<HTMLElement>(FOCUSABLE);
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement;
+
+        if (e.shiftKey && active === first) {
+            e.preventDefault();
+            last.focus();
+        } else if (!e.shiftKey && active === last) {
+            e.preventDefault();
+            first.focus();
+        }
+    };
+
+    container.addEventListener("keydown", handler);
+    return () => container.removeEventListener("keydown", handler);
+}

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -9,11 +9,13 @@
  * Anything more exotic is preserved as a raw string so we don't lose data.
  */
 
+export type FrontmatterValue = string | number | boolean | string[];
+
 export interface FrontmatterResult {
     /** Body markdown with the frontmatter block stripped. */
     body: string;
     /** Parsed key-value map. Empty object if no frontmatter present. */
-    data: Record<string, string | number | boolean | string[]>;
+    data: Record<string, FrontmatterValue>;
     /** True if the source started with a valid `---\n...\n---\n` block. */
     hasFrontmatter: boolean;
 }
@@ -106,4 +108,28 @@ export function parseFrontmatter(source: string): FrontmatterResult {
     }
 
     return { body, data, hasFrontmatter: true };
+}
+
+const formatScalar = (v: string | number | boolean): string => {
+    if (typeof v === "boolean") return v ? "true" : "false";
+    if (typeof v === "number") return String(v);
+    // Quote strings only if they contain colon, special chars, or look like a number/bool
+    if (/^(true|false|\d+(\.\d+)?)$/.test(v) || /[:#&*!|>'"]/.test(v) || v.includes("\n")) {
+        return `"${v.replace(/"/g, '\\"')}"`;
+    }
+    return v;
+};
+
+const formatValue = (v: FrontmatterValue): string => {
+    if (Array.isArray(v)) {
+        return `[${v.map((s) => formatScalar(s)).join(", ")}]`;
+    }
+    return formatScalar(v);
+};
+
+/** Serialize a parsed frontmatter map back into a `---` block + the body. */
+export function serializeFrontmatter(data: Record<string, FrontmatterValue>, body: string): string {
+    const lines = Object.entries(data).map(([k, v]) => `${k}: ${formatValue(v)}`);
+    if (lines.length === 0) return body;
+    return `---\n${lines.join("\n")}\n---\n${body.startsWith("\n") ? "" : "\n"}${body}`;
 }

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -1,0 +1,109 @@
+/**
+ * Lightweight YAML-frontmatter parser.
+ *
+ * Handles the subset of YAML that's actually used in markdown frontmatter:
+ *   - scalar values (strings, numbers, booleans)
+ *   - inline arrays: tags: [a, b, c]
+ *   - block arrays: tags:\n  - a\n  - b
+ *
+ * Anything more exotic is preserved as a raw string so we don't lose data.
+ */
+
+export interface FrontmatterResult {
+    /** Body markdown with the frontmatter block stripped. */
+    body: string;
+    /** Parsed key-value map. Empty object if no frontmatter present. */
+    data: Record<string, string | number | boolean | string[]>;
+    /** True if the source started with a valid `---\n...\n---\n` block. */
+    hasFrontmatter: boolean;
+}
+
+const FM_REGEX = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+const stripQuotes = (s: string): string => {
+    const t = s.trim();
+    if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) {
+        return t.slice(1, -1);
+    }
+    return t;
+};
+
+const coerceScalar = (raw: string): string | number | boolean => {
+    const t = raw.trim();
+    if (t === "true") return true;
+    if (t === "false") return false;
+    if (/^-?\d+$/.test(t)) return parseInt(t, 10);
+    if (/^-?\d*\.\d+$/.test(t)) return parseFloat(t);
+    return stripQuotes(t);
+};
+
+const parseInlineArray = (raw: string): string[] => {
+    const inner = raw.trim().slice(1, -1); // remove [ ]
+    if (!inner.trim()) return [];
+    return inner.split(",").map((s) => stripQuotes(s.trim()));
+};
+
+export function parseFrontmatter(source: string): FrontmatterResult {
+    const match = source.match(FM_REGEX);
+    if (!match) {
+        return { body: source, data: {}, hasFrontmatter: false };
+    }
+
+    const yaml = match[1];
+    const body = source.slice(match[0].length);
+    const data: Record<string, string | number | boolean | string[]> = {};
+
+    const lines = yaml.split(/\r?\n/);
+    let i = 0;
+    while (i < lines.length) {
+        const line = lines[i];
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) {
+            i++;
+            continue;
+        }
+
+        const colonIdx = trimmed.indexOf(":");
+        if (colonIdx === -1) {
+            i++;
+            continue;
+        }
+
+        const key = trimmed.slice(0, colonIdx).trim();
+        const value = trimmed.slice(colonIdx + 1).trim();
+
+        // Inline array: tags: [a, b, c]
+        if (value.startsWith("[") && value.endsWith("]")) {
+            data[key] = parseInlineArray(value);
+            i++;
+            continue;
+        }
+
+        // Block array: next non-empty lines start with "- "
+        if (value === "") {
+            const items: string[] = [];
+            let j = i + 1;
+            while (j < lines.length) {
+                const next = lines[j];
+                const ntrim = next.trim();
+                if (!ntrim) { j++; continue; }
+                if (next.startsWith("  - ") || next.startsWith("- ")) {
+                    items.push(stripQuotes(ntrim.replace(/^-\s*/, "")));
+                    j++;
+                } else {
+                    break;
+                }
+            }
+            if (items.length > 0) {
+                data[key] = items;
+                i = j;
+                continue;
+            }
+        }
+
+        data[key] = coerceScalar(value);
+        i++;
+    }
+
+    return { body, data, hasFrontmatter: true };
+}

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -1,0 +1,63 @@
+/**
+ * localStorage-backed persistence for app state across sessions.
+ * Tauri's webview has localStorage available; values survive app restarts.
+ */
+
+const KEY_RECENT_FILES = "marklite:recentFiles";
+const KEY_LAST_FILE = "marklite:lastFile";
+const KEY_VIEW_MODE = "marklite:viewMode";
+const KEY_SPLIT_RATIO = "marklite:splitRatio";
+
+const MAX_RECENT = 10;
+
+const safeGet = <T>(key: string, fallback: T): T => {
+    try {
+        const raw = localStorage.getItem(key);
+        return raw === null ? fallback : (JSON.parse(raw) as T);
+    } catch {
+        return fallback;
+    }
+};
+
+const safeSet = (key: string, value: unknown): void => {
+    try {
+        localStorage.setItem(key, JSON.stringify(value));
+    } catch {/* storage may be full / disabled */}
+};
+
+export interface RecentFile {
+    path: string;
+    name: string;
+    openedAt: number;
+}
+
+export const getRecentFiles = (): RecentFile[] => safeGet<RecentFile[]>(KEY_RECENT_FILES, []);
+
+export const addRecentFile = (path: string, name: string): RecentFile[] => {
+    const list = getRecentFiles().filter((f) => f.path !== path);
+    list.unshift({ path, name, openedAt: Date.now() });
+    const trimmed = list.slice(0, MAX_RECENT);
+    safeSet(KEY_RECENT_FILES, trimmed);
+    return trimmed;
+};
+
+export const removeRecentFile = (path: string): RecentFile[] => {
+    const list = getRecentFiles().filter((f) => f.path !== path);
+    safeSet(KEY_RECENT_FILES, list);
+    return list;
+};
+
+export const clearRecentFiles = (): void => safeSet(KEY_RECENT_FILES, []);
+
+export const getLastFile = (): string | null => safeGet<string | null>(KEY_LAST_FILE, null);
+export const setLastFile = (path: string | null): void => safeSet(KEY_LAST_FILE, path);
+
+export const getSavedViewMode = (): "preview" | "code" | "split" =>
+    safeGet<"preview" | "code" | "split">(KEY_VIEW_MODE, "preview");
+export const setSavedViewMode = (m: "preview" | "code" | "split"): void => safeSet(KEY_VIEW_MODE, m);
+
+export const getSplitRatio = (): number => {
+    const r = safeGet<number>(KEY_SPLIT_RATIO, 0.5);
+    return Number.isFinite(r) && r > 0.15 && r < 0.85 ? r : 0.5;
+};
+export const setSplitRatio = (r: number): void => safeSet(KEY_SPLIT_RATIO, r);

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -61,3 +61,7 @@ export const getSplitRatio = (): number => {
     return Number.isFinite(r) && r > 0.15 && r < 0.85 ? r : 0.5;
 };
 export const setSplitRatio = (r: number): void => safeSet(KEY_SPLIT_RATIO, r);
+
+const KEY_AUTOSAVE = "marklite:autoSave";
+export const getAutoSave = (): boolean => safeGet<boolean>(KEY_AUTOSAVE, false);
+export const setAutoSave = (v: boolean): void => safeSet(KEY_AUTOSAVE, v);

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -65,3 +65,27 @@ export const setSplitRatio = (r: number): void => safeSet(KEY_SPLIT_RATIO, r);
 const KEY_AUTOSAVE = "marklite:autoSave";
 export const getAutoSave = (): boolean => safeGet<boolean>(KEY_AUTOSAVE, false);
 export const setAutoSave = (v: boolean): void => safeSet(KEY_AUTOSAVE, v);
+
+const KEY_FOCUS_MODE = "marklite:focusMode";
+const KEY_TYPEWRITER_MODE = "marklite:typewriterMode";
+const KEY_TOOLBAR = "marklite:toolbar";
+export const getFocusMode = (): boolean => safeGet<boolean>(KEY_FOCUS_MODE, false);
+export const setFocusMode = (v: boolean): void => safeSet(KEY_FOCUS_MODE, v);
+export const getTypewriterMode = (): boolean => safeGet<boolean>(KEY_TYPEWRITER_MODE, false);
+export const setTypewriterMode = (v: boolean): void => safeSet(KEY_TYPEWRITER_MODE, v);
+export const getToolbarEnabled = (): boolean => safeGet<boolean>(KEY_TOOLBAR, false);
+export const setToolbarEnabled = (v: boolean): void => safeSet(KEY_TOOLBAR, v);
+
+const KEY_AI_ENDPOINT = "marklite:aiEndpoint";
+const KEY_AI_MODEL = "marklite:aiModel";
+const KEY_AI_API_KEY = "marklite:aiApiKey";
+export const getAIConfig = (): { endpoint: string; model: string; apiKey: string } => ({
+    endpoint: safeGet<string>(KEY_AI_ENDPOINT, ""),
+    model: safeGet<string>(KEY_AI_MODEL, ""),
+    apiKey: safeGet<string>(KEY_AI_API_KEY, ""),
+});
+export const setAIConfig = (cfg: { endpoint: string; model: string; apiKey: string }): void => {
+    safeSet(KEY_AI_ENDPOINT, cfg.endpoint);
+    safeSet(KEY_AI_MODEL, cfg.model);
+    safeSet(KEY_AI_API_KEY, cfg.apiKey);
+};

--- a/src/utils/scrollSync.ts
+++ b/src/utils/scrollSync.ts
@@ -1,0 +1,62 @@
+/**
+ * Bidirectional scroll-fraction sync.
+ *
+ * Each side (code editor textarea, preview <main>) registers a "scroller"
+ * with a `setFraction(0..1)` method. When one side scrolls, we compute its
+ * fraction and apply it to the other.
+ *
+ * To avoid feedback loops, when we set a fraction programmatically on side X
+ * we mark X as "ignoring" for a short window — its native scroll handler may
+ * fire from the imperative scrollTop change, but we drop that echo.
+ */
+
+export interface Scroller {
+    setFraction: (fraction: number) => void;
+}
+
+export type SyncSide = "code" | "preview";
+
+export interface ScrollSync {
+    /** Side X registers its imperative scroller. */
+    register: (side: SyncSide, scroller: Scroller | null) => void;
+    /** Side X reports a user-driven scroll. */
+    notify: (side: SyncSide, fraction: number) => void;
+    /** Disable / enable syncing (used to turn off in non-split modes). */
+    setEnabled: (enabled: boolean) => void;
+}
+
+export function createScrollSync(): ScrollSync {
+    const scrollers: Record<SyncSide, Scroller | null> = { code: null, preview: null };
+    const ignore: Record<SyncSide, boolean> = { code: false, preview: false };
+    let enabled = false;
+    const ignoreTimers: Record<SyncSide, number | null> = { code: null, preview: null };
+
+    const setIgnore = (side: SyncSide) => {
+        ignore[side] = true;
+        if (ignoreTimers[side] !== null) {
+            window.clearTimeout(ignoreTimers[side] as number);
+        }
+        ignoreTimers[side] = window.setTimeout(() => {
+            ignore[side] = false;
+            ignoreTimers[side] = null;
+        }, 80);
+    };
+
+    return {
+        register: (side, scroller) => {
+            scrollers[side] = scroller;
+        },
+        notify: (side, fraction) => {
+            if (!enabled) return;
+            if (ignore[side]) return; // this scroll was triggered by our own programmatic sync
+            const otherSide: SyncSide = side === "code" ? "preview" : "code";
+            const other = scrollers[otherSide];
+            if (!other) return;
+            setIgnore(otherSide); // we're about to scroll the other side; suppress its echo
+            other.setFraction(Math.max(0, Math.min(1, fraction)));
+        },
+        setEnabled: (e) => {
+            enabled = e;
+        },
+    };
+}

--- a/src/utils/smartPaste.ts
+++ b/src/utils/smartPaste.ts
@@ -1,0 +1,107 @@
+/**
+ * Smart-paste rules — examined in order. The first one that returns a
+ * non-null EditorResult wins; otherwise default paste behavior runs.
+ */
+
+import type { EditorResult, EditorState } from "./editorActions";
+
+const URL_RE = /^https?:\/\/\S+$/;
+
+/** If user pastes a URL on a non-empty selection, wrap it as `[selection](url)`. */
+export function pasteUrlOnSelection(state: EditorState, pasted: string): EditorResult | null {
+    if (state.selStart === state.selEnd) return null;
+    const trimmed = pasted.trim();
+    if (!URL_RE.test(trimmed)) return null;
+    const selected = state.text.slice(state.selStart, state.selEnd);
+    const inserted = `[${selected}](${trimmed})`;
+    return {
+        text: state.text.slice(0, state.selStart) + inserted + state.text.slice(state.selEnd),
+        selStart: state.selStart + inserted.length,
+        selEnd: state.selStart + inserted.length,
+    };
+}
+
+/** Paste plain URL on empty selection → autolink `<url>`. */
+export function pasteUrlAutolink(state: EditorState, pasted: string): EditorResult | null {
+    if (state.selStart !== state.selEnd) return null;
+    const trimmed = pasted.trim();
+    if (!URL_RE.test(trimmed)) return null;
+    const inserted = `<${trimmed}>`;
+    return {
+        text: state.text.slice(0, state.selStart) + inserted + state.text.slice(state.selEnd),
+        selStart: state.selStart + inserted.length,
+        selEnd: state.selStart + inserted.length,
+    };
+}
+
+/** TSV (or 2+ tab-separated rows) → GFM markdown table. */
+export function pasteTsvAsTable(state: EditorState, pasted: string): EditorResult | null {
+    if (!pasted.includes("\t")) return null;
+    const rows = pasted.replace(/\r\n/g, "\n").split("\n").filter((r) => r.length > 0);
+    if (rows.length < 1) return null;
+    const cells = rows.map((r) => r.split("\t"));
+    const cols = Math.max(...cells.map((r) => r.length));
+    if (cols < 2) return null;
+
+    // Pad short rows so every row has the same number of columns
+    const padded = cells.map((r) => {
+        const out = [...r];
+        while (out.length < cols) out.push("");
+        return out;
+    });
+
+    // First row is headers; if there's only one row, synthesize headers
+    const headers = padded[0];
+    const body = padded.slice(1);
+    const sep = headers.map(() => "---");
+    const lines = [
+        `| ${headers.map(escapeCell).join(" | ")} |`,
+        `| ${sep.join(" | ")} |`,
+        ...body.map((r) => `| ${r.map(escapeCell).join(" | ")} |`),
+    ];
+    const table = lines.join("\n");
+
+    // If we're in the middle of a line, ensure the table starts on a fresh line
+    const before = state.text.slice(0, state.selStart);
+    const needsLeadingNl = before.length > 0 && !before.endsWith("\n") ? "\n" : "";
+    const inserted = needsLeadingNl + table + "\n";
+
+    return {
+        text: state.text.slice(0, state.selStart) + inserted + state.text.slice(state.selEnd),
+        selStart: state.selStart + inserted.length,
+        selEnd: state.selStart + inserted.length,
+    };
+}
+
+const escapeCell = (s: string) => s.replace(/\|/g, "\\|").replace(/\n/g, " ");
+
+/**
+ * HTML → markdown via turndown. Loaded lazily so the bundle stays small for
+ * users who never paste rich content.
+ */
+let turndownPromise: Promise<{ turndownService: import("turndown") }> | null = null;
+const loadTurndown = () => {
+    if (turndownPromise) return turndownPromise;
+    turndownPromise = import("turndown").then((mod) => {
+        const TurndownService = mod.default;
+        const ts = new TurndownService({
+            headingStyle: "atx",
+            codeBlockStyle: "fenced",
+            bulletListMarker: "-",
+            emDelimiter: "*",
+        });
+        // GFM strikethrough + tables — turndown core doesn't ship them, but the
+        // tiny rules below cover the common cases.
+        ts.addRule("strikethrough", {
+            filter: ["del", "s"] as Array<keyof HTMLElementTagNameMap>,
+            replacement: (content: string) => `~~${content}~~`,
+        });
+        return { turndownService: ts };
+    });
+    return turndownPromise;
+};
+
+export async function htmlToMarkdown(html: string): Promise<string> {
+    const { turndownService } = await loadTurndown();
+    return turndownService.turndown(html);
+}


### PR DESCRIPTION
## Summary

- **Editor**: caret-sync fix, Tab indent, list/quote continuation, auto-pair, Ctrl+B/I/K/​/, Find & Replace, slash commands, smart paste (URL/HTML/TSV), table Tab nav, formatting toolbar, focus + typewriter modes
- **Preview**: code copy buttons, heading anchors, image lightbox, interactive task checkboxes, KaTeX math, Mermaid diagrams (both lazy-loaded), editable frontmatter properties, wikilinks
- **App**: split view + bidirectional scroll sync, command palette (Ctrl+P), cheatsheet (?), settings modal (Ctrl+,), New / Save As, external-change detection, auto-save with status chip, recent files, restore last file, AI assist scaffold (Ctrl+J)
- **A11y / polish**: focus rings, reduced-motion, focus traps, paper-theme contrast fix, design tokens, microcopy

18 commits. Build passes.