### PR TITLE
Math/chemistry rendering + caret alignment + large-doc typing perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Chemistry notation in math
+
+- KaTeX now loads the **mhchem** contrib alongside the rest of the math
+  bundle, so `\ce{...}` and `\pu{...}` render in the preview.
+  This unlocks textbook-grade chemistry: balanced equations, ions,
+  isotopes, oxidation states, arrows, and Kröger-Vink defect notation
+  (e.g. `$\ce{2 Fe^x_{Fe} + O^x_{O} -> 2 Fe'_{Fe} + V_{O}^{**} + 1/2 O2 ^}$`).
+  The math-detection regex now also picks up bare `\ce{` / `\pu{`,
+  so chemistry-only documents trigger the lazy load even without
+  `$` delimiters. New `/chem` slash command inserts a starter snippet.
+
+### Improved — Book-style math typography
+
+- Display equations are centered with proper vertical breathing room and
+  scroll horizontally on narrow viewports instead of overflowing the
+  reading column. KaTeX glyphs no longer inherit the global `code` border
+  /background, and equation tags pick up the muted-text colour for a
+  printed-textbook feel.
+
+### Fixed — Caret drifts off the rendered glyph after scrolling
+
+- The CodeEditor stacks a transparent `<textarea>` on top of a styled
+  highlight overlay; alignment relies on both layers wrapping at the
+  same column. Once the document grew past the viewport the textarea
+  sprouted a vertical scrollbar that quietly ate ~10 px of its content
+  area, while the overlay kept its full width. With word-wrap on, the
+  two layers wrapped at different columns and the caret started landing
+  a character or two off the rendered text after every scroll. Both
+  layers now reserve a fixed scrollbar gutter (`scrollbar-gutter: stable`),
+  and the overlay's own scrollbar is hidden visually so only the
+  textarea's remains user-facing.
+
+### Improved — Editor performance on large documents
+
+- Typing into a 5 k+ line markdown file used to feel "sticky" because
+  the highlight overlay mounted every line as a `<div>` and React's
+  reconciler walked the lot on every keystroke. The overlay now
+  virtualizes: only the lines visible in the viewport (plus a 40-line
+  buffer) render, with fixed-height spacers above and below preserving
+  scroll-height parity with the textarea so caret alignment is intact.
+  Re-renders only fire when the visible window shifts by more than half
+  the buffer, so smooth scrolling no longer thrashes setState.
+  Word-wrap mode and small docs (under 400 lines) keep the previous
+  full-render path. Per-line wrapper styles are also hoisted to module
+  scope and the non-virtualized list is wrapped in `React.memo` so
+  unchanged lines short-circuit prop diffing.
+
 ### Fixed — Webview accelerator collision
 
 - AI assist shortcut now also responds to **Alt+J**. On Windows, WebView2

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ I wanted a simple, lightweight solution that renders markdown beautifully while 
 - **GitHub Flavored Markdown** with task lists, tables, strikethrough
 - **Code blocks** with syntax highlighting and one-click copy
 - **Math** via KaTeX (`$inline$`, `$$block$$`) — loaded only when needed
-- **Mermaid diagrams** (` ```mermaid `) — loaded only when needed
+- **Chemistry** via mhchem — `$\ce{2 H2 + O2 -> 2 H2O}$`, ions, isotopes, Kröger-Vink defects
+- **Mermaid diagrams** (` ```mermaid `) — flowcharts, sequence, class, state, gantt, ER, mindmaps
 - **Image lightbox** — click to zoom; lazy loading
 - **Interactive task checkboxes** — toggling writes back to source
 - **Heading anchors** with click-to-jump

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -69,6 +69,15 @@ const sharedTextStyle: React.CSSProperties = {
     wordBreak: "normal",
     overflowWrap: "normal",
     boxSizing: "border-box",
+    // Reserve a fixed-width scrollbar gutter on both layers regardless of
+    // whether the scrollbar is currently shown. Without this, the textarea's
+    // scrollbar appears once content overflows vertically and silently
+    // narrows the content area by ~10px — but the highlight overlay (which
+    // has no scrollbar) keeps its full width. The two layers then wrap text
+    // at different columns, and after a couple of wrapped lines the caret
+    // visibly drifts off the rendered glyph. Reserving the gutter keeps
+    // both layers' content widths identical.
+    scrollbarGutter: "stable",
 };
 
 // Line-number gutter. Extracted + memoized so typing within a single line
