### PR TITLE
Revert textarea-visible flip + fix click-after-scroll alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed — Typing now feels native
+### Fixed — Click after scroll lands on the right line
 
-- The CodeEditor stacks a transparent `<textarea>` under a styled
-  highlight overlay. Until now the textarea had `text-transparent`, so
-  even though the browser painted typed characters into it within the
-  same frame as the keypress, the user **could not see** that paint.
-  The visible text only appeared once React reconciled the overlay —
-  which on a large doc is 10–30 ms behind the keypress and is what made
-  typing feel like it was lagging behind keys, especially compared to
-  Notepad or any native text editor.
-- Flipped the layering: the textarea now renders with
-  `text-[var(--text-primary)]` (visible default-color glyphs) and the
-  highlight overlay defaults to `text-transparent`. Syntax-colored
-  spans in the overlay set their own color via Tailwind classes, which
-  override the inherited transparent and continue to paint cleanly over
-  the textarea's plain text. The overlay is moved to `z-[1]` so its
-  syntax colors stay on top, and gets `contain: paint` +
-  `will-change: transform` so its frequent re-renders compose on a
-  separate layer instead of invalidating the editor surface.
-- Result: every typed character appears in the same frame as the
-  keypress (browser-native paint), and the syntax colors fade in once
-  React catches up. Typing now feels like Notepad even on multi-megabyte
-  documents.
+- Scrolling and immediately clicking (or double-clicking) used to land
+  the caret on a line one row off from where it visibly looked like
+  the click was — typing then added text to the "wrong" line, which
+  was confusing. The cause: the highlight overlay's `scrollTop` was
+  synced to the textarea via a rAF loop, which catches up on the NEXT
+  frame after the scroll. If you clicked inside that 16-ms window, the
+  textarea had already placed the caret at the new position but the
+  overlay was still painting the old one, so the visible glyph at the
+  click coordinate didn't match the textarea's text-position mapping.
+- Replaced the rAF loop with a synchronous `onScroll` handler on the
+  textarea. The overlay's scrollTop is now updated in the same turn
+  as the scroll event, so the two layers stay in lockstep and clicks
+  always land where the user expects. Also frees the main thread from
+  a 60 Hz rAF callback that was firing whether the editor was idle or
+  not.
+
+### Improved — Smaller per-keystroke recompute
+
+- `updateCursorPosition` ran twice per keystroke (selectionchange AND
+  keyup both fire). The downstream setStates already bailed via
+  `Object.is`, but the substring + split work itself ran twice. Now
+  caches the last reported (start, end) range and short-circuits at
+  the top when nothing's moved.
 
 ### Improved — Cold start and runtime performance
 

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -533,58 +533,42 @@ function CodeEditorImpl({ content, onChange, onCursorChange, onSelectionChange, 
         };
     }, [updateCursorPosition]);
 
-    // Indirection ref so the rAF sync below can call the latest
-    // recomputeVisible without re-installing the rAF loop on every render.
+    // Indirection ref so handleTextareaScroll below can call the latest
+    // recomputeVisible without re-creating the callback on every render.
     // Assigned just below where recomputeVisible is declared.
     const recomputeVisibleRef = useRef<() => void>(() => { });
 
