### PR TITLE
Hardening + UX polish: file size limits, AI timeout, selection word count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Security
+
+- `read_file` / `save_file` refuse documents above 50 MB. Stat happens before
+  the read so an oversized file fails fast with a clear "File too large"
+  toast instead of pulling hundreds of MB of UTF-8 into the webview while
+  the UI freezes.
+- `save_image` refuses payloads above 25 MB and now enforces an extension
+  whitelist (`png`, `jpg`, `jpeg`, `gif`, `webp`, `bmp`, `svg`,
+  case-insensitive). A caller can no longer drop a `.exe` / `.dll` / `.lnk`
+  into the user's documents folder under cover of the markdown image-paste
+  flow. Tests cover the new rejections plus all whitelisted extensions.
+- AI requests get a 60 s wall-clock timeout (composed with the user's
+  existing `AbortController`) and the response is capped at 200 KB. A
+  stuck local llama.cpp or a runaway model can no longer hang the AI
+  bubble forever or paste megabytes of text into the editor.
+- Tauri CSP further tightened: `object-src 'none'`, `base-uri 'self'`,
+  `form-action 'none'`, `frame-ancestors 'none'`. Asset protocol disabled
+  (it was scoped to `**` but the app loads images via plugin-fs + blob
+  URLs and never touches `asset:`), and `asset:`/`https://asset.localhost`
+  dropped from `default-src` and `img-src`.
+
+### Added
+
+- Status bar shows a "selected / total" word count when the editor has a
+  non-empty selection; reverts to total when the selection collapses.
+- Welcome screen: a Settings button next to Open/New, a "Clear all" link in
+  the Recent header, and a visible drag highlight (dashed accent outline +
+  hover background) so the drop target is obvious.
+
+### Fixed — UX
+
+- File-operation errors now surface the actual message from Rust
+  ("File too large", "Image filename must end in …") instead of the
+  generic "Failed to open file" / "Failed to save image. Please try again."
+  toasts. Restore-on-launch surfaces TooLarge specifically so a user whose
+  yesterday-doc grew above the cap gets an explanation instead of the
+  editor silently opening to a blank welcome screen.
+- Welcome screen: per-row Remove button on a Recent file used to be a
+  `<span role="button">` nested inside the row's `<button>`. That's invalid
+  HTML and could double-fire — clicking Remove sometimes also reopened the
+  file. Split into two sibling buttons.
+
+### Removed
+
+- Dead `localStorage` helpers `getFocusMode` / `setFocusMode` /
+  `getAutoSave` / `setAutoSave`. Both features were retired in 0.6.1 and
+  nothing reads these keys anymore.
+
 ### Changed — Offline support
 
 - All UI fonts (Inter, JetBrains Mono, Merriweather, Lora, Source Serif 4,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1932,7 +1932,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "marklite"
-version = "0.6.5"
+version = "0.6.7"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1470,12 +1470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3615,7 +3609,6 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "http-range",
  "jni",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["protocol-asset"] }
+tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2,6 +2,23 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use thiserror::Error;
 