@@ -840,7 +849,15 @@ export function CodeEditor({ content, onChange, onCursorChange, onSelectionChang
                     since its fixed Y assumes uniform line heights. */}
                 <div
                     ref={highlightRef}
-                    className="absolute inset-0 text-[var(--text-primary)] pointer-events-none overflow-hidden"
+                    // overflow:auto (instead of hidden) so the `scrollbar-gutter:
+                    // stable` rule in sharedTextStyle takes effect — that gutter
+                    // is what keeps wrap columns identical between this layer
+                    // and the textarea. The scrollbar itself stays invisible
+                    // (see .editor-overlay-scrollbar-hidden in index.css), and
+                    // pointer-events:none means the user never interacts with
+                    // it directly anyway. Vertical scroll position is driven
+                    // imperatively by the rAF sync below.
+                    className="absolute inset-0 text-[var(--text-primary)] pointer-events-none overflow-auto editor-overlay-scrollbar-hidden"
                     aria-hidden="true"
                     style={{ ...sharedTextStyle, ...wrapStyle }}
                 >

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -80,6 +80,79 @@ const sharedTextStyle: React.CSSProperties = {
     scrollbarGutter: "stable",
 };
 
+// Stable per-line wrapper styles. Hoisting these out of the render path means
+// every <div> in the highlight overlay receives the SAME style ref across
+// renders, so React's prop diff is a single ref check instead of an iteration
+// over the keys of a freshly-allocated style object. With 5k+ lines the
+// difference is measurable on each keystroke.
+const HIGHLIGHT_LINE_STYLE_FIXED: React.CSSProperties = {
+    height: `${EDITOR_LINE_HEIGHT}px`,
+    lineHeight: `${EDITOR_LINE_HEIGHT}px`,
+    position: "relative",
+};
+const HIGHLIGHT_LINE_STYLE_WRAP: React.CSSProperties = {
+    minHeight: `${EDITOR_LINE_HEIGHT}px`,
+    lineHeight: `${EDITOR_LINE_HEIGHT}px`,
+    position: "relative",
+};
+
+// Renders every line — used for small docs and word-wrap mode. Memoized so
+// React skips reconciliation entirely when the `lines` ref hasn't changed
+// (the per-line cache in CodeEditor preserves array refs for unchanged lines,
+// but React still walks children unless the parent itself short-circuits).
+const RenderedLines = memo(function RenderedLines({
+    lines,
+    wordWrap,
+}: {
+    lines: React.ReactNode[];
+    wordWrap: boolean;
+}) {
+    const lineStyle = wordWrap ? HIGHLIGHT_LINE_STYLE_WRAP : HIGHLIGHT_LINE_STYLE_FIXED;
+    return (
+        <>
+            {lines.map((node, i) => (
+                <div key={i} style={lineStyle}>
+                    {node}
+                </div>
+            ))}
+        </>
+    );
+});
+
+// Renders only the slice [firstVisible, lastVisible) of the doc, with
+// fixed-height spacers above and below to preserve the textarea/overlay
+// scroll-height parity (caret-glyph alignment depends on it). Only valid
+// when wordWrap is OFF — variable line heights would break the geometry.
+const VirtualizedHighlight = memo(function VirtualizedHighlight({
+    lines,
+    firstVisible,
+    lastVisible,
+}: {
+    lines: React.ReactNode[];
+    firstVisible: number;
+    lastVisible: number;
+}) {
+    const total = lines.length;
+    const slice: React.ReactNode[] = [];
+    const end = Math.min(lastVisible, total);
+    for (let i = firstVisible; i < end; i++) {
+        slice.push(
+            <div key={i} style={HIGHLIGHT_LINE_STYLE_FIXED}>
+                {lines[i]}
+            </div>
+        );
+    }
+    const topSpacer = firstVisible * EDITOR_LINE_HEIGHT;
+    const bottomSpacer = Math.max(0, total - end) * EDITOR_LINE_HEIGHT;
+    return (
+        <>
+            {topSpacer > 0 && <div aria-hidden style={{ height: `${topSpacer}px` }} />}
+            {slice}
+            {bottomSpacer > 0 && <div aria-hidden style={{ height: `${bottomSpacer}px` }} />}
+        </>
+    );
+});
+
 // Line-number gutter. Extracted + memoized so typing within a single line
 // (lineCount unchanged, activeLine unchanged) doesn't cause React to reconcile
 // thousands of <div>s on every keystroke. Only re-renders when the visible line
@@ -443,6 +516,11 @@ export function CodeEditor({ content, onChange, onCursorChange, onSelectionChang
         };
     }, [updateCursorPosition]);
 
