### PR TITLE
chore: security pass + word wrap, spell check, doc stats, reveal in folder

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"c7592f13-bd06-45cf-97ce-adb46a00c686","pid":22080,"acquiredAt":1777849157733}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"c7592f13-bd06-45cf-97ce-adb46a00c686","pid":22080,"acquiredAt":1777849157733}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Claude Code session state
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to MarkLite will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Word wrap toggle for the editor (Settings → Editor; default on). Wrapped
+  mode hides the line-number gutter so per-source-line numbers don't drift
+  out of alignment with wrapped visual rows.
+- Spell check toggle for the editor (Settings → Editor; default off).
+- Document statistics dialog (command palette → "Show document statistics"):
+  words, characters, sentences, paragraphs, headings, links, images, code
+  blocks, and reading time. Frontmatter and code blocks are excluded from
+  prose counts.
+- Command palette: "Reveal in folder" and "Copy file path" actions for the
+  current file.
+
+### Fixed — Security
+
+- Wikilink resolver now rejects targets containing `..`, path separators,
+  drive letters, or NUL bytes. A crafted document can no longer load files
+  outside the current folder.
+- Rust `save_image` command sanitizes the supplied filename to a bare
+  basename, preventing escape from the `images/` subdirectory. Backed by
+  unit tests covering common traversal payloads.
+- External markdown links (`http(s)://`, `mailto:`) now open in the system
+  default handler via `tauri-plugin-opener` instead of navigating the
+  webview itself; `rel="noopener noreferrer"` is also set as a fallback.
+- AI assist refuses non-`http(s)` endpoints; the Settings modal flags an
+  invalid endpoint inline so users get fast feedback before triggering a
+  request.
+- Settings modal makes it explicit that the AI API key is stored
+  unencrypted in localStorage.
+
+### Fixed — UX
+
+- AI assist bubble repositions when it would overflow the right or bottom
+  edge of the viewport, flipping above the anchor when there is no room
+  below.
+
 ## [0.6.1] - 2026-04-30
 
 ### Fixed

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1932,7 +1932,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "marklite"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,6 +14,8 @@
     "core:window:allow-close",
     "core:window:allow-start-dragging",
     "opener:default",
+    "opener:allow-open-url",
+    "opener:allow-reveal-item-in-dir",
     "fs:default",
     "fs:allow-read-text-file",
     "fs:allow-write-text-file",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -163,6 +163,28 @@ pub async fn list_directory_files(directory: String) -> Result<Vec<FileEntry>, C
     Ok(entries)
 }
 
+/// Strip any path components from a filename so it can't traverse outside the
+/// images directory. Rejects empty / dot-only names and names with separators,
+/// drive letters, or NUL bytes. Returns just the basename when valid.
+fn sanitize_image_name(name: &str) -> Result<String, CommandError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() || trimmed == "." || trimmed == ".." {
+        return Err(CommandError::WriteError("Invalid image filename".to_string()));
+    }
+    if trimmed.contains('\0') {
+        return Err(CommandError::WriteError("Invalid image filename".to_string()));
+    }
+    // Reject any path-like input — only a bare basename is allowed.
+    let basename = std::path::Path::new(trimmed)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| CommandError::WriteError("Invalid image filename".to_string()))?;
+    if basename != trimmed {
+        return Err(CommandError::WriteError("Invalid image filename".to_string()));
+    }
+    Ok(basename.to_string())
+}
+
 /// Save image data to a file in the images subdirectory
 /// Returns the relative path to use in markdown
 #[tauri::command]
