### PR TITLE
fix: quality sweep — 13 audit findings (HIGH + MEDIUM)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1932,7 +1932,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "marklite"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' https://asset.localhost asset:; img-src 'self' asset: https://asset.localhost blob: data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self'",
+      "csp": "default-src 'self' https://asset.localhost asset:; img-src 'self' asset: https://asset.localhost blob: data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self'; connect-src 'self' ipc: https: http://localhost:* http://127.0.0.1:*",
       "assetProtocol": {
         "enable": true,
         "scope": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -227,13 +227,14 @@ function AppContent() {
     ];
     handlers.forEach(([k, h]) => window.addEventListener(k, h));
 
-    // Re-read AI config when settings modal closes — cheap, single localStorage read
-    const onStorage = () => setAiConfigState(getAIConfig());
-    window.addEventListener("storage", onStorage);
+    // Note: there used to be a `storage` event listener here that re-read the
+    // AI config. It was dead code — the spec only fires `storage` events on
+    // OTHER documents/tabs that mutate localStorage, never on the writing
+    // document. The actual refresh path is the explicit `setAiConfigState(
+    // getAIConfig())` call in SettingsModal's onClose, which works correctly.
 
     return () => {
       handlers.forEach(([k, h]) => window.removeEventListener(k, h));
-      window.removeEventListener("storage", onStorage);
     };
   }, []);
 