+    // Indirection ref so the rAF sync below can call the latest
+    // recomputeVisible without re-installing the rAF loop on every render.
+    // Assigned just below where recomputeVisible is declared.
+    const recomputeVisibleRef = useRef<() => void>(() => { });
+
     // Use rAF-based scroll sync for sub-frame accuracy. The native scroll event
     // can lag the caret by 1 frame; rAF lets us catch up before paint.
     useEffect(() => {
@@ -469,9 +547,15 @@ export function CodeEditor({ content, onChange, onCursorChange, onSelectionChang
                 if (gutterRef.current) {
                     gutterRef.current.scrollTop = top;
                 }
-                if (top !== lastTop && onScrollFraction) {
-                    const max = t.scrollHeight - t.clientHeight;
-                    onScrollFraction(max > 0 ? top / max : 0);
+                if (top !== lastTop) {
+                    if (onScrollFraction) {
+                        const max = t.scrollHeight - t.clientHeight;
+                        onScrollFraction(max > 0 ? top / max : 0);
+                    }
+                    // Re-evaluate the virtualization window on real vertical
+                    // motion. The hysteresis inside guarantees we only call
+                    // setState when the window has actually moved.
+                    recomputeVisibleRef.current();
                 }
                 lastTop = top;
                 lastLeft = left;
@@ -547,6 +631,89 @@ export function CodeEditor({ content, onChange, onCursorChange, onSelectionChang
         }
         return out;
     }, [lines]);
+
+    // Virtualization for the highlight overlay.
+    //
+    // Without this, a 10k-line file mounts 10k <div> nodes in the highlight
+    // layer; every keystroke makes React's reconciler walk all of them even
+    // though the per-line node refs are cached and equal. That walk is what
+    // makes typing feel "sticky" on large markdown files.
+    //
+    // We only render the lines currently visible in the viewport, plus a
+    // generous buffer so scrolling never reveals an un-rendered gap before
+    // the next recompute fires. The total scroll height is preserved with
+    // top/bottom spacer divs so the textarea's and overlay's scroll
+    // geometry stay identical (caret-glyph alignment depends on it).
+    //
+    // Word-wrap mode opts out: line heights vary with content there, so we
+    // can't compute slot positions without measurement. The cap on
+    // `RENDER_ALL_THRESHOLD` keeps small/medium docs unchanged regardless,
+    // because virtualization adds a (tiny) per-scroll cost of its own.
+    const VIRTUALIZE_BUFFER = 40;
+    const RENDER_ALL_THRESHOLD = 400;
+    const shouldVirtualize = !wordWrap && lineCount > RENDER_ALL_THRESHOLD;
+    const [visibleRange, setVisibleRange] = useState({ first: 0, last: 0 });
+    const visibleRangeRef = useRef(visibleRange);
+    visibleRangeRef.current = visibleRange;
+
+    const recomputeVisible = useCallback(() => {
+        if (!shouldVirtualize) return;
+        const t = textareaRef.current;
+        if (!t) return;
+        const top = t.scrollTop;
+        const height = t.clientHeight;
+        const first = Math.max(
+            0,
+            Math.floor((top - EDITOR_PADDING) / EDITOR_LINE_HEIGHT) - VIRTUALIZE_BUFFER
+        );
+        const last = Math.min(
+            lineCount,
+            Math.ceil((top + height - EDITOR_PADDING) / EDITOR_LINE_HEIGHT) + VIRTUALIZE_BUFFER
+        );
+        const cur = visibleRangeRef.current;
+        // Hysteresis: only update when the window has shifted enough that a
+        // re-render is genuinely needed. Prevents setState thrash during
+        // smooth scrolling.
+        const halfBuf = VIRTUALIZE_BUFFER / 2;
+        if (Math.abs(first - cur.first) >= halfBuf || Math.abs(last - cur.last) >= halfBuf) {
+            setVisibleRange({ first, last });
+        }
+    }, [shouldVirtualize, lineCount]);
+
+    // Keep the ref pointed at the latest recomputeVisible so the rAF sync
+    // (which depends only on onScrollFraction) doesn't tear down + rebuild
+    // every time lineCount or shouldVirtualize changes.
+    recomputeVisibleRef.current = recomputeVisible;
+
+    // Initialize / reset the visible window when virtualization toggles or the
+    // doc is replaced wholesale (file open, big paste). Without this the
+    // initial state {first:0, last:0} would render zero lines on first paint.
+    useEffect(() => {
+        if (!shouldVirtualize) {
+            // Make sure the next switch back into virtualization re-seeds.
+            if (visibleRangeRef.current.last !== 0) {
+                setVisibleRange({ first: 0, last: 0 });
+            }
+            return;
+        }
+        const t = textareaRef.current;
+        if (!t) return;
+        const top = t.scrollTop;
+        const height = t.clientHeight || 600;
+        const first = Math.max(
+            0,
+            Math.floor((top - EDITOR_PADDING) / EDITOR_LINE_HEIGHT) - VIRTUALIZE_BUFFER
+        );
+        const last = Math.min(
+            lineCount,
+            Math.ceil((top + height - EDITOR_PADDING) / EDITOR_LINE_HEIGHT) + VIRTUALIZE_BUFFER
+        );
+        setVisibleRange({ first, last });
+    }, [shouldVirtualize, lineCount]);
+
+    // Hook recomputeVisible into scroll. We piggyback on the existing rAF in
+    // the next effect (it already runs on every frame while there's scroll
+    // motion); no extra event listener needed.
 
     // Typewriter mode: keep the active line vertically centered as the caret moves.
     useEffect(() => {
@@ -872,22 +1039,15 @@ export function CodeEditor({ content, onChange, onCursorChange, onSelectionChang
                             }}
                         />
                     )}
-                    {highlightedLines.map((highlighted, i) => {
-                        const lineSizing: React.CSSProperties = wordWrap
-                            ? { minHeight: `${EDITOR_LINE_HEIGHT}px`, lineHeight: `${EDITOR_LINE_HEIGHT}px` }
-                            : { height: `${EDITOR_LINE_HEIGHT}px`, lineHeight: `${EDITOR_LINE_HEIGHT}px` };
-                        return (
-                            <div
-                                key={i}
-                                style={{
-                                    ...lineSizing,
-                                    position: "relative",
-                                }}
-                            >
-                                {highlighted}
-                            </div>
-                        );
-                    })}
+                    {shouldVirtualize ? (
+                        <VirtualizedHighlight
+                            lines={highlightedLines}
+                            firstVisible={visibleRange.first}
+                            lastVisible={visibleRange.last}
+                        />
+                    ) : (
+                        <RenderedLines lines={highlightedLines} wordWrap={wordWrap} />
+                    )}
                 </div>
 
                 <FindReplaceBar

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -10,8 +10,9 @@ import { MermaidBlock, isMermaidLanguage } from "./MermaidBlock";
 
 // Detect KaTeX-style math so we only load the heavy katex bundle when needed.
 // $$...$$ for block math, $...$ for inline math (not preceded/followed by digit
-// to avoid false positives like "$5 and $10").
-const MATH_DETECTION_REGEX = /(\$\$[\s\S]+?\$\$)|((?:^|[^\d$])\$[^\s$][^\n$]*?[^\s$]\$(?!\d))/m;
+// to avoid false positives like "$5 and $10"). Also matches chemistry blocks
+// written as \ce{...} / \pu{...} so people can use mhchem without explicit $$.
+const MATH_DETECTION_REGEX = /(\$\$[\s\S]+?\$\$)|((?:^|[^\d$])\$[^\s$][^\n$]*?[^\s$]\$(?!\d))|(\\ce\{)|(\\pu\{)/m;
 const hasMath = (s: string): boolean => MATH_DETECTION_REGEX.test(s);
 
 type PluginPair = { remark: unknown; rehype: unknown };
@@ -21,10 +22,15 @@ let mathLoadPromise: Promise<PluginPair> | null = null;
 const loadMathPlugins = (): Promise<PluginPair> => {
     if (mathPluginsCache) return Promise.resolve(mathPluginsCache);
     if (mathLoadPromise) return mathLoadPromise;
+    // Load mhchem alongside KaTeX so chemistry notation like
+    //   $\ce{2 Fe^x_{Fe} + O^x_{O} -> 2 Fe'_{Fe} + V_{O}^{**} + 1/2 O2 ^}$
+    // renders properly in standard book-style typography. mhchem patches
+    // KaTeX's macro table on import, so it must load before the first render.
     mathLoadPromise = Promise.all([
         import("remark-math"),
         import("rehype-katex"),
         import("katex/dist/katex.min.css"),
+        import("katex/dist/contrib/mhchem.mjs"),
     ]).then(([rm, rk]) => {
         mathPluginsCache = { remark: rm.default, rehype: rk.default };
         return mathPluginsCache;

--- a/src/components/SlashMenu.tsx
+++ b/src/components/SlashMenu.tsx
@@ -23,6 +23,7 @@ const commands: SlashCommand[] = [
     { id: "table", label: "Table", description: "| h | h |\\n| - | - |", snippet: "| Header 1 | Header 2 |\n| --- | --- |\n| Cell | Cell |\n", caretOffset: 11, icon: "table_chart" },
     { id: "hr", label: "Divider", description: "Horizontal rule", snippet: "\n---\n\n", caretOffset: 6, icon: "horizontal_rule" },
     { id: "math", label: "Math block", description: "$$ ... $$", snippet: "$$\n\n$$\n", caretOffset: 3, icon: "function" },
+    { id: "chem", label: "Chemistry equation", description: "$\\ce{...}$ — mhchem", snippet: "$\\ce{}$", caretOffset: 5, icon: "science" },
     { id: "mermaid", label: "Mermaid diagram", description: "```mermaid", snippet: "```mermaid\ngraph LR\n  A --> B\n```\n", caretOffset: 11, icon: "schema" },
     { id: "callout", label: "Callout", description: "> [!NOTE]", snippet: "> [!NOTE]\n> ", caretOffset: 12, icon: "info" },
 ];

--- a/src/index.css
+++ b/src/index.css
@@ -376,6 +376,33 @@ select:focus-visible,
   font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 }
 
+/* ===== Editor overlay scrollbar reservation =====
+   The CodeEditor stacks a transparent <textarea> on top of a styled highlight
+   overlay. They MUST agree on content width or word-wrap fires at different
+   columns and the caret drifts off the rendered glyph after scrolling.
+   `scrollbar-gutter: stable` keeps a fixed-width gutter in both layers
+   regardless of whether the scrollbar is currently shown, eliminating the
+   reflow that used to mis-align the two when content grew past the viewport.
+
+   The highlight layer should never *show* its own scrollbar — the textarea
+   owns the visible one. We hide it by making the scrollbar track + thumb
+   transparent and unclickable. This works with `pointer-events: none` on the
+   parent (so the user never tries to scroll it directly anyway). */
+.editor-overlay-scrollbar-hidden::-webkit-scrollbar-thumb,
+.editor-overlay-scrollbar-hidden::-webkit-scrollbar-track,
+.editor-overlay-scrollbar-hidden::-webkit-scrollbar-corner {
+  background: transparent;
+  border: 0;
+}
+
+.editor-overlay-scrollbar-hidden::-webkit-scrollbar-thumb:hover {
+  background: transparent;
+}
+
+.editor-overlay-scrollbar-hidden {
+  scrollbar-color: transparent transparent;
+}
+
 /* ===== Blinking Cursor Animation ===== */
 @keyframes blink {
 

--- a/src/index.css
+++ b/src/index.css
@@ -699,6 +699,51 @@ select:focus-visible,
   font-weight: 600;
 }
 
+/* ===== Math (KaTeX) — book-style typography =====
+   KaTeX ships its own font stack, so we don't override font-family.
+   We DO style the surrounding block math: center it, give it breathing
+   room above/below the paragraph, and let long equations scroll on
+   narrow viewports instead of overflowing the column. */
+.markdown-body .katex {
+  font-size: 1.05em;
+  color: var(--text-primary);
+}
+
+.markdown-body .katex-display {
+  margin: 1.25rem 0;
+  padding: 0.25rem 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  /* Prefer centered display equations like a printed textbook */
+  text-align: center;
+}
+
+/* Inline math should sit on the prose baseline without inheriting
+   border/background from the global `code` styles. rehype-katex emits
+   <span class="katex"> only, but mhchem can briefly produce nested
+   <code> nodes during parsing — strip the outline so chemistry blocks
+   render cleanly. */
+.markdown-body .katex,
+.markdown-body .katex * {
+  background: transparent;
+  border: 0;
+}
+
+/* Equation numbering (\tag{}) and small labels: keep the muted tone
+   consistent with the rest of the doc rather than KaTeX's default black. */
+.markdown-body .katex .tag {
+  color: var(--text-secondary);
+}
+
+/* On narrow screens, equations may exceed column width. KaTeX wraps the
+   math in <span class="katex-display"><span class="katex">...</span></span>;
+   the inner element controls width, so we constrain the outer scroller. */
+.markdown-body .katex-display > .katex {
+  display: inline-block;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
 /* ===== Syntax Highlighting (code blocks) ===== */
 .hljs {
   background: transparent;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+// KaTeX ships its mhchem extension as a side-effect module that patches the
+// global KaTeX macro table. There's no public type surface — we just need to
+// import it for its side effects. Without this declaration, TS errors on the
+// dynamic import inside MarkdownPreview.tsx.
+declare module "katex/dist/contrib/mhchem.mjs";


### PR DESCRIPTION
## Summary

Reported issue: math equations don't render in standard book-style format,
typing in code mode feels sluggish on large markdown files, and after
scrolling-then-typing the caret no longer lands on the rendered character.

This PR addresses all three plus surfaces chemistry rendering for the user
who asked about `2 Fe^x_Fe + O^x_O -> ...` Kröger-Vink notation.

### Changes

- **`feat(math)`** — KaTeX now lazy-loads the **mhchem** contrib alongside
  the rest of the math bundle, so `\ce{...}` and `\pu{...}` render in the
  preview. Math-detection regex picks up bare `\ce{` / `\pu{` so chemistry-
  only docs trigger the lazy load even without `$` delimiters. New `/chem`
  slash command drops a starter snippet.
- **`style(math)`** — Display equations are centered, get vertical
  breathing room, and scroll horizontally on narrow viewports instead of
  overflowing the column. KaTeX glyphs no longer inherit the global `code`
  border/background.
- **`fix(editor)`** — Caret alignment after scroll/wrap. The transparent
  textarea was sprouting a vertical scrollbar that ate ~10 px of content
  width while the highlight overlay stayed full-width, so the two layers
  wrapped at different columns. Both layers now reserve a fixed scrollbar
  gutter (`scrollbar-gutter: stable`); the overlay's scrollbar is hidden
  visually so only the textarea's stays user-facing.
- **`perf(editor)`** — Virtualization for large no-wrap docs. The highlight
  overlay used to mount every line as a `<div>` (e.g. 5k+ DOM nodes for a
  big file), so React's reconciler walked the lot on every keystroke. Now
  only the visible window plus a 40-line buffer renders, with fixed-height
  spacers preserving scroll-height parity for caret alignment. Word-wrap
  mode and small docs (< 400 lines) keep the previous full-render path.
  Per-line wrapper styles hoisted to module scope; `RenderedLines` wrapped
  in `React.memo` to short-circuit prop diffing.

### Files

- `src/components/MarkdownPreview.tsx` — load mhchem with KaTeX, broaden math
  detection.
- `src/components/CodeEditor.tsx` — scrollbar gutter + virtualization.
- `src/components/SlashMenu.tsx` — new `/chem` command.
- `src/index.css` — book-style math typography + overlay scrollbar hiding.
- `src/vite-env.d.ts` — ambient declaration for the side-effect mhchem import.
- `README.md`, `CHANGELOG.md` — user-facing notes.

## Test plan

- [ ] Paste this in a doc and confirm preview renders the textbook equation:
      ```
      $$\ce{2 Fe^x_{Fe} + O^x_{O} -> 2 Fe'_{Fe} + V_{O}^{**} + 1/2 O2 ^}$$
      ```
- [ ] Inline chemistry: `Water is $\ce{H2O}$.` renders with subscript.
- [ ] Standard math still works: `$E = mc^2$` and `$$\int_0^\infty e^{-x}\,dx = 1$$`.
- [ ] Mermaid diagrams still render (no regression): a `mermaid` code block
      with a flowchart.
- [ ] Open a large markdown file (5 k+ lines), turn off word-wrap, type at
      various positions — should feel responsive, no stutter.
- [ ] In the same file with word-wrap on, scroll halfway, click into a
      paragraph, type — caret should land where the click was.
- [ ] `/chem` from slash menu inserts `$\ce{}$` with the caret between the braces.
- [ ] No TypeScript errors (`tsc --noEmit`).
- [ ] `vite build` succeeds.