### PR TITLE
AI chat panel — Phase 1 (right-side streaming Ask mode)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,9 @@ const ShortcutCheatsheet = lazy(() =>
 const UnsavedChangesDialog = lazy(() =>
     import("./components/UnsavedChangesDialog").then((m) => ({ default: m.UnsavedChangesDialog }))
 );
+const AIPanel = lazy(() =>
+    import("./components/AIPanel").then((m) => ({ default: m.AIPanel }))
+);
 import { getRecentFiles } from "./utils/persistence";
 import {
   addRecentFile,
@@ -148,6 +151,7 @@ function AppContent() {
   // Sidebar panel state
   const [showFileExplorer, setShowFileExplorer] = useState(false);
   const [showTOC, setShowTOC] = useState(false);
+  const [showAIPanel, setShowAIPanel] = useState(false);
 
   // Preview scroll position
   const [previewLine, setPreviewLine] = useState(1);
@@ -609,6 +613,9 @@ function AppContent() {
     setShowFileExplorer(false);
   }, []);
 
+  // Toggle the right-side AI assistant panel.
+  const handleToggleAI = useCallback(() => setShowAIPanel((v) => !v), []);
+
   // Close all panels
   const closeAllPanels = useCallback(() => {
     setShowFileExplorer(false);
@@ -1068,6 +1075,8 @@ function AppContent() {
         getExportHtml={getExportHtml}
         onExportSuccess={handleExportSuccess}
         onExportError={handleExportError}
+        onToggleAI={handleToggleAI}
+        aiActive={showAIPanel}
       />
 
       {!hasFile ? (
@@ -1173,6 +1182,21 @@ function AppContent() {
                 content={deferredContent}
                 onClose={closeAllPanels}
                 activeLine={mode === "preview" ? previewLine : cursorPosition.line}
+              />
+            </Suspense>
+          )}
+
+          {/* Right-side AI assistant panel. Reads the live document + current
+              selection; chat is read-only for now (edit/agent flow is next). */}
+          {showAIPanel && (
+            <Suspense fallback={null}>
+              <AIPanel
+                isOpen={showAIPanel}
+                onClose={() => setShowAIPanel(false)}
+                note={content}
+                fileName={fileName || ""}
+                selectionText={content.slice(selectionRange.start, selectionRange.end)}
+                aiConfig={aiConfig}
               />
             </Suspense>
           )}

--- a/src/components/AIPanel.tsx
+++ b/src/components/AIPanel.tsx
@@ -1,0 +1,208 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { streamChat, buildAskMessages, type ChatMessage } from "../utils/aiChat";
+import type { AIConfig } from "../utils/aiAssist";
+
+interface AIPanelProps {
+    isOpen: boolean;
+    onClose: () => void;
+    /** Current document text. */
+    note: string;
+    fileName: string;
+    /** Currently-selected text in the editor, if any. */
+    selectionText: string;
+    aiConfig: AIConfig;
+}
+
+interface UIMessage {
+    role: "user" | "assistant";
+    content: string;
+}
+
+// Keep the last N turns as conversation context (token efficiency — the document
+// itself is attached only to the latest turn inside buildAskMessages).
+const MAX_HISTORY_TURNS = 8;
+
+export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConfig }: AIPanelProps) {
+    const [messages, setMessages] = useState<UIMessage[]>([]);
+    const [input, setInput] = useState("");
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const abortRef = useRef<AbortController | null>(null);
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLTextAreaElement>(null);
+
+    const configured = !!aiConfig.endpoint && !!aiConfig.model;
+
+    useEffect(() => { if (isOpen) inputRef.current?.focus(); }, [isOpen]);
+    useEffect(() => {
+        const el = scrollRef.current;
+        if (el) el.scrollTop = el.scrollHeight;
+    }, [messages]);
+    useEffect(() => () => abortRef.current?.abort(), []);
+
+    const send = useCallback(async () => {
+        const text = input.trim();
+        if (!text || busy) return;
+        if (!configured) { setError("Configure an AI endpoint in Settings → AI first."); return; }
+        setError(null);
+        setInput("");
+
+        // Prior turns as plain Q/A (no document) — the doc is attached only to the
+        // newest user turn by buildAskMessages.
+        const history: ChatMessage[] = messages
+            .slice(-MAX_HISTORY_TURNS * 2)
+            .map((m) => ({ role: m.role, content: m.content }));
+
+        const withUser: UIMessage[] = [...messages, { role: "user", content: text }, { role: "assistant", content: "" }];
+        const assistantIdx = withUser.length - 1;
+        setMessages(withUser);
+        setBusy(true);
+
+        const ctrl = new AbortController();
+        abortRef.current = ctrl;
+        try {
+            const msgs = buildAskMessages(history, note, selectionText, text);
+            await streamChat(msgs, aiConfig, {
+                signal: ctrl.signal,
+                onToken: (delta) => {
+                    setMessages((prev) => {
+                        const copy = prev.slice();
+                        const cur = copy[assistantIdx];
+                        if (cur) copy[assistantIdx] = { role: "assistant", content: cur.content + delta };
+                        return copy;
+                    });
+                },
+            });
+        } catch (e) {
+            if ((e as Error).name !== "AbortError") setError((e as Error).message);
+            // Drop the empty assistant bubble if nothing streamed in.
+            setMessages((prev) => (prev[assistantIdx]?.content ? prev : prev.slice(0, assistantIdx)));
+        } finally {
+            setBusy(false);
+            abortRef.current = null;
+        }
+    }, [input, busy, configured, messages, note, selectionText, aiConfig]);
+
+    const stop = useCallback(() => abortRef.current?.abort(), []);
+    const clear = useCallback(() => { abortRef.current?.abort(); setMessages([]); setError(null); }, []);
+
+    if (!isOpen) return null;
+
+    const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            send();
+        }
+    };
+
+    return (
+        <aside
+            role="complementary"
+            aria-label="AI assistant"
+            className="fixed right-0 top-12 bottom-7 w-[400px] max-w-[90vw] z-50 flex flex-col bg-[var(--bg-secondary)] border-l border-[var(--border)] shadow-2xl"
+        >
+            {/* Header */}
+            <div className="h-10 shrink-0 px-3 flex items-center justify-between border-b border-[var(--border)] bg-[var(--bg-titlebar)]">
+                <div className="flex items-center gap-2 text-sm font-semibold text-[var(--text-primary)] no-select">
+                    <span className="material-symbols-outlined text-[18px] text-[var(--accent)]">auto_awesome</span>
+                    <span>AI Assistant</span>
+                </div>
+                <div className="flex items-center gap-1">
+                    {messages.length > 0 && (
+                        <button onClick={clear} title="New chat" aria-label="New chat" className="w-7 h-7 rounded-[var(--radius-sm)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] flex items-center justify-center transition-colors">
+                            <span className="material-symbols-outlined text-[18px]">add_comment</span>
+                        </button>
+                    )}
+                    <button onClick={onClose} title="Close" aria-label="Close AI panel" className="w-7 h-7 rounded-[var(--radius-sm)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] flex items-center justify-center transition-colors">
+                        <span className="material-symbols-outlined text-[18px]">close</span>
+                    </button>
+                </div>
+            </div>
+
+            {/* Context indicator */}
+            <div className="px-3 py-1.5 shrink-0 border-b border-[var(--border-subtle)] text-[11px] text-[var(--text-muted)] flex items-center gap-1.5">
+                <span className="material-symbols-outlined text-[13px]">description</span>
+                <span className="truncate">{fileName || "Untitled"}</span>
+                {selectionText.trim() && (
+                    <span className="ml-auto px-1.5 py-0.5 rounded bg-[var(--bg-hover)] text-[var(--accent)]">selection</span>
+                )}
+            </div>
+
+            {/* Messages */}
+            <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto px-3 py-3 space-y-3">
+                {!configured ? (
+                    <div className="flex flex-col items-center justify-center h-full text-center gap-3 text-sm text-[var(--text-secondary)]">
+                        <span className="material-symbols-outlined text-[32px] opacity-40">key</span>
+                        <p>Connect an AI provider to start chatting about your note.</p>
+                        <button
+                            onClick={() => window.dispatchEvent(new CustomEvent("marklite:open-settings"))}
+                            className="px-3 py-1.5 text-sm rounded-[var(--radius-md)] bg-[var(--accent)] text-[var(--accent-text)] hover:opacity-90"
+                        >
+                            Open AI settings
+                        </button>
+                    </div>
+                ) : messages.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center h-full text-center gap-2 text-sm text-[var(--text-secondary)] px-4">
+                        <span className="material-symbols-outlined text-[32px] opacity-40">forum</span>
+                        <p>Ask anything about <strong>{fileName || "this note"}</strong> — summarize it, find something, or get suggestions.</p>
+                        <p className="text-[11px] text-[var(--text-muted)]">Editing your note from here is coming in the next update.</p>
+                    </div>
+                ) : (
+                    messages.map((m, i) => (
+                        <div key={i} className={m.role === "user" ? "flex justify-end" : "flex justify-start"}>
+                            {m.role === "user" ? (
+                                <div className="max-w-[85%] px-3 py-2 rounded-[var(--radius-md)] bg-[var(--accent)] text-[var(--accent-text)] text-sm whitespace-pre-wrap break-words">
+                                    {m.content}
+                                </div>
+                            ) : (
+                                <div className="max-w-[92%] px-3 py-2 rounded-[var(--radius-md)] bg-[var(--bg-input)] border border-[var(--border-subtle)] text-sm w-full">
+                                    {m.content ? (
+                                        <div className="markdown-body !text-sm [&_*]:!text-sm [&_h1]:!text-base [&_h2]:!text-sm [&_pre]:!text-xs">
+                                            <Markdown remarkPlugins={[remarkGfm]}>{m.content}</Markdown>
+                                        </div>
+                                    ) : (
+                                        <span className="inline-flex gap-1 text-[var(--text-muted)]">
+                                            <span className="material-symbols-outlined text-[16px] animate-spin">progress_activity</span>
+                                            Thinking…
+                                        </span>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    ))
+                )}
+                {error && (
+                    <div className="px-3 py-2 text-xs text-[var(--danger)] bg-[var(--danger)]/10 rounded-[var(--radius-sm)] whitespace-pre-wrap">{error}</div>
+                )}
+            </div>
+
+            {/* Input */}
+            {configured && (
+                <div className="shrink-0 border-t border-[var(--border)] p-2">
+                    <div className="flex items-end gap-2 bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-md)] px-2 py-1.5 focus-within:border-[var(--accent)] transition-colors">
+                        <textarea
+                            ref={inputRef}
+                            value={input}
+                            onChange={(e) => setInput(e.target.value)}
+                            onKeyDown={onKeyDown}
+                            rows={1}
+                            placeholder="Ask about this note…  (Enter to send, Shift+Enter for newline)"
+                            className="flex-1 bg-transparent text-sm text-[var(--text-primary)] outline-none resize-none max-h-32 placeholder:text-[var(--text-muted)]"
+                        />
+                        {busy ? (
+                            <button onClick={stop} title="Stop" aria-label="Stop generating" className="w-7 h-7 rounded-[var(--radius-sm)] bg-[var(--bg-hover)] text-[var(--text-primary)] flex items-center justify-center">
+                                <span className="material-symbols-outlined text-[18px]">stop</span>
+                            </button>
+                        ) : (
+                            <button onClick={send} disabled={!input.trim()} title="Send" aria-label="Send" className="w-7 h-7 rounded-[var(--radius-sm)] bg-[var(--accent)] text-[var(--accent-text)] flex items-center justify-center disabled:opacity-40">
+                                <span className="material-symbols-outlined text-[18px]">arrow_upward</span>
+                            </button>
+                        )}
+                    </div>
+                </div>
+            )}
+        </aside>
+    );
+}

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -20,9 +20,11 @@ interface TitleBarProps {
     getExportHtml?: () => string;
     onExportSuccess?: (format: string) => void;
     onExportError?: (format: string) => void;
+    onToggleAI?: () => void;
+    aiActive?: boolean;
 }
 
-function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, onSaveFile, getExportHtml, onExportSuccess, onExportError }: TitleBarProps) {
+function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, onSaveFile, getExportHtml, onExportSuccess, onExportError, onToggleAI, aiActive }: TitleBarProps) {
     const [showUnsavedDialog, setShowUnsavedDialog] = useState(false);
 
     const handleMinimize = async () => {
@@ -150,6 +152,21 @@ function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, onSa
                                 onSuccess={onExportSuccess}
                                 onError={onExportError}
                             />
+                            {onToggleAI && (
+                                <button
+                                    onClick={onToggleAI}
+                                    aria-label="AI assistant"
+                                    aria-pressed={aiActive}
+                                    title="AI assistant"
+                                    className={`flex items-center gap-1 px-2 py-1 rounded-[var(--radius-md)] transition-colors text-xs ${aiActive
+                                        ? "bg-[var(--accent)] text-[var(--accent-text)]"
+                                        : "hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                                        }`}
+                                >
+                                    <span className="material-symbols-outlined text-[16px]">auto_awesome</span>
+                                    <span>AI</span>
+                                </button>
+                            )}
                         </>
                     )}
                 </div>

--- a/src/utils/aiChat.test.ts
+++ b/src/utils/aiChat.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { buildAskMessages } from "./aiChat";
+
+describe("buildAskMessages", () => {
+    it("puts the system prompt first and the document only in the latest turn", () => {
+        const history = [
+            { role: "user" as const, content: "hi" },
+            { role: "assistant" as const, content: "hello" },
+        ];
+        const msgs = buildAskMessages(history, "# My Note\nbody", "", "summarize it");
+
+        expect(msgs[0].role).toBe("system");
+        // History is carried through verbatim and stays document-free (token efficiency).
+        expect(msgs.some((m) => m.content === "hi")).toBe(true);
+        expect(history.every((h) => !h.content.includes("My Note"))).toBe(true);
+
+        const last = msgs[msgs.length - 1];
+        expect(last.role).toBe("user");
+        expect(last.content).toContain("# My Note");
+        expect(last.content).toContain("summarize it");
+    });
+
+    it("includes the selected passage when present", () => {
+        const msgs = buildAskMessages([], "full document text", "the selected bit", "what is this");
+        const last = msgs[msgs.length - 1];
+        expect(last.content).toContain("the selected bit");
+        expect(last.content.toLowerCase()).toContain("selected");
+    });
+});

--- a/src/utils/aiChat.ts
+++ b/src/utils/aiChat.ts
@@ -1,0 +1,149 @@
+/**
+ * Streaming chat client for the AI panel — talks to the same OpenAI-compatible
+ * endpoint as aiAssist (OpenAI, Gemini's OpenAI-compat layer, Ollama, etc.) but
+ * with `stream: true` so the panel can render tokens as they arrive.
+ */
+
+import type { AIConfig } from "./aiAssist";
+
+export type ChatRole = "system" | "user" | "assistant";
+export interface ChatMessage {
+    role: ChatRole;
+    content: string;
+}
+
+const AI_CONNECT_TIMEOUT_MS = 120_000;
+
+function mapHttpError(status: number, body: string): string {
+    const detail = body.trim().slice(0, 200);
+    let msg: string;
+    if (status === 401 || status === 403) msg = "API key invalid or unauthorized — check Settings → AI.";
+    else if (status === 404) msg = "Endpoint not found (404) — check the URL in Settings → AI.";
+    else if (status === 429) msg = "Rate limited (429) — wait a moment and try again.";
+    else if (status >= 500) msg = `AI service unavailable (${status}). Try again later.`;
+    else msg = `AI request failed (${status}).`;
+    return detail ? `${msg}\n${detail}` : msg;
+}
+
+/** Pull assistant text from a non-streamed completion (OpenAI or Ollama shape). */
+function extractContent(data: unknown): string {
+    const d = data as { choices?: Array<{ message?: { content?: string } }>; message?: { content?: string } };
+    return d?.choices?.[0]?.message?.content ?? d?.message?.content ?? "";
+}
+
+/**
+ * Stream a chat completion. Calls `onToken` with each incremental delta and
+ * resolves with the full text. Aborts cleanly via `opts.signal`.
+ */
+export async function streamChat(
+    messages: ChatMessage[],
+    cfg: AIConfig,
+    opts: { signal?: AbortSignal; onToken?: (delta: string) => void; temperature?: number } = {}
+): Promise<string> {
+    if (!cfg.endpoint) throw new Error("AI endpoint not configured. Open Settings → AI to set one up.");
+    if (!cfg.model) throw new Error("AI model not configured.");
+
+    const ctrl = new AbortController();
+    const onUserAbort = () => ctrl.abort();
+    opts.signal?.addEventListener("abort", onUserAbort);
+    // Guards only the initial connection; cleared once the response headers
+    // arrive so a long generation isn't cut off mid-stream.
+    const connectTimeout = window.setTimeout(() => ctrl.abort(), AI_CONNECT_TIMEOUT_MS);
+
+    try {
+        const res = await fetch(cfg.endpoint, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                ...(cfg.apiKey ? { Authorization: `Bearer ${cfg.apiKey}` } : {}),
+            },
+            body: JSON.stringify({
+                model: cfg.model,
+                messages,
+                temperature: opts.temperature ?? 0.4,
+                stream: true,
+            }),
+            signal: ctrl.signal,
+        });
+        window.clearTimeout(connectTimeout);
+
+        if (!res.ok) {
+            const body = await res.text().catch(() => "");
+            throw new Error(mapHttpError(res.status, body));
+        }
+
+        // Endpoint ignored `stream` (or returned no body) — read the whole thing.
+        if (!res.body) {
+            const data = await res.json();
+            const content = extractContent(data);
+            if (content) opts.onToken?.(content);
+            return content;
+        }
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let full = "";
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            // Process complete SSE lines; keep any trailing partial line buffered.
+            const lines = buffer.split("\n");
+            buffer = lines.pop() ?? "";
+            for (const line of lines) {
+                const trimmed = line.trim();
+                if (!trimmed.startsWith("data:")) continue;
+                const payload = trimmed.slice(5).trim();
+                if (payload === "[DONE]") continue;
+                try {
+                    const json = JSON.parse(payload);
+                    const delta: string = json?.choices?.[0]?.delta?.content ?? "";
+                    if (delta) {
+                        full += delta;
+                        opts.onToken?.(delta);
+                    }
+                } catch {
+                    /* partial JSON across chunk boundary — completed on next read */
+                }
+            }
+        }
+        return full;
+    } finally {
+        window.clearTimeout(connectTimeout);
+        opts.signal?.removeEventListener("abort", onUserAbort);
+    }
+}
+
+// ===== Prompt + message construction =====
+//
+// Token efficiency: the (possibly large) document is included only in the LATEST
+// user turn — never duplicated through the conversation history. Prior turns are
+// just the plain Q/A text. The caller trims history length.
+
+export const ASK_SYSTEM_PROMPT =
+    "You are the writing assistant inside MarkLite, a Markdown editor. Answer the " +
+    "user's questions about their current Markdown document clearly and concisely, " +
+    "formatted in Markdown. This is a read-only Q&A mode — do not rewrite or output " +
+    "the whole document unless explicitly asked.";
+
+/** Wrap untrusted document text in tags (avoids colliding with the doc's own ``` fences). */
+function asDocument(note: string): string {
+    return `<document>\n${note}\n</document>`;
+}
+
+export function buildAskMessages(
+    history: ChatMessage[],
+    note: string,
+    selection: string,
+    userInput: string
+): ChatMessage[] {
+    const ctx = selection.trim()
+        ? `Current document:\n${asDocument(note)}\n\nThe user has selected this passage:\n${asDocument(selection)}`
+        : `Current document:\n${asDocument(note)}`;
+    return [
+        { role: "system", content: ASK_SYSTEM_PROMPT },
+        ...history,
+        { role: "user", content: `${ctx}\n\n---\nQuestion: ${userInput}` },
+    ];
+}


### PR DESCRIPTION
Phase 1 of the AI assistant side panel. Right-side streaming chat that knows your current note (context = note + selection, document attached only to the latest turn for token efficiency). AI toggle button next to Export; works over your existing Gemini/OpenAI-compatible config. Phase 2 adds agent edits with per-change accept/reject via CodeMirror merge. tsc + 62 tests green.