@@ -249,6 +250,11 @@ function AppContent() {
           setContent(fileData.content);
           setOriginalContent(fileData.content);
           setFileSize(fileData.size);
+          // Bump the recents entry's timestamp to "now" so it sorts as
+          // most-recent. Previously the restored file kept the stale openedAt
+          // from whenever it was originally opened, which made the welcome
+          // screen show "3d ago" for the file you'd just been editing.
+          addRecentFile(fileData.path, fileData.name);
         })
         .catch(() => {
           setLastFile(null);
@@ -258,16 +264,28 @@ function AppContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Latest content + originalContent are read via refs inside `loadFile` so
+  // its identity stays stable across keystrokes. Without this, every typed
+  // character would change `loadFile`'s reference, which would tear down and
+  // re-register the Tauri DRAG_DROP listener, the file-open-from-cli listener,
+  // and the global keydown handler — all of which depend on `loadFile` —
+  // causing per-keystroke listener churn (and a small but real OS-level IPC
+  // round-trip for the Tauri ones).
+  const contentRef = useRef(content);
+  contentRef.current = content;
+  const originalContentRef = useRef(originalContent);
+  originalContentRef.current = originalContent;
+
   // Load file with unsaved changes protection
   const loadFile = useCallback(async (path: string) => {
-    if (content !== originalContent) {
+    if (contentRef.current !== originalContentRef.current) {
       // Has unsaved changes — ask user first
       setPendingFilePath(path);
       setShowUnsavedBeforeOpen(true);
     } else {
       await loadFileDirect(path);
     }
-  }, [content, originalContent, loadFileDirect]);
+  }, [loadFileDirect]);
 
   // New file: clears buffer. Used by handleNewFile and the dialog handlers.
   const startBlankFile = useCallback(() => {
@@ -543,65 +561,73 @@ function AppContent() {
 
   // Hide toast
   const hideToast = useCallback(() => {
-    setToast(prev => ({ ...prev, isVisible: false }));
+    // Bail out when the toast is already hidden — without this guard, a
+    // duplicate hide call (e.g. from a quick second toast cancelling the
+    // first) allocates a fresh object even though `isVisible: false` was
+    // already true, triggering a Toast re-render that schedules a fresh
+    // pair of fade/hide timers.
+    setToast(prev => prev.isVisible ? { ...prev, isVisible: false } : prev);
   }, []);
 
   // Keyboard shortcuts
+  // Keyboard shortcut handler. Mounted once on app start; reads the latest
+  // values for handlers + hasFile/content via a ref so the listener doesn't
+  // need to be removed and re-added on every keystroke (which the previous
+  // dep-array form did because `content` was listed as a dep).
+  const shortcutsRef = useRef({
+    handleOpenFile, handleSaveFile, handleSaveAs, handleNewFile,
+    handleToggleMode, handleToggleSplit, handleToggleFileExplorer, handleToggleTOC,
+    hasFile, content,
+  });
+  shortcutsRef.current = {
+    handleOpenFile, handleSaveFile, handleSaveAs, handleNewFile,
+    handleToggleMode, handleToggleSplit, handleToggleFileExplorer, handleToggleTOC,
+    hasFile, content,
+  };
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      const s = shortcutsRef.current;
       // Ctrl+Shift+E - Toggle file explorer (check before Ctrl+E)
       if (e.ctrlKey && e.shiftKey && e.key === "E") {
         e.preventDefault();
-        if (hasFile) {
-          handleToggleFileExplorer();
-        }
+        if (s.hasFile) s.handleToggleFileExplorer();
         return;
       }
       // Ctrl+Shift+O - Toggle TOC (check before Ctrl+O)
       if (e.ctrlKey && e.shiftKey && e.key === "O") {
         e.preventDefault();
-        if (hasFile) {
-          handleToggleTOC();
-        }
+        if (s.hasFile) s.handleToggleTOC();
         return;
       }
       // Ctrl+O - Open file (without Shift)
       if (e.ctrlKey && !e.shiftKey && e.key === "o") {
         e.preventDefault();
-        handleOpenFile();
+        s.handleOpenFile();
       }
       // Ctrl+S - Save file
       if (e.ctrlKey && !e.shiftKey && e.key === "s") {
         e.preventDefault();
-        if (hasFile || content) {
-          handleSaveFile();
-        }
+        if (s.hasFile || s.content) s.handleSaveFile();
       }
       // Ctrl+Shift+S - Save As
       if (e.ctrlKey && e.shiftKey && (e.key === "s" || e.key === "S")) {
         e.preventDefault();
-        if (hasFile || content) {
-          handleSaveAs();
-        }
+        if (s.hasFile || s.content) s.handleSaveAs();
       }
       // Ctrl+N - New file
       if (e.ctrlKey && !e.shiftKey && e.key === "n") {
         e.preventDefault();
-        handleNewFile();
+        s.handleNewFile();
       }
       // Ctrl+E - Toggle preview/code mode (without Shift)
       if (e.ctrlKey && !e.shiftKey && e.key === "e") {
         e.preventDefault();
-        if (hasFile) {
-          handleToggleMode();
-        }
+        if (s.hasFile) s.handleToggleMode();
       }
       // Ctrl+\ - Toggle split view
       if (e.ctrlKey && !e.shiftKey && e.key === "\\") {
         e.preventDefault();
-        if (hasFile) {
-          handleToggleSplit();
-        }
+        if (s.hasFile) s.handleToggleSplit();
       }
       // ? — Show cheatsheet (only when no input is focused)
       if (e.key === "?" && !e.ctrlKey && !e.metaKey && !e.altKey) {
@@ -626,7 +652,7 @@ function AppContent() {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [handleOpenFile, handleSaveFile, handleSaveAs, handleNewFile, handleToggleMode, handleToggleSplit, handleToggleFileExplorer, handleToggleTOC, hasFile, content]);
+  }, []);
 
   // Get export HTML from the visible preview on demand (avoids duplicate rendering)
   const getExportHtml = useCallback((): string => {
@@ -981,7 +1007,12 @@ function AppContent() {
       )}
 
       <ShortcutCheatsheet isOpen={showCheatsheet} onClose={() => setShowCheatsheet(false)} />
-      <StatsDialog isOpen={showStats} content={deferredContent} onClose={() => setShowStats(false)} />
+      {/* Stats dialog reads LIVE `content`, not the debounced version. The
+          dialog opens on a discrete user action (palette command), not while
+          typing, so the typing-fast-path argument doesn't apply — and a user
+          who opens "Show document statistics" expects the numbers to match
+          what they just typed. */}
+      <StatsDialog isOpen={showStats} content={content} onClose={() => setShowStats(false)} />
       <CommandPalette isOpen={showPalette} items={paletteItems} onClose={() => setShowPalette(false)} />
       <SettingsModal
         isOpen={showSettings}

--- a/src/components/AIBubble.tsx
+++ b/src/components/AIBubble.tsx
@@ -39,6 +39,18 @@ export function AIBubble({ anchor, selectedText, config, onReplace, onInsert, on
         }
     }, [anchor]);
 
+    // Final-cleanup: parents commonly unmount AIBubble outright (e.g. by
+    // setting their own `aiBubble` state to null) instead of toggling `anchor`.
+    // The effect above only fires while the component is alive, so we also
+    // abort here to prevent an in-flight fetch from calling setResult on an
+    // unmounted component (React 18+ no-ops the setState but logs a warning,
+    // and the request itself keeps running until the network resolves).
+    useEffect(() => {
+        return () => {
+            abortRef.current?.abort();
+        };
+    }, []);
+
     // Reposition the bubble so it stays inside the viewport. Recomputed when
     // the anchor moves or after a result/error appears (which changes height).
     useLayoutEffect(() => {

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -49,7 +49,16 @@ const sharedTextStyle: React.CSSProperties = {
     padding: `${EDITOR_PADDING}px`,
     tabSize: EDITOR_TAB_SIZE,
     MozTabSize: EDITOR_TAB_SIZE,
+    // Lock every metric-affecting property to defend the textarea/overlay
+    // alignment guarantee. If a parent rule (theme, body, dialog, etc.) ever
+    // sets bold/italic/etc. on an ancestor, both layers must inherit the SAME
+    // value or the caret will visually offset from the rendered glyph.
+    fontWeight: 400,
+    fontStyle: "normal",
     fontVariantLigatures: "none",
+    fontVariantNumeric: "normal",
+    fontFeatureSettings: "normal",
+    fontVariationSettings: "normal",
     fontKerning: "none",
     letterSpacing: "0px",
     whiteSpace: "pre",
@@ -468,9 +477,14 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
     // re-running `highlightLine` over every line — and minting fresh React
     // elements for the unchanged ones — is wasted work. The cache returns the
     // identical React node for repeat line text; React's reconciler then
-    // short-circuits on `prev === next` and skips the unchanged children. Cache
-    // is per-component-instance so it dies with the editor; pruned when growth
-    // outpaces the visible line count by a comfortable margin.
+    // short-circuits on `prev === next` and skips the unchanged children.
+    //
+    // Cache is per-component-instance and bounded two ways:
+    //   1) HARD CAP via LRU eviction (Map insertion-order). Without this, a
+    //      doc where every line is unique (think 10k lines of UUIDs) would
+    //      grow the cache by `lines.length` per render forever.
+    //   2) Stale-entry pruning when growth outpaces in-use lines by >256.
+    const HIGHLIGHT_CACHE_MAX = 4096;
     const highlightCacheRef = useRef<Map<string, React.ReactNode>>(new Map());
     const highlightedLines = useMemo(() => {
         const cache = highlightCacheRef.current;
@@ -482,6 +496,10 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
             if (node === undefined) {
                 node = highlightLine(line);
                 cache.set(line, node);
+            } else {
+                // Re-insert to mark as MRU.
+                cache.delete(line);
+                cache.set(line, node);
             }
             out[i] = node;
             inUse.add(line);
@@ -490,6 +508,14 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
             for (const key of cache.keys()) {
                 if (!inUse.has(key)) cache.delete(key);
             }
+        }
+        // Hard ceiling regardless of in-use set size: protects against
+        // pathological docs where every line is unique and `inUse` itself is
+        // huge. Evict from the front (LRU) until under the cap.
+        while (cache.size > HIGHLIGHT_CACHE_MAX) {
+            const oldest = cache.keys().next().value;
+            if (oldest === undefined) break;
+            cache.delete(oldest);
         }
         return out;
     }, [lines]);

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -110,10 +110,14 @@ export function CommandPalette({ isOpen, items, onClose }: CommandPaletteProps) 
         return out;
     }, [ranked]);
 
-    // Keep activeIdx valid when results change
+    // Keep activeIdx valid when results change. Functional update so React
+    // bails out via Object.is when no clamp is needed — otherwise this effect
+    // would queue a setState on every render where activeIdx is already in
+    // range, triggering the same setState-in-effect pattern that caused the
+    // earlier "Maximum update depth" crash.
     useEffect(() => {
-        if (activeIdx >= ranked.length) setActiveIdx(0);
-    }, [ranked.length, activeIdx]);
+        setActiveIdx((prev) => (prev >= ranked.length ? 0 : prev));
+    }, [ranked.length]);
 
     // Auto-scroll active row into view
     useEffect(() => {

--- a/src/components/FindReplaceBar.tsx
+++ b/src/components/FindReplaceBar.tsx
@@ -80,11 +80,14 @@ export function FindReplaceBar({
         }
     }, [isOpen, initialMode]);
 
-    // Recompute matches when query or content changes
+    // Recompute matches when query or content changes. Bail out by returning
+    // `prev` when nothing changed — without this, every editor keystroke causes
+    // setMatch to mint a fresh `{ matches: [], activeIdx: -1 }` for an empty
+    // query, which re-renders this dialog (and re-fires the auto-jump effect
+    // below) on every character typed in the editor.
     useEffect(() => {
         const m = findAll(content, query, caseSensitive, regex);
         setMatch((prev) => {
-            // Try to keep activeIdx pointing to a position near the selection
             let active = -1;
             if (m.length > 0) {
                 active = m.findIndex((pos) => pos >= selectionStart);
@@ -92,6 +95,14 @@ export function FindReplaceBar({
                 if (prev.activeIdx >= 0 && prev.activeIdx < m.length && prev.matches[prev.activeIdx] === m[prev.activeIdx]) {
                     active = prev.activeIdx;
                 }
+            }
+            // Same activeIdx + same-length + same-positions ⇒ nothing changed.
+            if (
+                prev.activeIdx === active &&
+                prev.matches.length === m.length &&
+                prev.matches.every((pos, i) => pos === m[i])
+            ) {
+                return prev;
             }
             return { matches: m, activeIdx: active };
         });

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -79,55 +79,101 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
     'bmp': 'image/bmp'
 };
 
+// Module-level shared cache for local image blobs. Without this, a doc that
+// references the same image 50 times reads the file 50 times and creates 50
+// independent ObjectURLs. With it, repeat references hit memory.
+//
+// LRU eviction at CACHE_CAP entries: the Map preserves insertion order, so we
+// re-insert on hit (move to end) and evict from the front when full. Evicted
+// URLs are revoked so the image data can be GC'd.
+const LOCAL_IMAGE_CACHE = new Map<string, string>();
+const LOCAL_IMAGE_CACHE_CAP = 100;
+
+async function getCachedLocalImageUrl(fullPath: string, mimeType: string): Promise<string> {
+    const hit = LOCAL_IMAGE_CACHE.get(fullPath);
+    if (hit !== undefined) {
+        // Move-to-end so this entry is now most-recently-used.
+        LOCAL_IMAGE_CACHE.delete(fullPath);
+        LOCAL_IMAGE_CACHE.set(fullPath, hit);
+        return hit;
+    }
+    const data = await readFile(fullPath);
+    const blob = new Blob([new Uint8Array(data)], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    LOCAL_IMAGE_CACHE.set(fullPath, url);
+    if (LOCAL_IMAGE_CACHE.size > LOCAL_IMAGE_CACHE_CAP) {
+        const oldestKey = LOCAL_IMAGE_CACHE.keys().next().value;
+        if (oldestKey !== undefined) {
+            const oldUrl = LOCAL_IMAGE_CACHE.get(oldestKey);
+            if (oldUrl) URL.revokeObjectURL(oldUrl);
+            LOCAL_IMAGE_CACHE.delete(oldestKey);
+        }
+    }
+    return url;
+}
+
+/**
+ * Reject paths that would escape the markdown file's directory or name an
+ * absolute location. The capabilities allow `**` reads, so we have to enforce
+ * the boundary in code: a malicious .md must not be able to use
+ * `![pwn](../../../etc/passwd)` to peek at arbitrary files.
+ */
+function isUnsafeRelativePath(p: string): boolean {
+    if (!p) return true;
+    if (/\0/.test(p)) return true;
+    // Absolute paths: leading slash, leading backslash, or drive letter.
+    if (/^([a-zA-Z]:|\/|\\)/.test(p)) return true;
+    // Any segment that is exactly `..` (handles foo/../etc, ../etc, etc.).
+    const segments = p.split(/[/\\]+/);
+    return segments.some((seg) => seg === "..");
+}
+
 // Component to handle local image loading
 function LocalImage({ src, alt, baseDir, ...props }: { src: string; alt: string; baseDir: string | null } & React.ImgHTMLAttributes<HTMLImageElement>) {
     const [imageSrc, setImageSrc] = useState<string>('');
     const [error, setError] = useState(false);
 
     useEffect(() => {
-        let objectUrl: string | null = null;
+        if (!baseDir || !src) return;
 
-        const loadImage = async () => {
-            if (!baseDir || !src) return;
+        // External URLs and data: URIs go straight to the <img>.
+        if (src.includes('://') || src.startsWith('data:')) {
+            setImageSrc(src);
+            setError(false);
+            return;
+        }
 
-            // Check if it's a relative path
-            if (src.startsWith('./') || src.startsWith('../') || (!src.includes('://') && !src.startsWith('data:'))) {
-                try {
-                    // Remove leading ./ if present
-                    const cleanPath = src.startsWith('./') ? src.slice(2) : src;
-                    // Construct full path - handle both Windows and Unix separators
-                    const sep = baseDir.includes('\\') ? '\\' : '/';
-                    const fullPath = `${baseDir}${sep}${cleanPath.replace(/[/\\]/g, sep)}`;
+        // Strip a leading `./` then validate. Anything with a `..` segment, an
+        // absolute prefix, or a drive letter is rejected — see
+        // isUnsafeRelativePath above.
+        const cleanPath = src.startsWith('./') ? src.slice(2) : src;
+        if (isUnsafeRelativePath(cleanPath)) {
+            setError(true);
+            return;
+        }
 
-                    // Read the file as binary
-                    const data = await readFile(fullPath);
+        const sep = baseDir.includes('\\') ? '\\' : '/';
+        const fullPath = `${baseDir}${sep}${cleanPath.replace(/[/\\]/g, sep)}`;
+        const ext = cleanPath.split('.').pop()?.toLowerCase() || 'png';
+        const mimeType = IMAGE_MIME_TYPES[ext] || 'image/png';
 
-                    // Detect image type from extension
-                    const ext = cleanPath.split('.').pop()?.toLowerCase() || 'png';
-                    const mimeType = IMAGE_MIME_TYPES[ext] || 'image/png';
-
-                    // Use Blob + ObjectURL instead of base64 for better performance
-                    const blob = new Blob([data], { type: mimeType });
-                    objectUrl = URL.createObjectURL(blob);
-                    setImageSrc(objectUrl);
+        let cancelled = false;
+        getCachedLocalImageUrl(fullPath, mimeType)
+            .then((url) => {
+                if (!cancelled) {
+                    setImageSrc(url);
                     setError(false);
-                } catch (err) {
-                    console.error('Failed to load image:', err);
-                    setError(true);
                 }
-            } else {
-                // External URL or data URL - use as is
-                setImageSrc(src);
-            }
-        };
+            })
+            .catch((err) => {
+                console.error('Failed to load image:', err);
+                if (!cancelled) setError(true);
+            });
 
-        loadImage();
-
-        // Revoke object URL on cleanup to prevent memory leaks
         return () => {
-            if (objectUrl) {
-                URL.revokeObjectURL(objectUrl);
-            }
+            cancelled = true;
+            // Don't revoke the URL — the cache owns it. Cache eviction handles
+            // revocation when the entry is pushed out by LRU pressure.
         };
     }, [src, baseDir]);
 
@@ -434,12 +480,21 @@ export function MarkdownPreview({
 
     // Toggle a task list checkbox by index — write back to the source markdown.
     // Counts task items in document order; toggles the Nth one.
+    // SKIPS lines inside fenced code blocks so a literal `- [ ] foo` written
+    // in a documentation example doesn't shift the index of the real tasks.
     const handleTaskToggle = useCallback((index: number, checked: boolean) => {
         if (!onContentChange) return;
         const lines = content.split("\n");
         let count = 0;
+        let inFence = false;
+        const fenceRe = /^(\s*)(```|~~~)/;
         const taskRe = /^(\s*[-*+]\s+\[)([ xX])(\]\s+)/;
         for (let i = 0; i < lines.length; i++) {
+            if (fenceRe.test(lines[i])) {
+                inFence = !inFence;
+                continue;
+            }
+            if (inFence) continue;
             const m = lines[i].match(taskRe);
             if (m) {
                 if (count === index) {
@@ -539,20 +594,31 @@ export function MarkdownPreview({
         h4: (props: React.HTMLAttributes<HTMLHeadingElement>) => <HeadingWithAnchor level={4} {...props} />,
         h5: (props: React.HTMLAttributes<HTMLHeadingElement>) => <HeadingWithAnchor level={5} {...props} />,
         h6: (props: React.HTMLAttributes<HTMLHeadingElement>) => <HeadingWithAnchor level={6} {...props} />,
-        // Interactive task checkbox: react-markdown + remarkGfm renders <input type="checkbox" disabled />
+        // Interactive task checkbox: react-markdown + remarkGfm renders <input type="checkbox" disabled />.
+        // We capture the task's positional index AT RENDER TIME (so each <input>'s
+        // closure remembers its own index) — not on click. The previous form
+        // `onToggle={(c) => handleTaskToggle(counter.current++, c)}` incremented
+        // the counter on click, which meant clicking any checkbox toggled the
+        // (click-count)-th task in source order, not the task that was actually
+        // clicked. The capture-on-render form always toggles the right task.
         input: ({ type, checked, ...rest }: React.InputHTMLAttributes<HTMLInputElement>) => {
             if (type !== "checkbox") return <input type={type} checked={checked} {...rest} />;
+            const idx = taskCheckboxCounter.current++;
             return (
                 <InteractiveTaskCheckbox
                     initialChecked={!!checked}
-                    onToggle={(c) => handleTaskToggle(taskCheckboxCounter.current++, c)}
+                    onToggle={(c) => handleTaskToggle(idx, c)}
                 />
             );
         },
     }), [baseDir, handleTaskToggle, onWikilinkClick]);
 
     // Reset the task index counter on every render so the next render starts at 0.
-    // (react-markdown renders synchronously top-to-bottom, so order matches doc order)
+    // react-markdown traverses the AST top-to-bottom inside the same render
+    // pass, so by the time react-markdown finishes the counter equals the
+    // total task count. StrictMode dev double-invokes the render body but
+    // resets the counter at the top of each pass, so each <input>'s captured
+    // idx is consistent regardless of which pass committed.
     const taskCheckboxCounter = useRef(0);
     taskCheckboxCounter.current = 0;
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -105,6 +105,20 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
         };
     }, [isOpen, onClose]);
 
+    // Persist AI fields on close. The endpoint/model/key inputs save on blur,
+    // but Escape-to-close or backdrop-click can fire before the input loses
+    // focus, dropping the in-flight edit. Refresh persistence on every close
+    // transition so unblurred edits survive (only when the endpoint is valid;
+    // an invalid URL is left unsaved so the user can fix it on next open).
+    const aiRef = useRef(ai);
+    aiRef.current = ai;
+    useEffect(() => {
+        if (isOpen) return; // only fire on open→close transition
+        const current = aiRef.current;
+        if (current.endpoint && !isValidEndpoint(current.endpoint)) return;
+        setAIConfig(current);
+    }, [isOpen]);
+
     if (!isOpen) return null;
 
     const matches = (text: string) => !filter || text.toLowerCase().includes(filter.toLowerCase());


### PR DESCRIPTION
> **Note:** This PR is stacked on top of [#27](https://github.com/Razee4315/MarkLite/pull/27) (cursor drift + welcome screen logo + favicon). Merge #27 first, then rebase this onto main, or merge them in either order — there are no conflicts.

## What and why

You asked for a thorough sweep for issues like the ones we'd already found. I ran a focused audit pass and surfaced 40+ items. This PR fixes the **HIGH and MEDIUM**-severity ones; LOW items I either folded in here when trivial or left for a follow-up.

## HIGH

### Tauri listener churn on every keystroke (A4/A5/A6)
`loadFile`'s `useCallback` listed `content` and `originalContent` as deps → fresh reference on every keystroke → propagated into:
- DRAG_DROP `useEffect` → tore down + re-registered a Tauri OS-level listener via IPC every keystroke
- file-open-from-cli `useEffect` → same
- global `keydown` handler `useEffect` → same (and `content` was a direct dep there too)

**Fix:** read `content`/`originalContent` through refs inside `loadFile` so its identity stays stable; rewrite the keyboard shortcut effect to use a single ref-object so it mounts ONCE on app start. The Tauri listeners now register once for the lifetime of the app.

### Click-to-wrong-task in markdown preview (A1 — actually worse than audit said)
The task-checkbox onToggle was `(c) => handleTaskToggle(taskCheckboxCounter.current++, c)`. The `++` runs **on click**, not during render. So clicking any checkbox toggled the (click-count)-th task in source order, regardless of which checkbox was actually clicked.

**Fix:** capture the index at render time into the closure: `const idx = counter++; onToggle = c => handleTaskToggle(idx, c)`. Each `<input>` now remembers its own positional index. Also skip lines inside fenced code blocks when counting tasks in the source so `- [ ] foo` inside a code example doesn't shift real-task indices (G3).

### CSP missing `connect-src` (E1)
The CSP had no `connect-src` directive, so AI assist's `fetch()` to user-configured endpoints fell through to `default-src 'self' https://asset.localhost asset:` and got blocked. **AI assist did not work.**

**Fix:** added `connect-src 'self' ipc: https: http://localhost:* http://127.0.0.1:*` so SaaS HTTPS endpoints work *and* local Ollama at `http://localhost:11434` works.

### LocalImage path traversal (E3)
The markdown `<img>` handler joined user-controlled `src` to `baseDir` without sanitization. A malicious `.md` with `![pwn](../../../etc/passwd)` triggered an arbitrary-file read (the fs:scope is `**`).

**Fix:** added `isUnsafeRelativePath()` that rejects `..` segments, absolute prefixes, drive letters, and NUL bytes before constructing the full path.

## MEDIUM

- **Editor metric lock-down** (D1/D2): `sharedTextStyle` now explicitly sets `fontWeight: 400`, `fontStyle: normal`, plus all the variant/feature/variation properties. Defends the textarea+overlay alignment against any future cascade rule that might apply bold/italic/feature-settings to one layer but not the other.
- **Highlight cache hard cap** (D4): added LRU eviction at 4096 entries on top of stale-prune so a 10k-line UUID file can't grow the cache forever.
- **LocalImage shared blob cache** (F3): a doc with 50 references to the same image used to load it 50× and create 50 ObjectURLs. New module-level `Map<fullPath, url>` LRU-cache (cap 100, evicted URLs revoked).
- **FindReplaceBar setMatch bail-out** (C6): position-by-position prev-vs-next compare returns `prev` unchanged when nothing moved. Stops dialog re-render churn during editor typing while find bar is open.
- **CommandPalette activeIdx clamp** (C5): switched from `if (activeIdx >= ranked.length) setActiveIdx(0)` to functional-update form so React bails out via `Object.is` when no clamp is needed — same shape that caused the earlier "Maximum update depth" crash.
- **AIBubble fetch abort on unmount** (G7): final-cleanup `useEffect` with `[]` deps so the in-flight fetch is aborted whether `anchor` flips null or the bubble unmounts outright.
- **SettingsModal persist on close** (G12): close-transition effect re-saves AI fields so Escape/backdrop-click before input blur doesn't lose the edit.

## LOW (folded in)

- `hideToast` returns `prev` when already hidden (B1)
- Removed dead `storage` event listener — only fires across documents, never within the same one (G2)
- `addRecentFile` on file restore so the welcome screen timestamp is fresh (G1)
- `StatsDialog` reads live `content` so the displayed numbers match what was just typed (G10)

## Verification
- `bun run build` — clean
- `cargo check` — clean
- 9 files changed, 245 insertions(+), 81 deletions(-).

## Test plan
- [x] Open a markdown file with multiple `- [ ]` task items mixed with a fenced code block that contains a fake `- [ ] example` line. Click any real checkbox — verify only the clicked task toggles in source.
- [x] Configure an AI endpoint (e.g. `https://api.openai.com/v1/chat/completions` with a real key, or `http://localhost:11434/v1/chat/completions` for Ollama). Press Ctrl+J on a selection — verify the request goes through (no CSP error in console).
- [x] Try opening `![x](../../../some-file)` — verify it shows "Failed to load image" and no `readFile` call to a path outside the markdown's directory occurs.
- [x] Type rapidly into a long file — caret should stay glued to the rendered glyph.
- [x] Open Settings → AI, type a partial endpoint, press Esc immediately — re-open Settings and verify the partial value is still there.