### PR TITLE
v0.6.1 — stability fixes from 0.6.0 feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to MarkLite will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-04-30
+
+### Fixed
+
+- "This file was deleted or moved" banner appearing on every opened file (false positive in mtime polling) — feature removed
+- Outline panel: scrolling broken and last item bleeding into status bar (missing `flex flex-col` + `min-h-0` chain on the panel)
+- TOC links inside markdown body (e.g. `[Q1](#q1)`) not navigating to their headings — explicit click handler added with fuzzy heading-text fallback for non-matching slugs
+- New File button doing nothing visible — `hasFile` now considers a blank `Untitled.md` buffer as "open"
+- Command palette on the welcome screen exposing Save / Save As / view toggles that wouldn't work without a buffer
+
+### Removed
+
+- Auto-save toggle (UI removed from Settings dropdown, Settings modal, command palette, status bar)
+- Focus-mode dimming of non-active editor lines — all lines now render at full opacity (typewriter mode kept)
+- External-change polling that was watching the open file's mtime
+
+### Changed
+
+- Wikilink resolution and recent-file existence checks use the existing `get_file_info` Rust command instead of the fs plugin's `stat`
+
 ## [0.6.0] - 2026-04-29
 
 ### Added — Editor

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marklite",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marklite"
-version = "0.6.0"
+version = "0.6.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MarkLite",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.saqla.marklite",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { listen, TauriEvent } from "@tauri-apps/api/event";
-import { stat } from "@tauri-apps/plugin-fs";
 
 import { ThemeProvider } from "./context/ThemeContext";
 import { TitleBar } from "./components/TitleBar";