@@ -171,13 +193,14 @@ pub async fn save_image(
     image_data: Vec<u8>,
     image_name: String,
 ) -> Result<String, CommandError> {
+    let safe_name = sanitize_image_name(&image_name)?;
     let md_path = PathBuf::from(&md_file_path);
-    
+
     // Get the directory containing the markdown file
     let parent_dir = md_path
         .parent()
         .ok_or_else(|| CommandError::WriteError("Cannot determine parent directory".to_string()))?;
-    
+
     // Create images subdirectory
     let images_dir = parent_dir.join("images");
     if !images_dir.exists() {
@@ -185,15 +208,38 @@ pub async fn save_image(
             .await
             .map_err(|e| CommandError::WriteError(format!("Failed to create images directory: {}", e)))?;
     }
-    
-    // Full path for the image
-    let image_path = images_dir.join(&image_name);
-    
+
+    // Full path for the image (basename only, no traversal possible).
+    let image_path = images_dir.join(&safe_name);
+
     // Write the image data
     tokio::fs::write(&image_path, &image_data)
         .await
         .map_err(|e| CommandError::WriteError(format!("Failed to write image: {}", e)))?;
-    
+
     // Return relative path for markdown (./images/filename.png)
-    Ok(format!("./images/{}", image_name))
+    Ok(format!("./images/{}", safe_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_image_name;
+
+    #[test]
+    fn accepts_basename() {
+        assert_eq!(sanitize_image_name("foo.png").unwrap(), "foo.png");
+        assert_eq!(sanitize_image_name("image-1234-abc.jpg").unwrap(), "image-1234-abc.jpg");
+    }
+
+    #[test]
+    fn rejects_traversal() {
+        assert!(sanitize_image_name("../foo.png").is_err());
+        assert!(sanitize_image_name("..\\foo.png").is_err());
+        assert!(sanitize_image_name("foo/bar.png").is_err());
+        assert!(sanitize_image_name("foo\\bar.png").is_err());
+        assert!(sanitize_image_name("..").is_err());
+        assert!(sanitize_image_name(".").is_err());
+        assert!(sanitize_image_name("").is_err());
+        assert!(sanitize_image_name("\0").is_err());
+    }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { listen, TauriEvent } from "@tauri-apps/api/event";
 
+import { revealItemInDir } from "@tauri-apps/plugin-opener";
+
 import { ThemeProvider } from "./context/ThemeContext";
 import { TitleBar } from "./components/TitleBar";
 import { WelcomeScreen } from "./components/WelcomeScreen";
@@ -19,6 +21,7 @@ import { createScrollSync } from "./utils/scrollSync";
 import { ShortcutCheatsheet } from "./components/ShortcutCheatsheet";
 import { CommandPalette, type PaletteCommand } from "./components/CommandPalette";
 import { SettingsModal } from "./components/SettingsModal";
+import { StatsDialog } from "./components/StatsDialog";
 import { getRecentFiles } from "./utils/persistence";
 import {
   addRecentFile,
@@ -66,6 +69,7 @@ function AppContent() {
   const [showCheatsheet, setShowCheatsheet] = useState(false);
   const [showPalette, setShowPalette] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const [showStats, setShowStats] = useState(false);
   const [splitRatio, setSplitRatioState] = useState<number>(() => getSplitRatio());
   const [aiConfig, setAiConfigState] = useState(() => getAIConfig());
   const [typewriterModeEnabled, setTypewriterModeEnabled] = useState<boolean>(() => getTypewriterMode());
@@ -615,6 +619,44 @@ function AppContent() {
         run: handleSaveAs,
       });
     }
+    if (filePath) {
+      items.push({
+        id: "file.reveal",
+        label: "Reveal in folder",
+        section: "File",
+        icon: "folder_open",
+        keywords: "show finder explorer locate",
+        run: () => {
+          revealItemInDir(filePath).catch((err) => {
+            console.error("Reveal failed:", err);
+            showToast("Could not reveal file", "error");
+          });
+        },
+      });
+      items.push({
+        id: "file.copypath",
+        label: "Copy file path",
+        section: "File",
+        icon: "content_copy",
+        keywords: "clipboard absolute",
+        run: () => {
+          navigator.clipboard.writeText(filePath).then(
+            () => showToast("File path copied", "success"),
+            () => showToast("Could not copy path", "error"),
+          );
+        },
+      });
+    }
+    if (hasFile) {
+      items.push({
+        id: "doc.stats",
+        label: "Show document statistics",
+        section: "File",
+        icon: "analytics",
+        keywords: "words count reading time",
+        run: () => setShowStats(true),
+      });
+    }
 
     // === View === only when a buffer exists
     if (hasFile) {
@@ -743,7 +785,7 @@ function AppContent() {
   }, [
     handleNewFile, handleOpenFile, handleSaveFile, handleSaveAs,
     handleToggleSplit, handleToggleFileExplorer, handleToggleTOC,
-    loadFile, filePath, content, hasFile,
+    loadFile, filePath, content, hasFile, showToast,
     typewriterModeEnabled, toolbarVisible,
   ]);
 
@@ -879,6 +921,7 @@ function AppContent() {
       )}
 
       <ShortcutCheatsheet isOpen={showCheatsheet} onClose={() => setShowCheatsheet(false)} />
+      <StatsDialog isOpen={showStats} content={content} onClose={() => setShowStats(false)} />
       <CommandPalette isOpen={showPalette} items={paletteItems} onClose={() => setShowPalette(false)} />
       <SettingsModal
         isOpen={showSettings}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -290,15 +290,31 @@ function AppContent() {
 
   // Wikilink click: resolve target relative to the current file's folder.
   // Tries `<target>.md` first, then `<target>` literal. Silently fails if neither exists.
+  // SECURITY: rejects path-traversal and absolute paths so a crafted document
+  // can't load arbitrary files outside the current folder.
   const handleWikilinkClick = useCallback(async (target: string) => {
     if (!filePath) return;
+    const cleaned = target.trim();
+    // Block traversal (`..`), path separators, drive letters, and absolute paths.
+    // Wikilinks should only reference siblings in the same folder.
+    if (
+      !cleaned ||
+      cleaned.includes("..") ||
+      cleaned.includes("/") ||
+      cleaned.includes("\\") ||
+      cleaned.includes("\0") ||
+      /^[a-zA-Z]:/.test(cleaned)
+    ) {
+      showToast(`Invalid wikilink target: [[${target}]]`, "error");
+      return;
+    }
     const lastSep = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
     const dir = lastSep > 0 ? filePath.slice(0, lastSep) : "";
     const sep = filePath.includes("\\") ? "\\" : "/";
     const candidates = [
-      `${dir}${sep}${target}.md`,
-      `${dir}${sep}${target}.markdown`,
-      `${dir}${sep}${target}`,
+      `${dir}${sep}${cleaned}.md`,
+      `${dir}${sep}${cleaned}.markdown`,
+      `${dir}${sep}${cleaned}`,
     ];
     for (const c of candidates) {
       try {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,14 +25,18 @@ import {
   getAIConfig,
   getLastFile,
   getSavedViewMode,
+  getSpellCheck,
   getSplitRatio,
   getToolbarEnabled,
   getTypewriterMode,
+  getWordWrap,
   setLastFile,
   setSavedViewMode,
+  setSpellCheck,
   setSplitRatio,
   setToolbarEnabled,
   setTypewriterMode,
+  setWordWrap,
 } from "./utils/persistence";
 
 interface FileData {
@@ -66,6 +70,8 @@ function AppContent() {
   const [aiConfig, setAiConfigState] = useState(() => getAIConfig());
   const [typewriterModeEnabled, setTypewriterModeEnabled] = useState<boolean>(() => getTypewriterMode());
   const [toolbarVisible, setToolbarVisible] = useState<boolean>(() => getToolbarEnabled());
+  const [wordWrapEnabled, setWordWrapEnabled] = useState<boolean>(() => getWordWrap());
+  const [spellCheckEnabled, setSpellCheckEnabled] = useState<boolean>(() => getSpellCheck());
   const [cursorPosition, setCursorPosition] = useState({ line: 1, col: 1 });
   const [isLoading, setIsLoading] = useState(false);
 
@@ -161,12 +167,16 @@ function AppContent() {
 
   useEffect(() => { setTypewriterMode(typewriterModeEnabled); }, [typewriterModeEnabled]);
   useEffect(() => { setToolbarEnabled(toolbarVisible); }, [toolbarVisible]);
+  useEffect(() => { setWordWrap(wordWrapEnabled); }, [wordWrapEnabled]);
+  useEffect(() => { setSpellCheck(spellCheckEnabled); }, [spellCheckEnabled]);
 
   // Cross-component event listeners — settings menu and command palette toggle these
   useEffect(() => {
     const handlers: Array<[string, (e: Event) => void]> = [
       ["marklite:typewriter-toggle", (e) => setTypewriterModeEnabled(!!(e as CustomEvent).detail?.enabled)],
       ["marklite:toolbar-toggle", (e) => setToolbarVisible(!!(e as CustomEvent).detail?.enabled)],
+      ["marklite:wordwrap-toggle", (e) => setWordWrapEnabled(!!(e as CustomEvent).detail?.enabled)],
+      ["marklite:spellcheck-toggle", (e) => setSpellCheckEnabled(!!(e as CustomEvent).detail?.enabled)],
     ];
     handlers.forEach(([k, h]) => window.addEventListener(k, h));
 
@@ -781,6 +791,8 @@ function AppContent() {
                 registerScroller={registerCodeScroller}
                 typewriterMode={typewriterModeEnabled}
                 showToolbar={toolbarVisible}
+                wordWrap={wordWrapEnabled}
+                spellCheck={spellCheckEnabled}
                 aiConfig={aiConfig}
               />
             </div>

--- a/src/components/AIBubble.tsx
+++ b/src/components/AIBubble.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { runAIAction, type AIAction, type AIConfig } from "../utils/aiAssist";
 
 interface AIBubbleProps {
@@ -27,6 +27,8 @@ export function AIBubble({ anchor, selectedText, config, onReplace, onInsert, on
     const [result, setResult] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
     const abortRef = useRef<AbortController | null>(null);
+    const bubbleRef = useRef<HTMLDivElement>(null);
+    const [adjusted, setAdjusted] = useState<{ left: number; top: number } | null>(null);
 
     useEffect(() => {
         if (!anchor) {
@@ -36,6 +38,27 @@ export function AIBubble({ anchor, selectedText, config, onReplace, onInsert, on
             abortRef.current?.abort();
         }
     }, [anchor]);
+
+    // Reposition the bubble so it stays inside the viewport. Recomputed when
+    // the anchor moves or after a result/error appears (which changes height).
+    useLayoutEffect(() => {
+        if (!anchor || !bubbleRef.current) return;
+        const margin = 8;
+        const rect = bubbleRef.current.getBoundingClientRect();
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+        let left = anchor.x;
+        let top = anchor.y;
+        if (left + rect.width + margin > vw) left = Math.max(margin, vw - rect.width - margin);
+        if (left < margin) left = margin;
+        if (top + rect.height + margin > vh) {
+            // Flip above the anchor when there's no room below.
+            const flipped = anchor.y - rect.height - 24;
+            top = flipped > margin ? flipped : Math.max(margin, vh - rect.height - margin);
+        }
+        if (top < margin) top = margin;
+        setAdjusted({ left, top });
+    }, [anchor, result, error, busy]);
 
     if (!anchor) return null;
 
@@ -58,10 +81,18 @@ export function AIBubble({ anchor, selectedText, config, onReplace, onInsert, on
 
     return (
         <div
+            ref={bubbleRef}
             role="dialog"
             aria-label="AI assist"
             className="fixed z-[90] bg-[var(--bg-secondary)] border border-[var(--border)] rounded-[var(--radius-md)] shadow-2xl animate-fade-in"
-            style={{ left: anchor.x, top: anchor.y, maxWidth: 380 }}
+            style={{
+                left: adjusted?.left ?? anchor.x,
+                top: adjusted?.top ?? anchor.y,
+                maxWidth: 380,
+                // Hide flicker on first measure: if we haven't adjusted yet,
+                // render off-screen-but-painted so the layout pass can size us.
+                visibility: adjusted ? "visible" : "hidden",
+            }}
         >
             <div className="flex items-center gap-1 px-1 py-1 border-b border-[var(--border-subtle)]">
                 {ACTIONS.filter((a) => !a.needsSelection || selectedText).map((a) => (

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -28,6 +28,8 @@ interface CodeEditorProps {
     registerScroller?: (scroller: Scroller | null) => void;
     typewriterMode?: boolean;
     showToolbar?: boolean;
+    wordWrap?: boolean;
+    spellCheck?: boolean;
     aiConfig?: { endpoint: string; model: string; apiKey: string };
 }
 
@@ -56,7 +58,13 @@ const sharedTextStyle: React.CSSProperties = {
     boxSizing: "border-box",
 };
 
-export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath, onScrollFraction, registerScroller, typewriterMode, showToolbar, aiConfig }: CodeEditorProps) {
+export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath, onScrollFraction, registerScroller, typewriterMode, showToolbar, wordWrap = true, spellCheck = false, aiConfig }: CodeEditorProps) {
+    // When word wrap is on, long lines wrap inside the editor and the highlight
+    // overlay; when off, lines scroll horizontally. Both layers must agree on
+    // these styles or the caret will visually drift away from the rendered text.
+    const wrapStyle: React.CSSProperties = wordWrap
+        ? { whiteSpace: "pre-wrap", wordBreak: "break-word", overflowWrap: "anywhere" }
+        : { whiteSpace: "pre", wordBreak: "normal", overflowWrap: "normal" };
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const gutterRef = useRef<HTMLDivElement>(null);
     const highlightRef = useRef<HTMLDivElement>(null);
@@ -703,7 +711,10 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                 />
             )}
             <div className="flex flex-1 overflow-hidden relative">
-            {/* Line Numbers Gutter */}
+            {/* Line Numbers Gutter — hidden in word-wrap mode because wrapped
+                lines occupy multiple visual rows, so per-source-line numbers
+                would no longer align with the editor content. */}
+            {!wordWrap && (
             <div
                 ref={gutterRef}
                 className="w-14 shrink-0 bg-[var(--bg-gutter)] border-r border-[var(--border-subtle)] no-select text-xs text-[var(--text-muted)] overflow-hidden transition-colors"
@@ -731,39 +742,49 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                     })}
                 </div>
             </div>
+            )}
 
             {/* Editor Container */}
             <div className="flex-1 relative bg-[var(--bg-editor)] transition-colors">
                 {/* Syntax Highlighted Layer (visual only).
                     Active-line band lives inside this scroll container so it tracks
-                    scroll naturally — no JS scrollTop math required. */}
+                    scroll naturally — no JS scrollTop math required.
+                    When wordWrap is on, per-line divs use minHeight (so wrapped
+                    content can grow) and the active-line band is suppressed,
+                    since its fixed Y assumes uniform line heights. */}
                 <div
                     ref={highlightRef}
                     className="absolute inset-0 text-[var(--text-primary)] pointer-events-none overflow-hidden"
                     aria-hidden="true"
-                    style={sharedTextStyle}
+                    style={{ ...sharedTextStyle, ...wrapStyle }}
                 >
-                    <div
-                        className="absolute left-0 right-0 pointer-events-none"
-                        style={{
-                            top: `${EDITOR_PADDING + (activeLine - 1) * EDITOR_LINE_HEIGHT}px`,
-                            height: `${EDITOR_LINE_HEIGHT}px`,
-                            background: "var(--bg-hover)",
-                            opacity: 0.45,
-                        }}
-                    />
-                    {highlightedLines.map((highlighted, i) => (
+                    {!wordWrap && (
                         <div
-                            key={i}
+                            className="absolute left-0 right-0 pointer-events-none"
                             style={{
+                                top: `${EDITOR_PADDING + (activeLine - 1) * EDITOR_LINE_HEIGHT}px`,
                                 height: `${EDITOR_LINE_HEIGHT}px`,
-                                lineHeight: `${EDITOR_LINE_HEIGHT}px`,
-                                position: "relative",
+                                background: "var(--bg-hover)",
+                                opacity: 0.45,
                             }}
-                        >
-                            {highlighted}
-                        </div>
-                    ))}
+                        />
+                    )}
+                    {highlightedLines.map((highlighted, i) => {
+                        const lineSizing: React.CSSProperties = wordWrap
+                            ? { minHeight: `${EDITOR_LINE_HEIGHT}px`, lineHeight: `${EDITOR_LINE_HEIGHT}px` }
+                            : { height: `${EDITOR_LINE_HEIGHT}px`, lineHeight: `${EDITOR_LINE_HEIGHT}px` };
+                        return (
+                            <div
+                                key={i}
+                                style={{
+                                    ...lineSizing,
+                                    position: "relative",
+                                }}
+                            >
+                                {highlighted}
+                            </div>
+                        );
+                    })}
                 </div>
 
                 <FindReplaceBar
@@ -813,20 +834,23 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
                     />
                 )}
 
-                {/* Actual Editable Textarea — transparent text, real caret. */}
+                {/* Actual Editable Textarea — transparent text, real caret.
+                    Caret color stays opaque so users see *where* they're typing,
+                    even though the glyphs themselves are rendered by the overlay. */}
                 <textarea
                     ref={textareaRef}
                     value={content}
                     onChange={handleChange}
                     onPaste={handlePaste}
                     onKeyDown={onKeyDown}
-                    spellCheck={false}
+                    spellCheck={spellCheck}
                     autoComplete="off"
-                    autoCorrect="off"
+                    autoCorrect={spellCheck ? "on" : "off"}
                     autoCapitalize="off"
                     className="absolute inset-0 w-full h-full bg-transparent text-transparent caret-[var(--accent)] resize-none outline-none overflow-auto border-0"
                     style={{
                         ...sharedTextStyle,
+                        ...wrapStyle,
                         caretColor: "var(--accent)",
                     }}
                 />

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -3,6 +3,7 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { readFile } from "@tauri-apps/plugin-fs";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { parseFrontmatter, serializeFrontmatter, type FrontmatterValue } from "../utils/frontmatter";
 import type { Scroller } from "../utils/scrollSync";
 import { MermaidBlock, isMermaidLanguage } from "./MermaidBlock";
@@ -509,7 +510,27 @@ export function MarkdownPreview({
                     </a>
                 );
             }
-            return <a href={href} {...rest}>{children}</a>;
+            // External http(s) and mailto links — route through the OS default
+            // handler so the webview itself doesn't navigate away from the app.
+            const isExternal = !!href && /^(https?:|mailto:)/i.test(href);
+            return (
+                <a
+                    href={href}
+                    {...rest}
+                    {...(isExternal
+                        ? { rel: "noopener noreferrer", target: "_blank" }
+                        : {})}
+                    onClick={(e) => {
+                        if (!isExternal || !href) return;
+                        e.preventDefault();
+                        openUrl(href).catch((err) =>
+                            console.error("Failed to open external URL:", err)
+                        );
+                    }}
+                >
+                    {children}
+                </a>
+            );
         },
         pre: (props: React.HTMLAttributes<HTMLPreElement>) => <CodeBlock {...props} />,
         h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => <HeadingWithAnchor level={1} {...props} />,

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -4,8 +4,11 @@ import {
     getTypewriterMode, setTypewriterMode,
     getToolbarEnabled, setToolbarEnabled,
     getAIConfig, setAIConfig,
+    getWordWrap, setWordWrap,
+    getSpellCheck, setSpellCheck,
 } from "../utils/persistence";
 import { attachFocusTrap } from "../utils/focusTrap";
+import { isValidEndpoint } from "../utils/aiAssist";
 
 interface SettingsModalProps {
     isOpen: boolean;
@@ -77,8 +80,11 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
 
     const [typewriter, setTypewriterLocal] = useState(getTypewriterMode);
     const [toolbar, setToolbarLocal] = useState(getToolbarEnabled);
+    const [wordWrap, setWordWrapLocal] = useState(getWordWrap);
+    const [spellCheck, setSpellCheckLocal] = useState(getSpellCheck);
 
     const [ai, setAi] = useState(getAIConfig);
+    const aiEndpointInvalid = ai.endpoint.length > 0 && !isValidEndpoint(ai.endpoint);
 
     const fire = (event: string, enabled: boolean) =>
         window.dispatchEvent(new CustomEvent(event, { detail: { enabled } }));
@@ -231,6 +237,14 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                     <ToggleRow label="Show formatting toolbar" description="Toolbar above the editor" checked={toolbar}
                                         onChange={(v) => { setToolbarLocal(v); setToolbarEnabled(v); fire("marklite:toolbar-toggle", v); }} />
                                 )}
+                                {matches("word wrap") && (
+                                    <ToggleRow label="Word wrap" description="Wrap long lines instead of horizontal scroll" checked={wordWrap}
+                                        onChange={(v) => { setWordWrapLocal(v); setWordWrap(v); fire("marklite:wordwrap-toggle", v); }} />
+                                )}
+                                {matches("spell check") && (
+                                    <ToggleRow label="Spell check" description="Underline misspelled words while you type" checked={spellCheck}
+                                        onChange={(v) => { setSpellCheckLocal(v); setSpellCheck(v); fire("marklite:spellcheck-toggle", v); }} />
+                                )}
                             </>
                         )}
 
@@ -246,10 +260,14 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                             type="url"
                                             value={ai.endpoint}
                                             onChange={(e) => setAi({ ...ai, endpoint: e.target.value })}
-                                            onBlur={() => setAIConfig(ai)}
+                                            onBlur={() => { if (!aiEndpointInvalid) setAIConfig(ai); }}
                                             placeholder="https://api.openai.com/v1/chat/completions"
-                                            className="mt-1 w-full px-3 py-2 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-md)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)] font-mono"
+                                            aria-invalid={aiEndpointInvalid}
+                                            className={`mt-1 w-full px-3 py-2 text-sm bg-[var(--bg-input)] border rounded-[var(--radius-md)] text-[var(--text-primary)] outline-none font-mono ${aiEndpointInvalid ? "border-[var(--danger)] focus:border-[var(--danger)]" : "border-[var(--border)] focus:border-[var(--accent)]"}`}
                                         />
+                                        {aiEndpointInvalid && (
+                                            <span className="block mt-1 text-[11px] text-[var(--danger)]">Must be a valid http:// or https:// URL.</span>
+                                        )}
                                     </label>
                                     <label className="block">
                                         <span className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider">Model</span>
@@ -274,7 +292,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                         />
                                     </label>
                                     <p className="text-[11px] text-[var(--text-muted)]">
-                                        Stored in localStorage on this machine only. Use a local provider (e.g. Ollama at <code>http://localhost:11434/v1</code>) for full privacy.
+                                        Stored in localStorage on this machine only — <strong>not encrypted</strong>. Anyone with access to your user profile can read it. Use a local provider (e.g. Ollama at <code>http://localhost:11434/v1/chat/completions</code>) for full privacy.
                                     </p>
                                 </div>
                             </>

--- a/src/components/StatsDialog.tsx
+++ b/src/components/StatsDialog.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useMemo, useRef } from "react";
+import { computeStats } from "../utils/documentStats";
+import { attachFocusTrap } from "../utils/focusTrap";
+
+interface StatsDialogProps {
+    isOpen: boolean;
+    content: string;
+    onClose: () => void;
+}
+
+const formatReadingTime = (min: number): string => {
+    if (min < 1) return "< 1 min";
+    if (min < 60) return `${Math.round(min)} min`;
+    const hours = Math.floor(min / 60);
+    const rem = Math.round(min % 60);
+    return rem === 0 ? `${hours}h` : `${hours}h ${rem}m`;
+};
+
+export function StatsDialog({ isOpen, content, onClose }: StatsDialogProps) {
+    const dialogRef = useRef<HTMLDivElement>(null);
+
+    const stats = useMemo(() => (isOpen ? computeStats(content) : null), [isOpen, content]);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                e.preventDefault();
+                onClose();
+            }
+        };
+        document.addEventListener("keydown", onKey);
+        const detach = attachFocusTrap(dialogRef.current);
+        return () => {
+            document.removeEventListener("keydown", onKey);
+            detach();
+        };
+    }, [isOpen, onClose]);
+
+    if (!isOpen || !stats) return null;
+
+    const rows: Array<[string, string]> = [
+        ["Words", stats.words.toLocaleString()],
+        ["Characters", stats.chars.toLocaleString()],
+        ["Characters (no spaces)", stats.charsNoSpaces.toLocaleString()],
+        ["Sentences", stats.sentences.toLocaleString()],
+        ["Paragraphs", stats.paragraphs.toLocaleString()],
+        ["Lines", stats.lines.toLocaleString()],
+        ["Headings", stats.headings.toLocaleString()],
+        ["Links", stats.links.toLocaleString()],
+        ["Images", stats.images.toLocaleString()],
+        ["Code blocks", stats.codeBlocks.toLocaleString()],
+        ["Reading time", formatReadingTime(stats.readingTimeMin)],
+    ];
+
+    return (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center" role="dialog" aria-modal="true" aria-label="Document statistics">
+            <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} aria-hidden="true" />
+            <div
+                ref={dialogRef}
+                className="relative z-10 w-[420px] max-w-[92vw] bg-[var(--bg-primary)] border border-[var(--border)] rounded-[var(--radius-lg)] shadow-2xl overflow-hidden animate-fade-in"
+            >
+                <header className="flex items-center justify-between px-5 py-3 border-b border-[var(--border)]">
+                    <h2 className="text-base font-semibold text-[var(--text-primary)]">Document statistics</h2>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        aria-label="Close statistics"
+                        className="w-7 h-7 rounded-[var(--radius-sm)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] flex items-center justify-center transition-colors"
+                    >
+                        <span className="material-symbols-outlined text-[18px]">close</span>
+                    </button>
+                </header>
+                <dl className="px-5 py-4 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                    {rows.map(([label, value]) => (
+                        <div key={label} className="contents">
+                            <dt className="text-[var(--text-secondary)]">{label}</dt>
+                            <dd className="text-right font-mono text-[var(--text-primary)] tabular-nums">{value}</dd>
+                        </div>
+                    ))}
+                </dl>
+                <footer className="px-5 py-2 text-[11px] text-[var(--text-muted)] border-t border-[var(--border-subtle)] bg-[var(--bg-secondary)]">
+                    Reading time assumes ~200 words per minute. Code blocks and frontmatter are excluded from word and sentence counts.
+                </footer>
+            </div>
+        </div>
+    );
+}

--- a/src/utils/aiAssist.ts
+++ b/src/utils/aiAssist.ts
@@ -27,6 +27,16 @@ export interface AIConfig {
     apiKey: string;
 }
 
+/** True when the URL is well-formed and uses http(s). */
+export function isValidEndpoint(raw: string): boolean {
+    try {
+        const u = new URL(raw);
+        return u.protocol === "http:" || u.protocol === "https:";
+    } catch {
+        return false;
+    }
+}
+
 export async function runAIAction(
     action: AIAction,
     text: string,
@@ -34,6 +44,9 @@ export async function runAIAction(
     signal?: AbortSignal
 ): Promise<string> {
     if (!cfg.endpoint) throw new Error("AI endpoint not configured. Open Settings → AI to set one up.");
+    if (!isValidEndpoint(cfg.endpoint)) {
+        throw new Error("AI endpoint must be a valid http:// or https:// URL.");
+    }
     if (!cfg.model) throw new Error("AI model not configured.");
 
     const res = await fetch(cfg.endpoint, {

--- a/src/utils/documentStats.ts
+++ b/src/utils/documentStats.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure markdown-document statistics. Strips frontmatter and code blocks before
+ * counting prose-y things (words, sentences) so a fenced code listing doesn't
+ * inflate the word count. Counts of structural elements (headings, links, etc.)
+ * are taken from the raw source instead.
+ */
+
+export interface DocumentStats {
+    chars: number;
+    charsNoSpaces: number;
+    words: number;
+    sentences: number;
+    paragraphs: number;
+    lines: number;
+    headings: number;
+    links: number;
+    images: number;
+    codeBlocks: number;
+    readingTimeMin: number;
+}
+
+const stripFrontmatter = (s: string): string => s.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
+const stripFencedCode = (s: string): string => s.replace(/```[\s\S]*?```/g, "");
+const stripInlineCode = (s: string): string => s.replace(/`[^`\n]*`/g, "");
+
+export function computeStats(source: string): DocumentStats {
+    const lines = source.length === 0 ? 0 : source.split("\n").length;
+
+    const body = stripFrontmatter(source);
+    const prose = stripInlineCode(stripFencedCode(body));
+
+    const trimmed = prose.trim();
+    const words = trimmed.length === 0 ? 0 : trimmed.split(/\s+/).length;
+
+    // Sentences: split on . ! ? followed by whitespace or end. Imperfect but
+    // good enough for an editor stats panel.
+    const sentenceMatches = trimmed.match(/[^.!?\n]+[.!?]+/g);
+    const sentences = sentenceMatches ? sentenceMatches.length : (trimmed.length > 0 ? 1 : 0);
+
+    const paragraphs = trimmed.length === 0
+        ? 0
+        : trimmed.split(/\n\s*\n+/).filter((p) => p.trim().length > 0).length;
+
+    const headings = (body.match(/^#{1,6}\s+\S/gm) || []).length;
+    // Markdown links — exclude images by requiring no leading `!`.
+    const links = (body.match(/(?<!\!)\[[^\]\n]*\]\([^)\n]+\)/g) || []).length;
+    const images = (body.match(/!\[[^\]\n]*\]\([^)\n]+\)/g) || []).length;
+    const codeBlocks = ((body.match(/```/g) || []).length / 2) | 0;
+
+    return {
+        chars: source.length,
+        charsNoSpaces: source.replace(/\s/g, "").length,
+        words,
+        sentences,
+        paragraphs,
+        lines,
+        headings,
+        links,
+        images,
+        codeBlocks,
+        readingTimeMin: words / 200,
+    };
+}

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -69,12 +69,18 @@ export const setAutoSave = (v: boolean): void => safeSet(KEY_AUTOSAVE, v);
 const KEY_FOCUS_MODE = "marklite:focusMode";
 const KEY_TYPEWRITER_MODE = "marklite:typewriterMode";
 const KEY_TOOLBAR = "marklite:toolbar";
+const KEY_WORD_WRAP = "marklite:wordWrap";
+const KEY_SPELL_CHECK = "marklite:spellCheck";
 export const getFocusMode = (): boolean => safeGet<boolean>(KEY_FOCUS_MODE, false);
 export const setFocusMode = (v: boolean): void => safeSet(KEY_FOCUS_MODE, v);
 export const getTypewriterMode = (): boolean => safeGet<boolean>(KEY_TYPEWRITER_MODE, false);
 export const setTypewriterMode = (v: boolean): void => safeSet(KEY_TYPEWRITER_MODE, v);
 export const getToolbarEnabled = (): boolean => safeGet<boolean>(KEY_TOOLBAR, false);
 export const setToolbarEnabled = (v: boolean): void => safeSet(KEY_TOOLBAR, v);
+export const getWordWrap = (): boolean => safeGet<boolean>(KEY_WORD_WRAP, true);
+export const setWordWrap = (v: boolean): void => safeSet(KEY_WORD_WRAP, v);
+export const getSpellCheck = (): boolean => safeGet<boolean>(KEY_SPELL_CHECK, false);
+export const setSpellCheck = (v: boolean): void => safeSet(KEY_SPELL_CHECK, v);
 
 const KEY_AI_ENDPOINT = "marklite:aiEndpoint";
 const KEY_AI_MODEL = "marklite:aiModel";


### PR DESCRIPTION
## Summary
- **Security**: block path traversal in wikilink resolution and the Rust `save_image` filename; route external markdown links through `tauri-plugin-opener` so the webview can no longer be navigated away from the app; reject non-`http(s)` AI endpoints with inline validation in Settings; flag the AI key as unencrypted at rest.
- **Features**: word-wrap and spell-check toggles for the editor (Settings → Editor); document statistics dialog (words / chars / sentences / paragraphs / structural counts / reading time); command palette gains "Reveal in folder" and "Copy file path".
- **UX**: AI assist bubble repositions to stay inside the viewport and flips above the anchor when there is no room below.

## Test plan
- [x] `bun run build` (TypeScript + Vite) — clean
- [x] `cargo check` in `src-tauri` — clean
- [x] `cargo test --lib` — new `sanitize_image_name` tests pass
- [x] Manual: open a `.md`, toggle word wrap / spell check, run all new commands from Ctrl+P, exercise wikilinks (valid and `[[../../etc/passwd]]`), paste an external link and click it