### PR TITLE
fix: Ctrl+J opens WebView2 Downloads — add Alt+J fallback for AI bubble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Webview accelerator collision
+
+- AI assist shortcut now also responds to **Alt+J**. On Windows, WebView2
+  treats `Ctrl+J` as a "browser accelerator" for the built-in Downloads
+  UI — the page never sees the keydown, so `e.preventDefault()` can't
+  rescue it. Alt+J skips that path entirely. macOS (WKWebView) and Linux
+  (WebKitGTK) keep `Ctrl+J` working; the cheatsheet detects the platform
+  and shows the right one. A capture-phase `keydown` listener also
+  preventDefaults Ctrl+J app-wide, so on platforms where the page does
+  see the event the host webview's default action is suppressed
+  regardless of which element is focused.
+
 ### Fixed — Security
 
 - `read_file` / `save_file` refuse documents above 50 MB. Stat happens before

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ A few essentials — press `?` inside the app for the full searchable list.
 | Find / Replace | Ctrl+F / Ctrl+H |
 | Bold / Italic / Link | Ctrl+B / Ctrl+I / Ctrl+K |
 | Toggle blockquote | Ctrl+/ |
-| AI assist | Ctrl+J |
+| AI assist | Ctrl+J (macOS/Linux) · Alt+J (Windows) |
 
 ## Tech Stack
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -683,7 +683,25 @@ function AppContent() {
     };
 
     window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
+
+    // Defense-in-depth for Ctrl+J: Edge/Chrome/WebView2 treat Ctrl+J as a
+    // "browser accelerator" for Downloads. On WebView2 (Windows) the page
+    // never sees this keydown, so JS can't help — users have Alt+J as the
+    // working alias there. On WebKitGTK (Linux) and WKWebView (macOS) the
+    // event DOES reach the page; we capture-phase preventDefault here so the
+    // host webview's default action is suppressed regardless of which
+    // element is focused (textarea, palette input, settings, etc.).
+    const blockCtrlJ = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && (e.key === "j" || e.key === "J")) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener("keydown", blockCtrlJ, { capture: true });
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keydown", blockCtrlJ, { capture: true } as EventListenerOptions);
+    };
   }, []);
 
   // Get export HTML from the visible preview on demand (avoids duplicate rendering)

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -175,19 +175,26 @@ export function CodeEditor({ content, onChange, onCursorChange, onSelectionChang
                 setFindOpen(true);
                 return;
             }
-            // Ctrl+J — open AI bubble on selection or current line
-            if (e.key === "j" || e.key === "J") {
-                e.preventDefault();
-                const t = textareaRef.current;
-                if (!t) return;
-                const lineIdx = t.value.slice(0, state.selStart).split("\n").length - 1;
-                const rect = t.getBoundingClientRect();
-                const y = rect.top + EDITOR_PADDING + lineIdx * EDITOR_LINE_HEIGHT - t.scrollTop + EDITOR_LINE_HEIGHT + 4;
-                const x = rect.left + EDITOR_PADDING + 12;
-                const text = state.text.slice(state.selStart, state.selEnd);
-                setAIBubble({ x, y, selStart: state.selStart, selEnd: state.selEnd, text });
-                return;
-            }
+        }
+        // AI bubble: Ctrl+J on Linux/macOS (WebKitGTK / WKWebView), Alt+J
+        // everywhere — including Windows, where WebView2 grabs Ctrl+J for
+        // the built-in Downloads UI before the page can preventDefault. The
+        // Alt+J alias keeps the J mnemonic without colliding with that
+        // accelerator.
+        const isAiCombo =
+            ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey && (e.key === "j" || e.key === "J")) ||
+            (e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey && (e.key === "j" || e.key === "J" || e.code === "KeyJ"));
+        if (isAiCombo) {
+            e.preventDefault();
+            const t = textareaRef.current;
+            if (!t) return;
+            const lineIdx = t.value.slice(0, state.selStart).split("\n").length - 1;
+            const rect = t.getBoundingClientRect();
+            const y = rect.top + EDITOR_PADDING + lineIdx * EDITOR_LINE_HEIGHT - t.scrollTop + EDITOR_LINE_HEIGHT + 4;
+            const x = rect.left + EDITOR_PADDING + 12;
+            const text = state.text.slice(state.selStart, state.selEnd);
+            setAIBubble({ x, y, selStart: state.selStart, selEnd: state.selEnd, text });
+            return;
         }
 
         // Ctrl/Cmd shortcuts (Bold, Italic, Link). Other Ctrl combos handled at app level.

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -17,7 +17,12 @@ interface ShortcutGroup {
 }
 
 const isMac = typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+const isWindows = typeof navigator !== "undefined" && /Win/.test(navigator.platform);
 const cmd = isMac ? "⌘" : "Ctrl";
+// On Windows, WebView2 grabs Ctrl+J for the built-in Downloads UI before
+// the page can preventDefault, so we surface Alt+J as the primary AI
+// shortcut there. macOS / Linux see Ctrl+J fine.
+const aiShortcut = isWindows ? "Alt+J" : `${cmd}+J`;
 
 const groups: ShortcutGroup[] = [
     {
@@ -38,7 +43,7 @@ const groups: ShortcutGroup[] = [
             { keys: `${cmd}+Shift+O`, description: "Toggle outline" },
             { keys: `${cmd}+P`, description: "Command palette" },
             { keys: `${cmd}+,`, description: "Open settings" },
-            { keys: `${cmd}+J`, description: "AI assist on selection" },
+            { keys: aiShortcut, description: "AI assist on selection" },
             { keys: "?", description: "Show this cheatsheet" },
         ],
     },


### PR DESCRIPTION
## Symptom

User reported: pressing **Ctrl+J** opens the WebView2 Downloads UI at the top right of the window instead of the AI assist bubble.

## Root cause

WebView2 (Windows) treats `Ctrl+J` as a **browser accelerator key** — it's intercepted by the host before the page-level keydown ever fires. `e.preventDefault()` in `CodeEditor`'s React `onKeyDown` runs on an event the page never receives, so it's a no-op on Windows. macOS (WKWebView) and Linux (WebKitGTK) don't have this problem.

I checked Tauri 2.9.5: there is no `browserAcceleratorKeys` field in `tauri.conf.json`, and reaching the wry Windows extension trait would require pulling in `webview2-com` + `windows` crates as deps.

## Fix

Pragmatic and dep-free:

1. **`Alt+J` is now an alias** for AI assist. Works on every webview because no host treats Alt+J as a built-in shortcut.
2. **`Ctrl+J` still works on macOS / Linux** (where the page actually sees the keydown).
3. **App-wide capture-phase listener** preventDefaults `Ctrl+J` regardless of focus, so the host webview's default action is suppressed on platforms that respect it. (No-op on Windows WebView2 but harmless.)
4. **Cheatsheet detects Windows** and surfaces `Alt+J`; macOS/Linux still see `⌘+J` / `Ctrl+J`.
5. **README** updated to reflect both shortcuts.

## Test plan

- [ ] Windows: press Alt+J with text selected → AI bubble opens (Downloads UI doesn't)
- [ ] Windows: press Ctrl+J → Downloads UI still opens (acknowledged limitation, documented)
- [ ] macOS: press ⌘+J → AI bubble opens
- [ ] Linux: press Ctrl+J → AI bubble opens
- [x] `bunx tsc --noEmit` clean
- [ ] Cheatsheet on Windows shows "Alt+J" for AI assist