+/// Hard ceiling on text-file content. 50 MB easily covers any sane markdown
+/// document while keeping a single careless `read_file` from holding hundreds
+/// of MB of UTF-8 in webview memory. Above this we fail fast with a clear
+/// error so the user sees a toast instead of a frozen editor.
+const MAX_TEXT_FILE_BYTES: u64 = 50 * 1024 * 1024;
+
+/// Hard ceiling on a pasted image. Markdown editors get pasted screenshots
+/// regularly; 25 MB is generous (a 4K PNG screenshot is ~5–10 MB) but blocks a
+/// runaway clipboard payload from filling the user's disk.
+const MAX_IMAGE_BYTES: usize = 25 * 1024 * 1024;
+
+/// Whitelist of allowed image extensions for `save_image`. Anything else is
+/// refused — prevents a malicious caller from writing an arbitrary `.exe` /
+/// `.dll` / `.lnk` into the user's documents folder under the cover of an
+/// image-paste flow.
+const ALLOWED_IMAGE_EXTS: &[&str] = &["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"];
+
 /// Error type for file operation commands
 #[derive(Debug, Error)]
 pub enum CommandError {
@@ -11,6 +28,8 @@ pub enum CommandError {
     ReadError(String),
     #[error("Failed to write file: {0}")]
     WriteError(String),
+    #[error("File too large: {0}")]
+    TooLarge(String),
 }
 
 impl Serialize for CommandError {
@@ -36,16 +55,27 @@ pub struct FileData {
 #[tauri::command]
 pub async fn read_file(path: String) -> Result<FileData, CommandError> {
     let file_path = PathBuf::from(&path);
-    
+
     if !file_path.exists() {
         return Err(CommandError::FileNotFound(path));
     }
-    
-    let content = tokio::fs::read_to_string(&file_path)
+
+    // Stat first so we can refuse oversized files before pulling them into
+    // memory. Without this, opening a multi-GB log accidentally renamed `.md`
+    // would freeze the UI thread for tens of seconds.
+    let metadata = tokio::fs::metadata(&file_path)
         .await
         .map_err(|e| CommandError::ReadError(e.to_string()))?;
-    
-    let metadata = tokio::fs::metadata(&file_path)
+
+    if metadata.len() > MAX_TEXT_FILE_BYTES {
+        return Err(CommandError::TooLarge(format!(
+            "File is {} MB; maximum is {} MB",
+            metadata.len() / (1024 * 1024),
+            MAX_TEXT_FILE_BYTES / (1024 * 1024),
+        )));
+    }
+
+    let content = tokio::fs::read_to_string(&file_path)
         .await
         .map_err(|e| CommandError::ReadError(e.to_string()))?;
     
@@ -69,10 +99,21 @@ pub async fn read_file(path: String) -> Result<FileData, CommandError> {
 /// Save content to a file
 #[tauri::command]
 pub async fn save_file(path: String, content: String) -> Result<(), CommandError> {
+    // Mirror the read-side limit. Refusing to write a >50 MB markdown file
+    // protects the user from accidentally truncating something pasted from
+    // another tool, and matches what `read_file` would refuse to load back.
+    if content.len() as u64 > MAX_TEXT_FILE_BYTES {
+        return Err(CommandError::TooLarge(format!(
+            "Document is {} MB; maximum is {} MB",
+            content.len() / (1024 * 1024),
+            MAX_TEXT_FILE_BYTES / (1024 * 1024),
+        )));
+    }
+
     tokio::fs::write(&path, &content)
         .await
         .map_err(|e| CommandError::WriteError(e.to_string()))?;
-    
+
     Ok(())
 }
 
@@ -165,7 +206,10 @@ pub async fn list_directory_files(directory: String) -> Result<Vec<FileEntry>, C
 
 /// Strip any path components from a filename so it can't traverse outside the
 /// images directory. Rejects empty / dot-only names and names with separators,
-/// drive letters, or NUL bytes. Returns just the basename when valid.
+/// drive letters, or NUL bytes. Also enforces an extension whitelist so the
+/// "image paste" command can't be used to drop a `.exe` / `.dll` / `.lnk`
+/// into the user's documents folder under cover of a markdown image flow.
+/// Returns just the basename when valid.
 fn sanitize_image_name(name: &str) -> Result<String, CommandError> {
     let trimmed = name.trim();
     if trimmed.is_empty() || trimmed == "." || trimmed == ".." {
@@ -182,7 +226,19 @@ fn sanitize_image_name(name: &str) -> Result<String, CommandError> {
     if basename != trimmed {
         return Err(CommandError::WriteError("Invalid image filename".to_string()));
     }
-    Ok(basename.to_string())
+    // Enforce extension whitelist (case-insensitive). A name with no extension,
+    // or one whose extension isn't a known image type, is rejected — this is
+    // a defense-in-depth check on top of the basename validation above.
+    let ext = std::path::Path::new(basename)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_ascii_lowercase());
+    match ext {
+        Some(e) if ALLOWED_IMAGE_EXTS.contains(&e.as_str()) => Ok(basename.to_string()),
+        _ => Err(CommandError::WriteError(
+            "Image filename must end in .png/.jpg/.jpeg/.gif/.webp/.bmp/.svg".to_string(),
+        )),
+    }
 }
 
 /// Save image data to a file in the images subdirectory
@@ -193,6 +249,13 @@ pub async fn save_image(
     image_data: Vec<u8>,
     image_name: String,
 ) -> Result<String, CommandError> {
+    if image_data.len() > MAX_IMAGE_BYTES {
+        return Err(CommandError::TooLarge(format!(
+            "Image is {} MB; maximum is {} MB",
+            image_data.len() / (1024 * 1024),
+            MAX_IMAGE_BYTES / (1024 * 1024),
+        )));
+    }
     let safe_name = sanitize_image_name(&image_name)?;
     let md_path = PathBuf::from(&md_file_path);
 
@@ -241,5 +304,25 @@ mod tests {
         assert!(sanitize_image_name(".").is_err());
         assert!(sanitize_image_name("").is_err());
         assert!(sanitize_image_name("\0").is_err());
+    }
+
+    #[test]
+    fn rejects_non_image_extensions() {
+        assert!(sanitize_image_name("malware.exe").is_err());
+        assert!(sanitize_image_name("script.lnk").is_err());
+        assert!(sanitize_image_name("payload.dll").is_err());
+        assert!(sanitize_image_name("noext").is_err());
+        assert!(sanitize_image_name("trailing.").is_err());
+        // Extension matching is case-insensitive — uppercase OK.
+        assert!(sanitize_image_name("photo.PNG").is_ok());
+        assert!(sanitize_image_name("photo.JpG").is_ok());
+    }
+
+    #[test]
+    fn accepts_all_whitelisted_extensions() {
+        for ext in &["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"] {
+            let name = format!("img.{}", ext);
+            assert!(sanitize_image_name(&name).is_ok(), "rejected {}", name);
+        }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,12 +24,10 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' https://asset.localhost asset:; img-src 'self' asset: https://asset.localhost blob: data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self'; connect-src 'self' ipc: https: http://localhost:* http://127.0.0.1:*",
+      "csp": "default-src 'self'; img-src 'self' blob: data:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self'; connect-src 'self' ipc: https: http://localhost:* http://127.0.0.1:*; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'",
       "assetProtocol": {
-        "enable": true,
-        "scope": [
-          "**"
-        ]
+        "enable": false,
+        "scope": []
       }
     }
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,6 +102,9 @@ function AppContent() {
   const [wordWrapEnabled, setWordWrapEnabled] = useState<boolean>(() => getWordWrap());
   const [spellCheckEnabled, setSpellCheckEnabled] = useState<boolean>(() => getSpellCheck());
   const [cursorPosition, setCursorPosition] = useState({ line: 1, col: 1 });
+  // Editor selection range. Collapsed (start === end) means no selection;
+  // when start < end we surface a "N words selected" chip in the status bar.
+  const [selectionRange, setSelectionRange] = useState<{ start: number; end: number }>({ start: 0, end: 0 });
   const [isLoading, setIsLoading] = useState(false);
 
   // Pending file to open after unsaved changes dialog
@@ -174,6 +177,15 @@ function AppContent() {
   // docs, so they read deferred too.
   const wordCount = useMemo(() => getWordCount(deferredContent), [deferredContent]);
   const charCount = deferredContent.length;
+  // Selection word count, when the user has a non-empty range highlighted.
+  // Reads LIVE `content` (not deferredContent) since the selection range and
+  // the underlying text must agree — sliding by 80ms would briefly count words
+  // from a stale buffer right after a fast edit. The slice is cheap regardless.
+  const selectionLength = selectionRange.end - selectionRange.start;
+  const selectionWordCount = useMemo(
+    () => (selectionLength > 0 ? getWordCount(content.slice(selectionRange.start, selectionRange.end)) : 0),
+    [content, selectionRange.start, selectionRange.end, selectionLength]
+  );
   // Average adult reading speed for prose: ~200 wpm.
   const readingTimeMin = useMemo(() => wordCount / 200, [wordCount]);
 
@@ -545,6 +557,13 @@ function AppContent() {
   const handleCursorChange = useCallback((line: number, col: number) => {
     setCursorPosition((prev) => (prev.line === line && prev.col === col ? prev : { line, col }));
   }, []);
+  // Bail out via functional update when the range hasn't actually changed —
+  // selectionchange fires constantly while typing even when caret is at the
+  // same offset, and we don't want to mint a fresh `{ start, end }` object
+  // (and trigger a status-bar re-render) on every keystroke.
+  const handleSelectionChange = useCallback((start: number, end: number) => {
+    setSelectionRange((prev) => (prev.start === start && prev.end === end ? prev : { start, end }));
+  }, []);
   const handlePreviewLineChange = useCallback((line: number) => {
     setPreviewLine((prev) => (prev === line ? prev : line));
   }, []);
@@ -890,7 +909,13 @@ function AppContent() {
       />
 
       {!hasFile ? (
-        <WelcomeScreen onOpenFile={handleOpenFile} onNewFile={handleNewFile} onFileDrop={handleFileDrop} onOpenRecent={loadFile} />
+        <WelcomeScreen
+          onOpenFile={handleOpenFile}
+          onNewFile={handleNewFile}
+          onOpenSettings={() => setShowSettings(true)}
+          onFileDrop={handleFileDrop}
+          onOpenRecent={loadFile}
+        />
       ) : (
         <>
           {/* Split-aware layout. Both views always mounted; CSS toggles their display
@@ -912,6 +937,7 @@ function AppContent() {
                 content={content}
                 onChange={handleContentChange}
                 onCursorChange={handleCursorChange}
+                onSelectionChange={handleSelectionChange}
                 onImagePaste={handleImagePaste}
                 onError={handleError}
                 filePath={filePath}
@@ -984,6 +1010,8 @@ function AppContent() {
             wordCount={wordCount}
             charCount={charCount}
             readingTimeMin={readingTimeMin}
+            selectionLength={mode !== "preview" ? selectionLength : 0}
+            selectionWordCount={selectionWordCount}
           />
         </>
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -209,7 +209,11 @@ function AppContent() {
       setLastFile(fileData.path);
     } catch (err) {
       console.error("Failed to load file:", err);
-      showToast("Failed to open file", "error");
+      // Surface the actual error from Rust so "File too large" / "File not
+      // found" reaches the user instead of a generic message — without this,
+      // hitting the new 50 MB cap looked exactly like a permission error.
+      const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
+      showToast(msg || "Failed to open file", "error");
     } finally {
       setIsLoading(false);
     }
@@ -254,7 +258,9 @@ function AppContent() {
     // Restore last opened file once on app launch
     const last = getLastFile();
     if (last) {
-      // Fire-and-forget; failures are silent (file may have been moved/deleted)
+      // Fire-and-forget; failures are mostly silent (file may have been moved
+      // / deleted), but we DO surface a toast for the new TooLarge case so a
+      // user who suddenly can't reopen yesterday's file isn't left guessing.
       invoke<FileData>("read_file", { path: last })
         .then((fileData) => {
           setFilePath(fileData.path);
@@ -268,8 +274,12 @@ function AppContent() {
           // screen show "3d ago" for the file you'd just been editing.
           addRecentFile(fileData.path, fileData.name);
         })
-        .catch(() => {
+        .catch((err) => {
           setLastFile(null);
+          const msg = typeof err === "string" ? err : (err as { message?: string })?.message || "";
+          if (/too large/i.test(msg)) {
+            showToast(`Could not restore last file: ${msg}`, "error");
+          }
         });
     }
     // Run only once on mount
@@ -320,7 +330,8 @@ function AppContent() {
         setOriginalContent(content);
       } catch (err) {
         console.error("Failed to save file:", err);
-        showToast("Failed to save file", "error");
+        const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
+        showToast(msg || "Failed to save file", "error");
         return;
       }
     }
@@ -462,7 +473,8 @@ function AppContent() {
       showToast("File saved", "success");
     } catch (err) {
       console.error("Failed to save file:", err);
-      showToast("Failed to save file", "error");
+      const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
+      showToast(msg || "Failed to save file", "error");
     }
   }, [content, fileName, showToast]);
 
@@ -478,7 +490,8 @@ function AppContent() {
       showToast("File saved", "success");
     } catch (err) {
       console.error("Failed to save file:", err);
-      showToast("Failed to save file", "error");
+      const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
+      showToast(msg || "Failed to save file", "error");
     }
   }, [filePath, content, showToast, handleSaveAs]);
 

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -21,6 +21,10 @@ interface CodeEditorProps {
     content: string;
     onChange: (content: string) => void;
     onCursorChange?: (line: number, column: number) => void;
+    /** Fires whenever the textarea's selection range changes. `start === end`
+     *  indicates a collapsed caret with no selection. Used by the status bar
+     *  to show "N words selected" while the user has a range highlighted. */
+    onSelectionChange?: (start: number, end: number) => void;
     onImagePaste?: () => void; // Callback when image is successfully pasted
     onError?: (message: string) => void; // Callback for error messages
     filePath?: string | null; // Current file path for saving images
@@ -105,7 +109,7 @@ const Gutter = memo(forwardRef<HTMLDivElement, { lineCount: number; activeLine: 
     }
 ));
 
-export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, onError, filePath, onScrollFraction, registerScroller, typewriterMode, showToolbar, wordWrap = true, spellCheck = false, aiConfig }: CodeEditorProps) {
+export function CodeEditor({ content, onChange, onCursorChange, onSelectionChange, onImagePaste, onError, filePath, onScrollFraction, registerScroller, typewriterMode, showToolbar, wordWrap = true, spellCheck = false, aiConfig }: CodeEditorProps) {
     // When word wrap is on, long lines wrap inside the editor and the highlight
     // overlay; when off, lines scroll horizontally. Both layers must agree on
     // these styles or the caret will visually drift away from the rendered text.
@@ -379,6 +383,7 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
 
         const textarea = textareaRef.current;
         const cursorPos = textarea.selectionStart;
+        const selEnd = textarea.selectionEnd;
         const textBeforeCursor = textarea.value.substring(0, cursorPos);
         const linesBeforeCursor = textBeforeCursor.split("\n");
         const line = linesBeforeCursor.length;
@@ -386,7 +391,8 @@ export function CodeEditor({ content, onChange, onCursorChange, onImagePaste, on
 
         setActiveLine(line);
         onCursorChange?.(line, column);
-    }, [onCursorChange]);
+        onSelectionChange?.(cursorPos, selEnd);
+    }, [onCursorChange, onSelectionChange]);
 
     // Track cursor on every relevant event (selectionchange catches all caret moves)
     useEffect(() => {

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -311,7 +311,13 @@ export function CodeEditor({ content, onChange, onCursorChange, onSelectionChang
                 return;
             } catch (error) {
                 console.error('Failed to paste image:', error);
-                onError?.('Failed to save image. Please try again.');
+                // Surface the actual error so "Image is 30 MB; maximum is
+                // 25 MB" reaches the user rather than a generic retry hint.
+                const msg =
+                    typeof error === "string"
+                        ? error
+                        : (error as { message?: string })?.message;
+                onError?.(msg || 'Failed to save image. Please try again.');
                 return;
             }
         }

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -10,6 +10,11 @@ interface StatusBarProps {
     wordCount?: number;
     charCount?: number;
     readingTimeMin?: number;
+    /** Character count of the active selection (0 = no selection). */
+    selectionLength?: number;
+    /** Word count inside the active selection. Only meaningful when
+     *  `selectionLength > 0`. */
+    selectionWordCount?: number;
 }
 
 const formatReadingTime = (min: number): string => {
@@ -32,7 +37,10 @@ export function StatusBar({
     wordCount,
     charCount,
     readingTimeMin,
+    selectionLength = 0,
+    selectionWordCount = 0,
 }: StatusBarProps) {
+    const hasSelection = selectionLength > 0;
     return (
         <footer
             role="status"
@@ -88,11 +96,17 @@ export function StatusBar({
                 )}
                 {wordCount !== undefined && (
                     <div
-                        className="flex items-center gap-1 hover:text-[var(--text-primary)] cursor-default transition-colors"
-                        title={charCount !== undefined ? `${charCount.toLocaleString()} characters` : undefined}
+                        className={`flex items-center gap-1 cursor-default transition-colors ${hasSelection ? "text-[var(--accent)]" : "hover:text-[var(--text-primary)]"}`}
+                        title={
+                            hasSelection
+                                ? `Selection: ${selectionWordCount.toLocaleString()} words, ${selectionLength.toLocaleString()} characters`
+                                : (charCount !== undefined ? `${charCount.toLocaleString()} characters` : undefined)
+                        }
                     >
                         <span className="material-symbols-outlined text-[14px] opacity-70">text_fields</span>
-                        {wordCount.toLocaleString()} words
+                        {hasSelection
+                            ? `${selectionWordCount.toLocaleString()} / ${wordCount.toLocaleString()} words`
+                            : `${wordCount.toLocaleString()} words`}
                     </div>
                 )}
                 {readingTimeMin !== undefined && readingTimeMin > 0 && (

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { getRecentFiles, removeRecentFile, type RecentFile } from "../utils/persistence";
+import { clearRecentFiles, getRecentFiles, removeRecentFile, type RecentFile } from "../utils/persistence";
 
 interface WelcomeScreenProps {
     onOpenFile: () => void;
     onNewFile?: () => void;
+    onOpenSettings?: () => void;
     onFileDrop: (path: string) => void;
     onOpenRecent?: (path: string) => void;
 }
@@ -25,9 +26,13 @@ const parentFolderOf = (path: string): string => {
     return segs.slice(-2).join("/") || segs.join("/");
 };
 
-export function WelcomeScreen({ onOpenFile, onNewFile, onFileDrop, onOpenRecent }: WelcomeScreenProps) {
+export function WelcomeScreen({ onOpenFile, onNewFile, onOpenSettings, onFileDrop, onOpenRecent }: WelcomeScreenProps) {
     const [recents, setRecents] = useState<RecentFile[]>([]);
     const [missing, setMissing] = useState<Set<string>>(new Set());
+    // Highlight while a markdown file is dragged over the welcome screen so
+    // the user gets immediate visual confirmation that the drop will be
+    // handled. Reset on drop / dragleave.
+    const [isDragging, setIsDragging] = useState(false);
 
     useEffect(() => {
         const list = getRecentFiles();
@@ -53,11 +58,21 @@ export function WelcomeScreen({ onOpenFile, onNewFile, onFileDrop, onOpenRecent 
     const handleDragOver = (e: React.DragEvent) => {
         e.preventDefault();
         e.stopPropagation();
+        if (!isDragging) setIsDragging(true);
+    };
+
+    const handleDragLeave = (e: React.DragEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        // Only reset when the drag leaves the outer container, not when it
+        // crosses into a child element.
+        if (e.currentTarget === e.target) setIsDragging(false);
     };
 
     const handleDrop = (e: React.DragEvent) => {
         e.preventDefault();
         e.stopPropagation();
+        setIsDragging(false);
 
         const files = e.dataTransfer.files;
         if (files.length > 0) {
@@ -72,12 +87,20 @@ export function WelcomeScreen({ onOpenFile, onNewFile, onFileDrop, onOpenRecent 
 
     const handleRemoveRecent = (e: React.MouseEvent, path: string) => {
         e.stopPropagation();
+        e.preventDefault();
         setRecents(removeRecentFile(path));
+    };
+
+    const handleClearAll = () => {
+        clearRecentFiles();
+        setRecents([]);
+        setMissing(new Set());
     };
 
     return (
         <main
             onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
             onDrop={handleDrop}
             // `justify-start` (not `justify-center`) plus generous vertical
             // padding keeps the logo anchored at the top of the visible area
@@ -86,7 +109,8 @@ export function WelcomeScreen({ onOpenFile, onNewFile, onFileDrop, onOpenRecent 
             // can be taller than the viewport, which causes flexbox to push
             // the top edge (the logo) above the scrollable area — invisible
             // unless the user scrolls up.
-            className="flex-1 flex flex-col items-center justify-start py-10 px-6 no-select overflow-y-auto"
+            className={`flex-1 flex flex-col items-center justify-start py-10 px-6 no-select overflow-y-auto transition-colors ${isDragging ? "bg-[var(--bg-hover)] outline outline-2 outline-dashed outline-[var(--accent)] -outline-offset-8" : ""}`}
+            aria-dropeffect="copy"
         >
             <div className="flex flex-col items-center gap-8 max-w-md w-full text-center animate-fade-in-up">
                 <div className="flex items-center justify-center w-20 h-20">
@@ -102,7 +126,7 @@ export function WelcomeScreen({ onOpenFile, onNewFile, onFileDrop, onOpenRecent 
                     </p>
                 </div>
 
-                <div className="flex gap-2">
+                <div className="flex gap-2 items-center">
                     <button
                         onClick={onOpenFile}
                         className="btn-press flex items-center gap-2 bg-[var(--accent)] hover:opacity-90 text-[var(--accent-text)] font-medium text-sm px-5 py-2.5 rounded-[var(--radius-md)] transition-all duration-200"
@@ -119,6 +143,16 @@ export function WelcomeScreen({ onOpenFile, onNewFile, onFileDrop, onOpenRecent 
                             <span>New File</span>
                         </button>
                     )}
+                    {onOpenSettings && (
+                        <button
+                            onClick={onOpenSettings}
+                            aria-label="Settings"
+                            title="Settings (Ctrl+,)"
+                            className="btn-press flex items-center justify-center w-10 h-10 rounded-[var(--radius-md)] bg-[var(--bg-secondary)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] border border-[var(--border)] transition-all duration-200"
+                        >
+                            <span className="material-symbols-outlined text-[20px]">settings</span>
+                        </button>
+                    )}
                 </div>
 
                 <p className="text-xs text-[var(--text-muted)]">
@@ -127,18 +161,35 @@ export function WelcomeScreen({ onOpenFile, onNewFile, onFileDrop, onOpenRecent 
 
                 {recents.length > 0 && onOpenRecent && (
                     <div className="w-full mt-4 text-left">
-                        <div className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider mb-2 px-1">
-                            Recent
+                        <div className="flex items-center justify-between mb-2 px-1">
+                            <div className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider">
+                                Recent
+                            </div>
+                            <button
+                                onClick={handleClearAll}
+                                aria-label="Clear all recent files"
+                                title="Clear all recents"
+                                className="text-[10px] uppercase tracking-wider text-[var(--text-muted)] hover:text-[var(--danger)] transition-colors px-1.5 py-0.5 rounded"
+                            >
+                                Clear all
+                            </button>
                         </div>
                         <ul className="flex flex-col">
                             {recents.map((f) => {
                                 const isMissing = missing.has(f.path);
                                 return (
-                                <li key={f.path} className="group">
+                                <li key={f.path} className="group relative">
+                                    {/* Two siblings instead of nested buttons:
+                                        the previous form had a `<span
+                                        role="button">` inside a `<button>`,
+                                        which is invalid HTML — depending on
+                                        browser, the click could bubble to
+                                        the outer button and re-open the file
+                                        right after the user removed it. */}
                                     <button
                                         onClick={() => !isMissing && onOpenRecent(f.path)}
                                         disabled={isMissing}
-                                        className={`btn-press w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] transition-colors text-left ${isMissing ? "opacity-50 cursor-not-allowed" : "hover:bg-[var(--bg-hover)]"}`}
+                                        className={`btn-press w-full flex items-center gap-3 px-3 pr-9 py-2 rounded-[var(--radius-md)] transition-colors text-left ${isMissing ? "opacity-50 cursor-not-allowed" : "hover:bg-[var(--bg-hover)]"}`}
                                         title={isMissing ? `${f.path} (missing)` : f.path}
                                     >
                                         <span className="material-symbols-outlined text-[18px] text-[var(--text-secondary)] shrink-0">
@@ -149,16 +200,15 @@ export function WelcomeScreen({ onOpenFile, onNewFile, onFileDrop, onOpenRecent 
                                             <div className="text-[11px] text-[var(--text-muted)] truncate">{parentFolderOf(f.path)}</div>
                                         </div>
                                         <span className="text-[11px] text-[var(--text-muted)] tabular-nums shrink-0">{isMissing ? "missing" : formatRelative(f.openedAt)}</span>
-                                        <span
-                                            role="button"
-                                            tabIndex={0}
-                                            aria-label={`Remove ${f.name} from recents`}
-                                            onClick={(e) => handleRemoveRecent(e, f.path)}
-                                            onKeyDown={(e) => { if (e.key === "Enter") handleRemoveRecent(e as unknown as React.MouseEvent, f.path); }}
-                                            className="opacity-0 group-hover:opacity-100 w-5 h-5 rounded hover:bg-[var(--bg-hover)] text-[var(--text-muted)] hover:text-[var(--danger)] transition-opacity flex items-center justify-center"
-                                        >
-                                            <span className="material-symbols-outlined text-[14px]">close</span>
-                                        </span>
+                                    </button>
+                                    <button
+                                        type="button"
+                                        aria-label={`Remove ${f.name} from recents`}
+                                        title="Remove from recents"
+                                        onClick={(e) => handleRemoveRecent(e, f.path)}
+                                        className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 w-6 h-6 rounded hover:bg-[var(--bg-hover)] text-[var(--text-muted)] hover:text-[var(--danger)] transition-opacity flex items-center justify-center"
+                                    >
+                                        <span className="material-symbols-outlined text-[14px]">close</span>
                                     </button>
                                 </li>
                                 );

--- a/src/utils/aiAssist.ts
+++ b/src/utils/aiAssist.ts
@@ -27,6 +27,18 @@ export interface AIConfig {
     apiKey: string;
 }
 
+/** Hard timeout for an AI request. A misconfigured endpoint or a stuck local
+ *  llama.cpp process otherwise leaves the bubble spinning forever; 60s is
+ *  long enough for slow local models on first load but short enough that the
+ *  user gets a clear error rather than a frozen UI. */
+const AI_REQUEST_TIMEOUT_MS = 60_000;
+
+/** Cap on what we accept back from the AI. Pasting hundreds of MB of model
+ *  output into the editor would freeze the textarea/preview; a 200 KB ceiling
+ *  covers any reasonable rewrite/expand and matches what a sane chat
+ *  completion returns. */
+const AI_MAX_OUTPUT_CHARS = 200_000;
+
 /** True when the URL is well-formed and uses http(s). */
 export function isValidEndpoint(raw: string): boolean {
     try {
@@ -49,23 +61,43 @@ export async function runAIAction(
     }
     if (!cfg.model) throw new Error("AI model not configured.");
 
-    const res = await fetch(cfg.endpoint, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            ...(cfg.apiKey ? { Authorization: `Bearer ${cfg.apiKey}` } : {}),
-        },
-        body: JSON.stringify({
-            model: cfg.model,
-            messages: [
-                { role: "system", content: SYSTEM_PROMPTS[action] },
-                { role: "user", content: text },
-            ],
-            temperature: 0.7,
-            stream: false,
-        }),
-        signal,
-    });
+    // Compose the user-supplied AbortSignal with our timeout signal so either
+    // path (user clicks close, or 60s elapses) cancels the in-flight request.
+    const timeoutCtrl = new AbortController();
+    const timeoutId = window.setTimeout(() => timeoutCtrl.abort(), AI_REQUEST_TIMEOUT_MS);
+    const onUserAbort = () => timeoutCtrl.abort();
+    signal?.addEventListener("abort", onUserAbort);
+
+    let res: Response;
+    try {
+        res = await fetch(cfg.endpoint, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                ...(cfg.apiKey ? { Authorization: `Bearer ${cfg.apiKey}` } : {}),
+            },
+            body: JSON.stringify({
+                model: cfg.model,
+                messages: [
+                    { role: "system", content: SYSTEM_PROMPTS[action] },
+                    { role: "user", content: text },
+                ],
+                temperature: 0.7,
+                stream: false,
+            }),
+            signal: timeoutCtrl.signal,
+        });
+    } catch (e) {
+        // If we tripped the timeout, surface that specifically so the user
+        // doesn't see a generic "AbortError" and think they cancelled it.
+        if (timeoutCtrl.signal.aborted && !signal?.aborted) {
+            throw new Error(`AI request timed out after ${AI_REQUEST_TIMEOUT_MS / 1000}s.`);
+        }
+        throw e;
+    } finally {
+        window.clearTimeout(timeoutId);
+        signal?.removeEventListener("abort", onUserAbort);
+    }
 
     if (!res.ok) {
         const body = await res.text();
@@ -78,5 +110,11 @@ export async function runAIAction(
         data?.message?.content ?? // ollama native shape, also handled
         "";
     if (!content) throw new Error("AI returned an empty response.");
-    return String(content).trim();
+    const out = String(content).trim();
+    // Truncate runaway responses. Markdown editors don't need megabyte-scale
+    // suggestions, and pasting one in tanks input latency for a long time.
+    if (out.length > AI_MAX_OUTPUT_CHARS) {
+        return out.slice(0, AI_MAX_OUTPUT_CHARS) + "\n\n[Response truncated]";
+    }
+    return out;
 }

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -62,17 +62,10 @@ export const getSplitRatio = (): number => {
 };
 export const setSplitRatio = (r: number): void => safeSet(KEY_SPLIT_RATIO, r);
 
-const KEY_AUTOSAVE = "marklite:autoSave";
-export const getAutoSave = (): boolean => safeGet<boolean>(KEY_AUTOSAVE, false);
-export const setAutoSave = (v: boolean): void => safeSet(KEY_AUTOSAVE, v);
-
-const KEY_FOCUS_MODE = "marklite:focusMode";
 const KEY_TYPEWRITER_MODE = "marklite:typewriterMode";
 const KEY_TOOLBAR = "marklite:toolbar";
 const KEY_WORD_WRAP = "marklite:wordWrap";
 const KEY_SPELL_CHECK = "marklite:spellCheck";
-export const getFocusMode = (): boolean => safeGet<boolean>(KEY_FOCUS_MODE, false);
-export const setFocusMode = (v: boolean): void => safeSet(KEY_FOCUS_MODE, v);
 export const getTypewriterMode = (): boolean => safeGet<boolean>(KEY_TYPEWRITER_MODE, false);
 export const setTypewriterMode = (v: boolean): void => safeSet(KEY_TYPEWRITER_MODE, v);
 export const getToolbarEnabled = (): boolean => safeGet<boolean>(KEY_TOOLBAR, false);


### PR DESCRIPTION
## Summary

Three commits of security hardening + one wave of UX polish, all on top of the current `main` (v0.6.7). Build + cargo-check pass locally.

### Security
- `read_file` / `save_file` cap at 50 MB (stat-then-read so oversized files fail fast).
- `save_image` caps at 25 MB and enforces an image-extension whitelist (png/jpg/jpeg/gif/webp/bmp/svg) — closes a small attack surface where the paste flow could write arbitrary `.exe` / `.lnk` / `.dll` into the user's documents.
- AI request gets a 60s wall-clock timeout (composed with user AbortController) and the response is capped at 200 KB.
- Tauri CSP tightened (`object-src 'none'`, `base-uri 'self'`, `form-action 'none'`, `frame-ancestors 'none'`); asset protocol disabled and the matching `protocol-asset` cargo feature dropped — the app loads images via plugin-fs + blob URLs and never touches `asset:`.

### UX
- Status bar shows "selected / total" word count when the editor has a selection.
- Welcome screen: Settings button next to Open/New, "Clear all" link in the Recent header, visible drag-highlight when a `.md` is dragged over.
- Welcome screen: per-row Remove on Recents was a `<span role="button">` nested inside a `<button>` — invalid HTML and could double-fire (remove then reopen). Split into siblings.
- File-op errors now surface the real Rust error message instead of a generic "Failed to save file" toast, so the new size limits are explained when hit.

### Code quality
- Dropped dead `localStorage` helpers `getFocusMode`/`setFocusMode`/`getAutoSave`/`setAutoSave` (both features were retired in 0.6.1).

