### PR TITLE
fix: cursor drift in editor + welcome-screen logo visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/icon.png" />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MarkLite</title>
     <!-- Fonts and Material Symbols are bundled locally via src/fonts.ts so the

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -79,7 +79,14 @@ export function WelcomeScreen({ onOpenFile, onNewFile, onFileDrop, onOpenRecent 
         <main
             onDragOver={handleDragOver}
             onDrop={handleDrop}
-            className="flex-1 flex flex-col items-center justify-center p-6 no-select overflow-y-auto"
+            // `justify-start` (not `justify-center`) plus generous vertical
+            // padding keeps the logo anchored at the top of the visible area
+            // when the Recents list grows tall enough for the page to scroll.
+            // With `justify-center` + `overflow-y-auto` the centered content
+            // can be taller than the viewport, which causes flexbox to push
+            // the top edge (the logo) above the scrollable area — invisible
+            // unless the user scrolls up.
+            className="flex-1 flex flex-col items-center justify-start py-10 px-6 no-select overflow-y-auto"
         >
             <div className="flex flex-col items-center gap-8 max-w-md w-full text-center animate-fade-in-up">
                 <div className="flex items-center justify-center w-20 h-20">

--- a/src/fonts.ts
+++ b/src/fonts.ts
@@ -21,9 +21,48 @@ import "@fontsource/inter/latin-600.css";
 import "@fontsource/inter/latin-700.css";
 import "@fontsource/inter/latin-800.css";
 
-// JetBrains Mono — code editor + inline `code`
-import "@fontsource/jetbrains-mono/latin-400.css";
-import "@fontsource/jetbrains-mono/latin-500.css";
+// JetBrains Mono — code editor + inline `code`. NOT loaded via the @fontsource
+// CSS file because that uses `font-display: swap`, which makes the editor
+// glyphs swap from a fallback monospace (e.g. Consolas) to JetBrains Mono once
+// the woff2 finishes downloading. The textarea's caret position is computed
+// against whatever font the textarea is currently rendering with, while the
+// syntax-highlight overlay re-flows simultaneously with slightly different
+// glyph advance widths — leaving the caret visually offset from the rendered
+// text. We override to `font-display: block` so the editor never paints in a
+// fallback metric: text is hidden for at most ~3s while the (already bundled,
+// near-instant) woff2 loads, and once shown it never reflows again.
+import jetbrainsMono400Url from "@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff2?url";
+import jetbrainsMono500Url from "@fontsource/jetbrains-mono/files/jetbrains-mono-latin-500-normal.woff2?url";
+
+const jetbrainsMonoFaces = `
+@font-face {
+    font-family: 'JetBrains Mono';
+    font-style: normal;
+    font-display: block;
+    font-weight: 400;
+    src: url(${jetbrainsMono400Url}) format('woff2');
+}
+@font-face {
+    font-family: 'JetBrains Mono';
+    font-style: normal;
+    font-display: block;
+    font-weight: 500;
+    src: url(${jetbrainsMono500Url}) format('woff2');
+}`;
+
+if (typeof document !== "undefined") {
+    const style = document.createElement("style");
+    style.setAttribute("data-marklite-fonts", "jetbrains-mono");
+    style.textContent = jetbrainsMonoFaces;
+    document.head.appendChild(style);
+    // Eagerly kick off the font load so the editor doesn't sit blank for any
+    // perceptible window. With `block` display the page would still wait up to
+    // ~3s of natural browser timing; this gets us closer to ~50ms.
+    if (document.fonts && typeof document.fonts.load === "function") {
+        document.fonts.load("400 14px 'JetBrains Mono'").catch(() => {});
+        document.fonts.load("500 14px 'JetBrains Mono'").catch(() => {});
+    }
+}
 
 // Merriweather — serif option
 import "@fontsource/merriweather/latin-300.css";


### PR DESCRIPTION
## Summary

Two issues from the offline-fonts migration (PR #26).

### 1. Editor caret/glyph drift

The `@fontsource/jetbrains-mono` CSS uses `font-display: swap`. So when the editor first painted, both the textarea and the syntax-highlight overlay rendered in a fallback monospace (e.g. Consolas) — and then both re-flowed to JetBrains Mono once the bundled woff2 loaded. Browsers compute textarea caret position against the *current* font; the overlay re-rendered its glyphs with slightly different advance widths. Net effect: caret visually detached from the typed character.

**Fix:** stop importing the swap-mode `@fontsource` CSS for JetBrains Mono and inject a custom `@font-face` with `font-display: block` at module load (before React renders). With `block`, the editor never paints in a fallback metric: text is simply hidden until the woff2 loads (~tens of ms with a local file), then appears in the final font. `document.fonts.load()` is kicked off eagerly so the block period is as short as possible. UI fonts (Inter, Lora, etc.) keep `swap` because body text drift is invisible to users.

### 2. Welcome screen logo could be invisible

`justify-center` + `overflow-y-auto` is a flexbox trap: when centered content is taller than the viewport (Recents list with several entries on a short window), flexbox pushes the top edge above the scrollable region. The logo was up there, unreachable without scrolling up.

**Fix:** `justify-start` + generous `py-10` so the logo is anchored at the top of the visible area; the rest scrolls naturally. Still feels centered when the content fits.

### 3. Bonus: favicon 404

`index.html` linked `/icon.png` which doesn't exist (only `icon.svg` is in `public/`). Browser was 404-ing on every load. Fixed to `type=image/svg+xml` and the correct path.

## Test plan
- [ ] Pull, `bun install`, `bun run tauri dev`. Type continuously into a fresh file and a long file — caret should always be exactly under the character you just typed.
- [ ] Resize the window to be short (~600px tall). Open a few markdown files to populate Recents. Re-launch app. Welcome screen logo should be visible at the top.
- [ ] DevTools → Network → check that `/icon.png` is no longer requested.