### PR TITLE
feat(offline): bundle all fonts and icons locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — Offline support
+
+- All UI fonts (Inter, JetBrains Mono, Merriweather, Lora, Source Serif 4,
+  Fira Sans) and the Material Symbols Outlined icon font are now bundled
+  with the app via `@fontsource/*` and `material-symbols`. The
+  `<link rel="stylesheet" href="https://fonts.googleapis.com/...">`
+  tags have been removed from `index.html`, so the editor renders identically
+  online and offline — no more "icon shows as text" while waiting for the CDN
+  on a slow connection.
+- Tauri CSP tightened: `style-src` no longer whitelists
+  `https://fonts.googleapis.com` and `font-src` no longer whitelists
+  `https://fonts.gstatic.com`. Fonts may now load only from `self` (the
+  bundled woff2 files) plus `data:` URLs (used by some embedded SVG icons).
+- HTML export drops the Google Fonts `@import`. The export now relies on
+  font-family fallbacks (system sans/serif/mono) so exporting succeeds
+  offline and the resulting file renders predictably anywhere.
+
 ### Added
 
 - Word wrap toggle for the editor (Settings → Editor; default on). Wrapped

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,12 @@
     "": {
       "name": "marklite",
       "dependencies": {
+        "@fontsource/fira-sans": "^5.2.7",
+        "@fontsource/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
+        "@fontsource/lora": "^5.2.8",
+        "@fontsource/merriweather": "^5.2.11",
+        "@fontsource/source-serif-4": "^5.2.9",
         "@tailwindcss/vite": "^4.1.18",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.4.2",
@@ -12,6 +18,7 @@
         "@tauri-apps/plugin-opener": "^2",
         "jspdf": "^4.0.0",
         "katex": "^0.16.45",
+        "material-symbols": "^0.44.6",
         "mermaid": "^11.14.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -143,6 +150,18 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
+
+    "@fontsource/fira-sans": ["@fontsource/fira-sans@5.2.7", "", {}, "sha512-5DE4AealD/VnbwdzMgnpWfCttMQBbteNiK9DCJE7cVwZEbDTPLUoFDMMvxNQ498nZc5in7Mta9c/s+3Ehh0BAg=="],
+
+    "@fontsource/inter": ["@fontsource/inter@5.2.8", "", {}, "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg=="],
+
+    "@fontsource/jetbrains-mono": ["@fontsource/jetbrains-mono@5.2.8", "", {}, "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ=="],
+
+    "@fontsource/lora": ["@fontsource/lora@5.2.8", "", {}, "sha512-AQlfsHw4TP1x/eb2IZ6VjQ70ctKa39m9JN9A4zlvDOeKYLrCs+GaYIEQ86Y6YfSPGHn01bErXkRcyktOW0LOPQ=="],
+
+    "@fontsource/merriweather": ["@fontsource/merriweather@5.2.11", "", {}, "sha512-ZiIMeUh5iT8d73o6xlSF8GKgjV5pgiFrufYc5jZTVAfExtWKqM2vQHnsqXSFMv4ELhAcjt6Vf+5T3oVGXhAizQ=="],
+
+    "@fontsource/source-serif-4": ["@fontsource/source-serif-4@5.2.9", "", {}, "sha512-er/Pym9emsEVJNf947umJ4kXarXfsiN6CN7kTYinefKRaHLwiquiiHOZvKvxWgkV8JMCf3pV3g0NcsPFpVCH9w=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
@@ -687,6 +706,8 @@
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
     "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "material-symbols": ["material-symbols@0.44.6", "", {}, "sha512-yEUZESJjKeVigMY2HCXZKEPhhVWdchzKsJ5u8YeTUBpov7oJCTVq9K2VA+uieeRYDf8L5QRgGANXZZmjXUWXZw=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 

--- a/index.html
+++ b/index.html
@@ -5,12 +5,8 @@
     <link rel="icon" type="image/png" href="/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MarkLite</title>
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&family=Merriweather:wght@300;400;700&family=Lora:wght@400;500;600;700&family=Source+Serif+4:wght@300;400;500;600;700&family=Fira+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
-    <!-- Material Symbols -->
-    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet" />
+    <!-- Fonts and Material Symbols are bundled locally via src/fonts.ts so the
+         app renders identically with or without an internet connection. -->
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@fontsource/fira-sans": "^5.2.7",
+    "@fontsource/inter": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/lora": "^5.2.8",
+    "@fontsource/merriweather": "^5.2.11",
+    "@fontsource/source-serif-4": "^5.2.9",
     "@tailwindcss/vite": "^4.1.18",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.4.2",
@@ -17,6 +23,7 @@
     "@tauri-apps/plugin-opener": "^2",
     "jspdf": "^4.0.0",
     "katex": "^0.16.45",
+    "material-symbols": "^0.44.6",
     "mermaid": "^11.14.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1932,7 +1932,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "marklite"
-version = "0.6.2"
+version = "0.6.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' https://asset.localhost asset:; img-src 'self' asset: https://asset.localhost blob: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; script-src 'self'",
+      "csp": "default-src 'self' https://asset.localhost asset:; img-src 'self' asset: https://asset.localhost blob: data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self'",
       "assetProtocol": {
         "enable": true,
         "scope": [

--- a/src/fonts.ts
+++ b/src/fonts.ts
@@ -1,0 +1,57 @@
+/**
+ * Local-only font loading. Every font face the app uses is bundled with the
+ * app — no requests to fonts.googleapis.com / fonts.gstatic.com — so MarkLite
+ * looks identical with or without an internet connection.
+ *
+ * We import the `latin-*` CSS files from each @fontsource package because they
+ * register only the latin subset's @font-face. That keeps the bundled woff2
+ * footprint reasonable while still covering the full ASCII + western-European
+ * character set the editor / preview ever displays. Each import resolves to a
+ * woff2 URL that Vite fingerprints and copies into `dist/assets/`.
+ *
+ * Weights match the set the previous Google Fonts <link> tag pulled, so the
+ * UI renders byte-identical to before — just served from disk.
+ */
+
+// Inter — primary sans (Settings → Appearance default)
+import "@fontsource/inter/latin-300.css";
+import "@fontsource/inter/latin-400.css";
+import "@fontsource/inter/latin-500.css";
+import "@fontsource/inter/latin-600.css";
+import "@fontsource/inter/latin-700.css";
+import "@fontsource/inter/latin-800.css";
+
+// JetBrains Mono — code editor + inline `code`
+import "@fontsource/jetbrains-mono/latin-400.css";
+import "@fontsource/jetbrains-mono/latin-500.css";
+
+// Merriweather — serif option
+import "@fontsource/merriweather/latin-300.css";
+import "@fontsource/merriweather/latin-400.css";
+import "@fontsource/merriweather/latin-700.css";
+
+// Lora — serif option
+import "@fontsource/lora/latin-400.css";
+import "@fontsource/lora/latin-500.css";
+import "@fontsource/lora/latin-600.css";
+import "@fontsource/lora/latin-700.css";
+
+// Source Serif 4 — serif option
+import "@fontsource/source-serif-4/latin-300.css";
+import "@fontsource/source-serif-4/latin-400.css";
+import "@fontsource/source-serif-4/latin-500.css";
+import "@fontsource/source-serif-4/latin-600.css";
+import "@fontsource/source-serif-4/latin-700.css";
+
+// Fira Sans — sans option
+import "@fontsource/fira-sans/latin-300.css";
+import "@fontsource/fira-sans/latin-400.css";
+import "@fontsource/fira-sans/latin-500.css";
+import "@fontsource/fira-sans/latin-600.css";
+import "@fontsource/fira-sans/latin-700.css";
+
+// Material Symbols Outlined — every UI icon. The package ships the variable
+// woff2 with the wght axis (100..700); FILL/GRAD/opsz are tuned via inline
+// `font-variation-settings` in `index.css`, so the same icon glyphs render
+// even when offline.
+import "material-symbols/outlined.css";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+// Bundled fonts — load BEFORE index.css so @font-face declarations are
+// registered before any rule that references the family names. Without this
+// import the app falls back to system fonts when there is no network.
+import "./fonts";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -93,9 +93,14 @@ function generateExportCSS(theme: Theme, font: FontFamily, fontSize: FontSize): 
     const fontFamily = fontFamilies[font];
     const sizes = fontSizes[fontSize];
 
+    // No Google Fonts @import here — exporting must succeed offline, and the
+    // resulting HTML must render reasonably on machines that can't reach the
+    // CDN. The font-family declarations below use the same display names as
+    // the editor (Inter, Merriweather, Lora, Source Serif 4, Fira Sans,
+    // JetBrains Mono); the recipient sees those if installed locally,
+    // otherwise the cascade falls back to a safe system font in the same
+    // genre (sans-serif, serif, or monospace).
     return `
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Merriweather:wght@400;700&family=Lora:wght@400;600;700&family=Source+Serif+4:wght@400;600;700&family=Fira+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
-
         * {
             margin: 0;
             padding: 0;


### PR DESCRIPTION
## Summary

The editor and titlebar icons were loading from Google Fonts at runtime — on a slow connection users would see plain text ("settings", "folder_open", "close") where icons should be, and on no connection the UI fell back to a system font. This PR self-hosts everything so MarkLite renders identically with or without internet, and tightens the CSP to match.

## Changes

### Frontend
- Added `@fontsource` packages for Inter, JetBrains Mono, Merriweather, Lora, Source Serif 4, Fira Sans (same weights as the old `<link>` tag requested) and the `material-symbols` package for the variable-axis icon font.
- New `src/fonts.ts` imports each weight's `latin-*.css` so Vite fingerprints + bundles the woff2 files into `dist/assets/`.
- `main.tsx` imports `./fonts` **before** `./index.css` so `@font-face` declarations register before any rule that references the family names.
- Stripped the four Google Fonts `<link>` / `<preconnect>` tags from `index.html`.

### Tauri
- CSP: dropped `https://fonts.googleapis.com` from `style-src` and `https://fonts.gstatic.com` from `font-src`. `font-src` is now `'self' data:`.

### HTML export
- Removed the `@import url('https://fonts.googleapis.com/...')` from generated stylesheets. The font-family declarations are unchanged but rely on the cascade's system fallback (sans-serif, serif, monospace) when a recipient doesn't have the font installed. Trade-off: exports look slightly different on machines without the fonts, but exporting now succeeds offline.

## Verification
- `bun run build` — clean
- `cargo check` — clean
- `dist/index.html` and `dist/assets/*.css` contain **zero** `googleapis` / `gstatic` references.
- Every `@font-face` `src` in shipped CSS resolves to a local `/assets/*-{hash}.woff2`.
- 26 woff2 files bundled (6 UI fonts × their weights + 1 Material Symbols variable font).

## Test plan
- [x] Pull, `bun install`, `bun run tauri dev`. Disable network. Open a `.md` file. Verify icons render and font choices in Settings → Appearance still apply.
- [x] Build a release (`bun run tauri build`) and run on a machine with no internet.
- [x] Export an HTML file while offline; verify it renders with system-font fallbacks.