@@ -24,15 +23,11 @@ import { getRecentFiles } from "./utils/persistence";
 import {
   addRecentFile,
   getAIConfig,
-  getAutoSave,
-  getFocusMode,
   getLastFile,
   getSavedViewMode,
   getSplitRatio,
   getToolbarEnabled,
   getTypewriterMode,
-  setAutoSave,
-  setFocusMode,
   setLastFile,
   setSavedViewMode,
   setSplitRatio,
@@ -68,13 +63,9 @@ function AppContent() {
   const [showPalette, setShowPalette] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [splitRatio, setSplitRatioState] = useState<number>(() => getSplitRatio());
-  const [autoSaveEnabled, setAutoSaveEnabled] = useState<boolean>(() => getAutoSave());
   const [aiConfig, setAiConfigState] = useState(() => getAIConfig());
-  const [focusModeEnabled, setFocusModeEnabled] = useState<boolean>(() => getFocusMode());
   const [typewriterModeEnabled, setTypewriterModeEnabled] = useState<boolean>(() => getTypewriterMode());
   const [toolbarVisible, setToolbarVisible] = useState<boolean>(() => getToolbarEnabled());
-  const [autoSaveStatus, setAutoSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const [externalChange, setExternalChange] = useState<{ kind: "modified" | "deleted"; lastMtime: number } | null>(null);
   const [cursorPosition, setCursorPosition] = useState({ line: 1, col: 1 });
   const [isLoading, setIsLoading] = useState(false);
 
@@ -125,7 +116,8 @@ function AppContent() {
   // Derived state
   const isDirty = content !== originalContent;
   const lineCount = useMemo(() => content.split("\n").length, [content]);
-  const hasFile = filePath !== null;
+  // "Has a buffer" — true once a file is opened OR a blank Untitled buffer is started
+  const hasFile = filePath !== null || fileName !== null;
   const wordCount = useMemo(() => getWordCount(content), [content]);
   const charCount = useMemo(() => content.length, [content]);
   // Average adult reading speed for prose: ~200 wpm. Markdown markup inflates
@@ -167,18 +159,12 @@ function AppContent() {
     setSplitRatio(splitRatio);
   }, [splitRatio]);
 
-  useEffect(() => {
-    setAutoSave(autoSaveEnabled);
-  }, [autoSaveEnabled]);
-
-  useEffect(() => { setFocusMode(focusModeEnabled); }, [focusModeEnabled]);
   useEffect(() => { setTypewriterMode(typewriterModeEnabled); }, [typewriterModeEnabled]);
   useEffect(() => { setToolbarEnabled(toolbarVisible); }, [toolbarVisible]);
 
   // Cross-component event listeners — settings menu and command palette toggle these
   useEffect(() => {
     const handlers: Array<[string, (e: Event) => void]> = [
-      ["marklite:focus-toggle", (e) => setFocusModeEnabled(!!(e as CustomEvent).detail?.enabled)],
       ["marklite:typewriter-toggle", (e) => setTypewriterModeEnabled(!!(e as CustomEvent).detail?.enabled)],
       ["marklite:toolbar-toggle", (e) => setToolbarVisible(!!(e as CustomEvent).detail?.enabled)],
     ];
@@ -193,110 +179,6 @@ function AppContent() {
       window.removeEventListener("storage", onStorage);
     };
   }, []);
-
-  // Listen for SettingsMenu toggling auto-save (cross-component event keeps both sides in sync)
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent).detail;
-      if (typeof detail?.enabled === "boolean") setAutoSaveEnabled(detail.enabled);
-    };
-    window.addEventListener("marklite:autosave-toggle", handler);
-    return () => window.removeEventListener("marklite:autosave-toggle", handler);
-  }, []);
-
-  // External-change detection: poll file mtime every 4s. If the file was modified
-  // by something outside MarkLite, we either silently reload (clean buffer) or
-  // banner the user with a choice (dirty buffer). If it was deleted, banner only.
-  const lastMtimeRef = useRef<number | null>(null);
-  useEffect(() => {
-    if (!filePath) {
-      lastMtimeRef.current = null;
-      setExternalChange(null);
-      return;
-    }
-    let cancelled = false;
-    let didInit = false;
-
-    const tick = async () => {
-      if (cancelled || !filePath) return;
-      try {
-        const s = await stat(filePath);
-        const mtime = s.mtime ? new Date(s.mtime).getTime() : 0;
-        if (!didInit) {
-          lastMtimeRef.current = mtime;
-          didInit = true;
-          return;
-        }
-        if (mtime !== lastMtimeRef.current) {
-          // Changed externally
-          if (content === originalContent) {
-            // Silently reload — buffer was clean
-            try {
-              const fileData = await invoke<FileData>("read_file", { path: filePath });
-              setContent(fileData.content);
-              setOriginalContent(fileData.content);
-              setFileSize(fileData.size);
-              lastMtimeRef.current = mtime;
-            } catch {
-              setExternalChange({ kind: "deleted", lastMtime: mtime });
-            }
-          } else {
-            setExternalChange({ kind: "modified", lastMtime: mtime });
-          }
-        }
-      } catch {
-        // File no longer exists
-        if (!externalChange) setExternalChange({ kind: "deleted", lastMtime: lastMtimeRef.current ?? 0 });
-      }
-    };
-
-    tick();
-    const id = window.setInterval(tick, 4000);
-    return () => {
-      cancelled = true;
-      window.clearInterval(id);
-    };
-  }, [filePath, content, originalContent, externalChange]);
-
-  const dismissExternalChange = useCallback(() => setExternalChange(null), []);
-  const reloadFromDisk = useCallback(async () => {
-    if (!filePath) return;
-    try {
-      const fileData = await invoke<FileData>("read_file", { path: filePath });
-      setContent(fileData.content);
-      setOriginalContent(fileData.content);
-      setFileSize(fileData.size);
-      const s = await stat(filePath);
-      lastMtimeRef.current = s.mtime ? new Date(s.mtime).getTime() : 0;
-      setExternalChange(null);
-    } catch (err) {
-      console.error("Reload failed:", err);
-      showToast("Failed to reload file", "error");
-    }
-  }, [filePath, showToast]);
-
-  // Auto-save: debounced 1.5s after typing stops, only if a file is open and dirty
-  useEffect(() => {
-    if (!autoSaveEnabled) return;
-    if (!filePath) return;
-    if (content === originalContent) return;
-
-    const timer = window.setTimeout(() => {
-      setAutoSaveStatus("saving");
-      invoke("save_file", { path: filePath, content })
-        .then(() => {
-          setOriginalContent(content);
-          setAutoSaveStatus("saved");
-          window.setTimeout(() => setAutoSaveStatus((s) => (s === "saved" ? "idle" : s)), 1500);
-        })
-        .catch((err) => {
-          console.error("Auto-save failed:", err);
-          setAutoSaveStatus("error");
-        });
-    }, 1500);
-
-    return () => window.clearTimeout(timer);
-  }, [autoSaveEnabled, content, originalContent, filePath]);
 
   useEffect(() => {
     // Restore last opened file once on app launch
@@ -420,7 +302,8 @@ function AppContent() {
     ];
     for (const c of candidates) {
       try {
-        await stat(c);
+        // get_file_info errors when the file doesn't exist; use it as a probe
+        await invoke("get_file_info", { path: c });
         loadFile(c);
         return;
       } catch {/* try next */}
@@ -687,73 +570,70 @@ function AppContent() {
       icon: "folder_open",
       run: handleOpenFile,
     });
-    items.push({
-      id: "file.save",
-      label: "Save",
-      hint: "Ctrl+S",
-      section: "File",
-      icon: "save",
-      run: handleSaveFile,
-    });
-    items.push({
-      id: "file.saveas",
-      label: "Save As…",
-      hint: "Ctrl+Shift+S",
-      section: "File",
-      icon: "save_as",
-      run: handleSaveAs,
-    });
+    // Save / Save As only make sense when a buffer is open
+    if (hasFile) {
+      items.push({
+        id: "file.save",
+        label: "Save",
+        hint: "Ctrl+S",
+        section: "File",
+        icon: "save",
+        run: handleSaveFile,
+      });
+      items.push({
+        id: "file.saveas",
+        label: "Save As…",
+        hint: "Ctrl+Shift+S",
+        section: "File",
+        icon: "save_as",
+        run: handleSaveAs,
+      });
+    }
 
-    // === View ===
-    items.push({
-      id: "view.preview",
-      label: "Switch to Reader mode",
-      hint: "Ctrl+E",
-      section: "View",
-      icon: "visibility",
-      run: () => setMode("preview"),
-    });
-    items.push({
-      id: "view.code",
-      label: "Switch to Code editor",
-      section: "View",
-      icon: "code",
-      run: () => setMode("code"),
-    });
-    items.push({
-      id: "view.split",
-      label: "Toggle Split view",
-      hint: "Ctrl+\\",
-      section: "View",
-      icon: "vertical_split",
-      run: handleToggleSplit,
-    });
-    items.push({
-      id: "view.explorer",
-      label: "Toggle file explorer",
-      hint: "Ctrl+Shift+E",
-      section: "View",
-      icon: "folder",
-      run: handleToggleFileExplorer,
-    });
-    items.push({
-      id: "view.toc",
-      label: "Toggle outline",
-      hint: "Ctrl+Shift+O",
-      section: "View",
-      icon: "format_list_bulleted",
-      run: handleToggleTOC,
-    });
+    // === View === only when a buffer exists
+    if (hasFile) {
+      items.push({
+        id: "view.preview",
+        label: "Switch to Reader mode",
+        hint: "Ctrl+E",
+        section: "View",
+        icon: "visibility",
+        run: () => setMode("preview"),
+      });
+      items.push({
+        id: "view.code",
+        label: "Switch to Code editor",
+        section: "View",
+        icon: "code",
+        run: () => setMode("code"),
+      });
+      items.push({
+        id: "view.split",
+        label: "Toggle Split view",
+        hint: "Ctrl+\\",
+        section: "View",
+        icon: "vertical_split",
+        run: handleToggleSplit,
+      });
+      items.push({
+        id: "view.explorer",
+        label: "Toggle file explorer",
+        hint: "Ctrl+Shift+E",
+        section: "View",
+        icon: "folder",
+        run: handleToggleFileExplorer,
+      });
+      items.push({
+        id: "view.toc",
+        label: "Toggle outline",
+        hint: "Ctrl+Shift+O",
+        section: "View",
+        icon: "format_list_bulleted",
+        run: handleToggleTOC,
+      });
+    }
 
     // === Toggles ===
-    items.push({
-      id: "toggle.focus",
-      label: focusModeEnabled ? "Disable Focus mode" : "Enable Focus mode",
-      section: "Toggles",
-      icon: "center_focus_strong",
-      keywords: "dim non-active line",
-      run: () => setFocusModeEnabled((v) => !v),
-    });
     items.push({
       id: "toggle.typewriter",
       label: typewriterModeEnabled ? "Disable Typewriter mode" : "Enable Typewriter mode",
@@ -768,13 +648,6 @@ function AppContent() {
       section: "Toggles",
       icon: "format_paint",
       run: () => setToolbarVisible((v) => !v),
-    });
-    items.push({
-      id: "toggle.autosave",
-      label: autoSaveEnabled ? "Disable auto-save" : "Enable auto-save",
-      section: "Toggles",
-      icon: "save_as",
-      run: () => setAutoSaveEnabled((v) => !v),
     });
 
     items.push({
@@ -844,8 +717,8 @@ function AppContent() {
   }, [
     handleNewFile, handleOpenFile, handleSaveFile, handleSaveAs,
     handleToggleSplit, handleToggleFileExplorer, handleToggleTOC,
-    loadFile, filePath, content,
-    focusModeEnabled, typewriterModeEnabled, toolbarVisible, autoSaveEnabled,
+    loadFile, filePath, content, hasFile,
+    typewriterModeEnabled, toolbarVisible,
   ]);
 
   return (
@@ -861,25 +734,6 @@ function AppContent() {
         onExportSuccess={(fmt) => showToast(`Exported as ${fmt}`, "success")}
         onExportError={(fmt) => showToast(`Failed to export ${fmt}`, "error")}
       />
-
-      {externalChange && hasFile && (
-        <div role="alert" className="px-4 py-2 bg-[var(--status-unsaved)]/15 border-b border-[var(--status-unsaved)]/30 flex items-center gap-3 text-sm text-[var(--text-primary)] animate-fade-in-down">
-          <span className="material-symbols-outlined text-[18px] text-[var(--status-unsaved)]">warning</span>
-          <span className="flex-1">
-            {externalChange.kind === "modified"
-              ? "This file was modified outside MarkLite."
-              : "This file was deleted or moved."}
-          </span>
-          {externalChange.kind === "modified" && (
-            <button onClick={reloadFromDisk} className="px-3 py-1 text-xs rounded-[var(--radius-sm)] bg-[var(--accent)] text-[var(--accent-text)] hover:opacity-90">
-              Reload from disk
-            </button>
-          )}
-          <button onClick={dismissExternalChange} className="px-3 py-1 text-xs rounded-[var(--radius-sm)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)]">
-            Keep mine
-          </button>
-        </div>
-      )}
 
       {!hasFile ? (
         <WelcomeScreen onOpenFile={handleOpenFile} onNewFile={handleNewFile} onFileDrop={handleFileDrop} onOpenRecent={loadFile} />
@@ -909,7 +763,6 @@ function AppContent() {
                 filePath={filePath}
                 onScrollFraction={onCodeScrollFraction}
                 registerScroller={registerCodeScroller}
-                focusMode={focusModeEnabled}
                 typewriterMode={typewriterModeEnabled}
                 showToolbar={toolbarVisible}
                 aiConfig={aiConfig}
@@ -975,7 +828,6 @@ function AppContent() {
             wordCount={wordCount}
             charCount={charCount}
             readingTimeMin={readingTimeMin}
-            autoSaveStatus={autoSaveStatus}
           />
         </>
       )}

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -26,7 +26,6 @@ interface CodeEditorProps {
     filePath?: string | null; // Current file path for saving images
     onScrollFraction?: (fraction: number) => void;
     registerScroller?: (scroller: Scroller | null) => void;
-    focusMode?: boolean;
     typewriterMode?: boolean;
     showToolbar?: boolean;
     aiConfig?: { endpoint: string; model: string; apiKey: string };
@@ -57,7 +56,7 @@ const sharedTextStyle: React.CSSProperties = {
     boxSizing: "border-box",
 };
 
-export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath, onScrollFraction, registerScroller, focusMode, typewriterMode, showToolbar, aiConfig }: CodeEditorProps) {
+export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath, onScrollFraction, registerScroller, typewriterMode, showToolbar, aiConfig }: CodeEditorProps) {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const gutterRef = useRef<HTMLDivElement>(null);
     const highlightRef = useRef<HTMLDivElement>(null);
@@ -753,23 +752,18 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                             opacity: 0.45,
                         }}
                     />
-                    {highlightedLines.map((highlighted, i) => {
-                        const isActive = i + 1 === activeLine;
-                        return (
-                            <div
-                                key={i}
-                                style={{
-                                    height: `${EDITOR_LINE_HEIGHT}px`,
-                                    lineHeight: `${EDITOR_LINE_HEIGHT}px`,
-                                    position: "relative",
-                                    opacity: focusMode && !isActive ? 0.35 : 1,
-                                    transition: focusMode ? "opacity 150ms ease-out" : undefined,
-                                }}
-                            >
-                                {highlighted}
-                            </div>
-                        );
-                    })}
+                    {highlightedLines.map((highlighted, i) => (
+                        <div
+                            key={i}
+                            style={{
+                                height: `${EDITOR_LINE_HEIGHT}px`,
+                                lineHeight: `${EDITOR_LINE_HEIGHT}px`,
+                                position: "relative",
+                            }}
+                        >
+                            {highlighted}
+                        </div>
+                    ))}
                 </div>
 
                 <FindReplaceBar

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -95,11 +95,11 @@ export function FileExplorer({
             role="navigation"
             aria-label="File explorer"
             tabIndex={-1}
-            className={`fixed left-0 top-12 bottom-7 w-72 bg-[var(--bg-secondary)] border-r border-[var(--border)] z-50 shadow-2xl transition-transform duration-200 ease-out ${isOpen ? "translate-x-0" : "-translate-x-full"
+            className={`fixed left-0 top-12 bottom-7 w-72 bg-[var(--bg-secondary)] border-r border-[var(--border)] z-50 shadow-2xl flex flex-col overflow-hidden transition-transform duration-200 ease-out ${isOpen ? "translate-x-0" : "-translate-x-full"
                 }`}
         >
             {/* Header */}
-            <div className="h-10 px-4 flex items-center justify-between border-b border-[var(--border)] bg-[var(--bg-titlebar)]">
+            <div className="h-10 shrink-0 px-4 flex items-center justify-between border-b border-[var(--border)] bg-[var(--bg-titlebar)]">
                 <div className="flex items-center gap-2 text-sm font-semibold text-[var(--text-primary)] no-select">
                     <span className="material-symbols-outlined text-[18px]">
                         folder_open
@@ -118,7 +118,7 @@ export function FileExplorer({
             </div>
 
             {/* Content */}
-            <div className="flex-1 overflow-y-auto h-[calc(100%-2.5rem)]">
+            <div className="flex-1 min-h-0 overflow-y-auto">
                 {isLoading ? (
                     <div className="flex items-center justify-center h-32 text-[var(--text-secondary)] text-sm">
                         Loading...

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -474,6 +474,41 @@ export function MarkdownPreview({
                     </a>
                 );
             }
+            // In-page hash link (#section). The Tauri webview's URL doesn't
+            // play well with native hash navigation, so we scroll explicitly.
+            // Falls back to a fuzzy heading-text match when the slug doesn't
+            // exactly match an existing id (different markdown anchor styles).
+            if (href && href.startsWith("#")) {
+                return (
+                    <a
+                        {...rest}
+                        href={href}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            const id = decodeURIComponent(href.slice(1));
+                            let el: HTMLElement | null = document.getElementById(id);
+                            if (!el) {
+                                // Fuzzy fallback: find a heading whose textContent
+                                // slugifies to a string containing the requested id.
+                                const needle = id.toLowerCase().replace(/-/g, " ").trim();
+                                const headings = document.querySelectorAll<HTMLElement>(
+                                    ".markdown-body h1, .markdown-body h2, .markdown-body h3, .markdown-body h4, .markdown-body h5, .markdown-body h6"
+                                );
+                                for (const h of headings) {
+                                    const text = (h.textContent ?? "").toLowerCase();
+                                    if (text.includes(needle) || needle.includes(text.trim())) {
+                                        el = h;
+                                        break;
+                                    }
+                                }
+                            }
+                            el?.scrollIntoView({ behavior: "smooth", block: "start" });
+                        }}
+                    >
+                        {children}
+                    </a>
+                );
+            }
             return <a href={href} {...rest}>{children}</a>;
         },
         pre: (props: React.HTMLAttributes<HTMLPreElement>) => <CodeBlock {...props} />,

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -1,6 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTheme, Theme, FontFamily, FontSize } from '../context/ThemeContext';
-import { getAutoSave, setAutoSave } from '../utils/persistence';
 
 const themes: { id: Theme; name: string; colors: [string, string]; textColor: string; icon?: string }[] = [
     { id: 'dark', name: 'Dark', colors: ['#0a0a0a', '#141414'], textColor: '#ffffff' },
@@ -25,17 +24,8 @@ const fontSizes: { id: FontSize; name: string; size: string }[] = [
 
 export function SettingsMenu() {
     const [isOpen, setIsOpen] = useState(false);
-    const [autoSave, setAutoSaveState] = useState(() => getAutoSave());
     const { theme, setTheme, font, setFont, fontSize, setFontSize } = useTheme();
     const menuRef = useRef<HTMLDivElement>(null);
-
-    const toggleAutoSave = () => {
-        const next = !autoSave;
-        setAutoSaveState(next);
-        setAutoSave(next);
-        // Notify the app so the auto-save effect picks up the new setting
-        window.dispatchEvent(new CustomEvent("marklite:autosave-toggle", { detail: { enabled: next } }));
-    };
 
     // Close menu when clicking outside
     useEffect(() => {
@@ -135,7 +125,7 @@ export function SettingsMenu() {
                     </div>
 
                     {/* Font Size Section */}
-                    <div className="p-4 border-b border-[var(--border)]">
+                    <div className="p-4">
                         <div className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider mb-3">
                             Font Size
                         </div>
@@ -153,31 +143,6 @@ export function SettingsMenu() {
                                 </button>
                             ))}
                         </div>
-                    </div>
-
-                    {/* Editor Section */}
-                    <div className="p-4">
-                        <div className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider mb-3">
-                            Editor
-                        </div>
-                        <button
-                            onClick={toggleAutoSave}
-                            role="switch"
-                            aria-checked={autoSave}
-                            className="w-full flex items-center justify-between px-3 py-2 rounded-lg hover:bg-[var(--bg-hover)] text-sm text-[var(--text-primary)]"
-                        >
-                            <span className="flex flex-col items-start">
-                                <span>Auto-save</span>
-                                <span className="text-[11px] text-[var(--text-muted)]">Save 1.5s after typing stops</span>
-                            </span>
-                            <span
-                                className={`relative inline-block w-9 h-5 rounded-full transition-colors ${autoSave ? "bg-[var(--accent)]" : "bg-[var(--border)]"}`}
-                            >
-                                <span
-                                    className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${autoSave ? "translate-x-4" : ""}`}
-                                />
-                            </span>
-                        </button>
                     </div>
                 </div>
             )}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useTheme, type Theme, type FontFamily, type FontSize } from "../context/ThemeContext";
 import {
-    getAutoSave, setAutoSave,
-    getFocusMode, setFocusMode,
     getTypewriterMode, setTypewriterMode,
     getToolbarEnabled, setToolbarEnabled,
     getAIConfig, setAIConfig,
@@ -77,8 +75,6 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     const [filter, setFilter] = useState("");
     const { theme, setTheme, font, setFont, fontSize, setFontSize } = useTheme();
 
-    const [autoSave, setAutoSaveLocal] = useState(getAutoSave);
-    const [focus, setFocusLocal] = useState(getFocusMode);
     const [typewriter, setTypewriterLocal] = useState(getTypewriterMode);
     const [toolbar, setToolbarLocal] = useState(getToolbarEnabled);
 
@@ -227,10 +223,6 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
 
                         {section === "editor" && (
                             <>
-                                {matches("focus") && (
-                                    <ToggleRow label="Focus mode" description="Dim non-active lines" checked={focus}
-                                        onChange={(v) => { setFocusLocal(v); setFocusMode(v); fire("marklite:focus-toggle", v); }} />
-                                )}
                                 {matches("typewriter") && (
                                     <ToggleRow label="Typewriter mode" description="Keep caret vertically centered" checked={typewriter}
                                         onChange={(v) => { setTypewriterLocal(v); setTypewriterMode(v); fire("marklite:typewriter-toggle", v); }} />
@@ -238,10 +230,6 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                 {matches("toolbar") && (
                                     <ToggleRow label="Show formatting toolbar" description="Toolbar above the editor" checked={toolbar}
                                         onChange={(v) => { setToolbarLocal(v); setToolbarEnabled(v); fire("marklite:toolbar-toggle", v); }} />
-                                )}
-                                {matches("auto-save") && (
-                                    <ToggleRow label="Auto-save" description="Save 1.5s after typing stops" checked={autoSave}
-                                        onChange={(v) => { setAutoSaveLocal(v); setAutoSave(v); fire("marklite:autosave-toggle", v); }} />
                                 )}
                             </>
                         )}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -10,7 +10,6 @@ interface StatusBarProps {
     wordCount?: number;
     charCount?: number;
     readingTimeMin?: number;
-    autoSaveStatus?: "idle" | "saving" | "saved" | "error";
 }
 
 const formatReadingTime = (min: number): string => {
@@ -33,15 +32,7 @@ export function StatusBar({
     wordCount,
     charCount,
     readingTimeMin,
-    autoSaveStatus = "idle",
 }: StatusBarProps) {
-    const autoSaveLabel: Record<string, { text: string; icon: string; color: string }> = {
-        idle: { text: "", icon: "", color: "" },
-        saving: { text: "Saving…", icon: "sync", color: "var(--text-secondary)" },
-        saved: { text: "Auto-saved", icon: "check", color: "var(--status-saved)" },
-        error: { text: "Save failed", icon: "error", color: "var(--danger)" },
-    };
-    const autoChip = autoSaveLabel[autoSaveStatus];
     return (
         <footer
             role="status"
@@ -81,14 +72,6 @@ export function StatusBar({
                 </button>
             </div>
             <div className="flex items-center gap-4">
-                {autoChip.text && (
-                    <div className="flex items-center gap-1 transition-opacity" style={{ color: autoChip.color }}>
-                        <span className={`material-symbols-outlined text-[13px] ${autoSaveStatus === "saving" ? "animate-spin" : ""}`}>
-                            {autoChip.icon}
-                        </span>
-                        <span>{autoChip.text}</span>
-                    </div>
-                )}
                 <div className="flex items-center gap-1.5" aria-label={isSaved ? "File saved" : "File has unsaved changes"}>
                     <span
                         className={`w-2 h-2 rounded-full transition-all ${isSaved

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -143,11 +143,11 @@ export function TableOfContents({
             role="navigation"
             aria-label="Table of contents"
             tabIndex={-1}
-            className={`fixed left-0 top-12 bottom-7 w-72 bg-[var(--bg-secondary)] border-r border-[var(--border)] z-50 shadow-2xl transition-transform duration-200 ease-out ${isOpen ? "translate-x-0" : "-translate-x-full"
+            className={`fixed left-0 top-12 bottom-7 w-72 bg-[var(--bg-secondary)] border-r border-[var(--border)] z-50 shadow-2xl flex flex-col overflow-hidden transition-transform duration-200 ease-out ${isOpen ? "translate-x-0" : "-translate-x-full"
                 }`}
         >
             {/* Header */}
-            <div className="h-10 px-4 flex items-center justify-between border-b border-[var(--border)] bg-[var(--bg-titlebar)]">
+            <div className="h-10 shrink-0 px-4 flex items-center justify-between border-b border-[var(--border)] bg-[var(--bg-titlebar)]">
                 <div className="flex items-center gap-2 text-sm font-semibold text-[var(--text-primary)] no-select">
                     <span className="material-symbols-outlined text-[18px]">format_list_bulleted</span>
                     <span>Outline</span>
@@ -163,7 +163,7 @@ export function TableOfContents({
 
             {/* Filter (only shown when there are >5 headings to keep it clean) */}
             {headings.length > 5 && (
-                <div className="px-3 py-2 border-b border-[var(--border-subtle)]">
+                <div className="px-3 py-2 shrink-0 border-b border-[var(--border-subtle)]">
                     <input
                         type="text"
                         value={filter}
@@ -176,7 +176,7 @@ export function TableOfContents({
             )}
 
             {/* Content */}
-            <nav className="flex-1 overflow-y-auto" aria-label="Document headings">
+            <nav className="flex-1 min-h-0 overflow-y-auto" aria-label="Document headings">
                 {headings.length === 0 ? (
                     <div className="flex flex-col items-center justify-center h-32 text-[var(--text-secondary)] text-sm gap-2 px-4 text-center">
                         <span className="material-symbols-outlined text-[32px] opacity-40">format_list_bulleted</span>

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { stat } from "@tauri-apps/plugin-fs";
+import { invoke } from "@tauri-apps/api/core";
 import { getRecentFiles, removeRecentFile, type RecentFile } from "../utils/persistence";
 
 interface WelcomeScreenProps {
@@ -37,7 +37,7 @@ export function WelcomeScreen({ onOpenFile, onNewFile, onFileDrop, onOpenRecent 
         Promise.all(
             list.map(async (f) => {
                 try {
-                    await stat(f.path);
+                    await invoke("get_file_info", { path: f.path });
                     return null;
                 } catch {
                     return f.path;


### PR DESCRIPTION
## Summary

- **Removed false 'file deleted' banner** — mtime poller dropped (was firing on every opened file)
- **Removed auto-save** — toggle, status chip, and effect all gone
- **Removed focus-mode dimming** — all editor lines render at full opacity again
- **Outline panel scroll fixed** — last items no longer bleed into the status bar
- **TOC links inside markdown navigate** — explicit hash-click handler with fuzzy heading-text fallback
- **New File now actually shows the editor** — `hasFile` considers a blank Untitled buffer as open
- **Command palette on welcome page** — Save / Save As / view toggles hidden when no buffer is open
- Wikilink + recent-file existence checks switched from fs plugin `stat` to the existing `get_file_info` Rust command