-    // Use rAF-based scroll sync for sub-frame accuracy. The native scroll event
-    // can lag the caret by 1 frame; rAF lets us catch up before paint.
-    useEffect(() => {
-        const textarea = textareaRef.current;
-        if (!textarea) return;
-
-        let rafId: number | null = null;
-        let lastTop = -1;
-        let lastLeft = -1;
-
-        const sync = () => {
-            const t = textareaRef.current;
-            if (!t) {
-                rafId = null;
-                return;
-            }
-            const top = t.scrollTop;
-            const left = t.scrollLeft;
-            if (top !== lastTop || left !== lastLeft) {
-                if (highlightRef.current) {
-                    highlightRef.current.scrollTop = top;
-                    highlightRef.current.scrollLeft = left;
-                }
-                if (gutterRef.current) {
-                    gutterRef.current.scrollTop = top;
-                }
-                if (top !== lastTop) {
-                    if (onScrollFraction) {
-                        const max = t.scrollHeight - t.clientHeight;
-                        onScrollFraction(max > 0 ? top / max : 0);
-                    }
-                    // Re-evaluate the virtualization window on real vertical
-                    // motion. The hysteresis inside guarantees we only call
-                    // setState when the window has actually moved.
-                    recomputeVisibleRef.current();
-                }
-                lastTop = top;
-                lastLeft = left;
-            }
-            rafId = requestAnimationFrame(sync);
-        };
-
-        rafId = requestAnimationFrame(sync);
-
-        return () => {
-            if (rafId !== null) cancelAnimationFrame(rafId);
-        };
+    // Synchronous scroll sync via the textarea's native onScroll. Wired into
+    // the JSX as `onScroll={handleTextareaScroll}`.
+    //
+    // Why this matters for click-after-scroll alignment: with the previous
+    // rAF-based sync the overlay's scrollTop only caught up on the NEXT
+    // animation frame after the textarea scrolled. If the user clicked
+    // (or double-clicked) inside that 16-ms window, the textarea placed
+    // the caret at the new scroll position but the overlay still painted
+    // the OLD position — giving the impression that the visible word was
+    // one line off from the click. Setting overlay.scrollTop in the same
+    // synchronous turn as the scroll event keeps the two layers in
+    // lockstep, so clicks always land where the user expects.
+    const handleTextareaScroll = useCallback((e: React.UIEvent<HTMLTextAreaElement>) => {
+        const t = e.currentTarget;
+        const top = t.scrollTop;
+        const left = t.scrollLeft;
+        if (highlightRef.current) {
+            highlightRef.current.scrollTop = top;
+            highlightRef.current.scrollLeft = left;
+        }
+        if (gutterRef.current) {
+            gutterRef.current.scrollTop = top;
+        }
+        if (onScrollFraction) {
+            const max = t.scrollHeight - t.clientHeight;
+            onScrollFraction(max > 0 ? top / max : 0);
+        }
+        // Virtualization window is recomputed on every scroll event; the
+        // hysteresis inside guarantees we only call setState when the
+        // visible window has genuinely moved.
+        recomputeVisibleRef.current();
     }, [onScrollFraction]);
 
     // Register an imperative scroller so external code (split-view sync) can
@@ -1044,36 +1028,11 @@ function CodeEditorImpl({ content, onChange, onCursorChange, onSelectionChange, 
                     // (see .editor-overlay-scrollbar-hidden in index.css), and
                     // pointer-events:none means the user never interacts with
                     // it directly anyway. Vertical scroll position is driven
-                    // imperatively by the rAF sync below.
-                    //
-                    // `text-transparent` on the wrapper — the textarea below
-                    // owns the visible default-color glyphs (see the textarea
-                    // styling for the full story). Syntax-colored spans here
-                    // set their own color via Tailwind classes
-                    // (text-[var(--syntax-h1)] etc.), which override the
-                    // inherited transparent and paint cleanly over the
-                    // textarea's plain rendering. Plain `<span>{text}</span>`
-                    // wrappers inherit transparent → invisible from this
-                    // layer → revealed by the textarea behind.
-                    //
-                    // z-index:1 keeps this overlay above the textarea so its
-                    // syntax-colored spans paint over the textarea's plain
-                    // rendering. The transparent regions (default-color text,
-                    // background) let the textarea show through.
-                    className="absolute inset-0 z-[1] text-transparent pointer-events-none overflow-auto editor-overlay-scrollbar-hidden"
+                    // imperatively from the textarea's onScroll handler so the
+                    // two layers stay in lockstep — see the textarea below.
+                    className="absolute inset-0 text-[var(--text-primary)] pointer-events-none overflow-auto editor-overlay-scrollbar-hidden"
                     aria-hidden="true"
-                    style={{
-                        ...sharedTextStyle,
-                        ...wrapStyle,
-                        // Promote the overlay to its own compositor layer so
-                        // syntax updates from React don't trigger a paint of
-                        // the underlying editor surface. Cheap on memory
-                        // (one bitmap per layer) and a meaningful win on
-                        // large docs where the overlay has thousands of
-                        // children to paint.
-                        willChange: "transform",
-                        contain: "paint",
-                    }}
+                    style={{ ...sharedTextStyle, ...wrapStyle }}
                 >
                     {!wordWrap && (
                         <div
@@ -1144,33 +1103,22 @@ function CodeEditorImpl({ content, onChange, onCursorChange, onSelectionChange, 
                     />
                 )}
 
-                {/* Editable textarea — the user-visible default-color text.
-                    The overlay above paints SYNTAX-COLORED spans on top of
-                    this textarea; non-styled text is rendered transparent up
-                    there so the textarea's plain rendering shows through.
-
-                    Why this stacking order matters for typing feel: when the
-                    user types, the browser updates this textarea's value and
-                    paints the new glyph in the same frame, before React even
-                    sees the input event. Previously the textarea was
-                    `text-transparent` so the user couldn't see that instant
-                    paint — they had to wait for React to reconcile the
-                    overlay (10-30 ms+ on a big doc). With visible textarea
-                    text, the typed character appears in the same frame as
-                    the keypress and the overlay's syntax colors fade in
-                    once React catches up. End result: typing feels native,
-                    the way Notepad does. */}
+                {/* Editable textarea — transparent text, real caret.
+                    The visible glyphs come from the highlight overlay above;
+                    this layer just owns input, selection, and the caret.
+                    Caret color stays opaque so the cursor is always visible. */}
                 <textarea
                     ref={textareaRef}
                     value={content}
                     onChange={handleChange}
                     onPaste={handlePaste}
                     onKeyDown={onKeyDown}
+                    onScroll={handleTextareaScroll}
                     spellCheck={spellCheck}
                     autoComplete="off"
                     autoCorrect={spellCheck ? "on" : "off"}
                     autoCapitalize="off"
-                    className="absolute inset-0 w-full h-full bg-transparent text-[var(--text-primary)] caret-[var(--accent)] resize-none outline-none overflow-auto border-0"
+                    className="absolute inset-0 w-full h-full bg-transparent text-transparent caret-[var(--accent)] resize-none outline-none overflow-auto border-0"
                     style={{
                         ...sharedTextStyle,
                         ...wrapStyle,


### PR DESCRIPTION
PR #35 was merged before my follow-up commit pushed, so main is currently
shipping the bad version. This PR brings the actual fix onto main.

## What's wrong on main right now

Commit `8e1fbfb` (merged via #35) tried to make typing feel instant by
flipping the textarea/overlay visibility — textarea visible, overlay
text-transparent. That approach **made things worse**, in two ways:

1. **Everything looks bold.** Every syntax-colored character (heading,
   code, link, list marker, bold) now gets painted twice — once by the
   textarea in regular weight + default color, once by the overlay in
   bold/colored. Anti-aliasing edges and font-weight mismatches make
   the result look subtly bolder and blurrier across all styled UI text.
2. **Typing feels slower, not faster.** The double-paint isn't free —
   the GPU has to composite two text layers per keystroke on top of
   React's normal render cost.

The user reported both issues immediately after #35 shipped.

## What this PR does

### Revert the flip

Restore the original architecture: textarea with `text-transparent`,
overlay with `text-[var(--text-primary)]`, no `z-index` hack, no
`contain` / `will-change` hints. Single layer of visible text, no
double-paint, no bold-looking artifacts.

### Fix click-after-scroll alignment for real

Separately, the user reported that clicking (or double-clicking) right
after a scroll lands the caret on a line one row off from where the
click visibly looked. Cause: the highlight overlay's `scrollTop` was
synced via a `requestAnimationFrame` loop, which catches up on the
*next* frame after the scroll. If the user clicked inside that 16-ms
window, the textarea had already placed the caret at the new scroll
position but the overlay was still painting the old one — visible glyph
at click coordinate didn't match where the textarea thought the caret
should go.

Replaced the rAF loop with a synchronous `onScroll` handler on the
textarea. The overlay's `scrollTop` is now updated in the same turn as
the scroll event, so the two layers stay in lockstep and clicks always
land where the user expects. Bonus: no more 60 Hz rAF callback firing
while the editor is idle.

### Keep cursor-recompute dedupe (already on main from #35)

This one (`6d632eb`) was a real, small perf win with no UI side effect.
It stays — nothing to revert.

## Files

- `src/components/CodeEditor.tsx` — revert flip, switch rAF→onScroll.
- `CHANGELOG.md` — entry under Unreleased rewritten to match what
  actually shipped.

## Test plan

- [ ] `tsc --noEmit` clean; `vite build` succeeds; main chunk near 282 kB.
- [ ] Open a long markdown file. Scroll halfway. Double-click a word.
      Selection visual is on the word you clicked, not the line below.
- [ ] Type after scrolling — text appears at the line you clicked, no
      offset.
- [ ] Headings, code, links, list markers render with their normal
      single-paint colors — no bold/heavy/double-rendering artifacts.
- [ ] Editor idle CPU is lower (no perpetual rAF callback).