### PR TITLE
AI panel: layout fix + Phase 2 agent editing (accept/reject)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language": "^6.12.3",
+        "@codemirror/merge": "^6.12.1",
         "@codemirror/search": "^6.7.0",
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.43.0",
@@ -137,6 +138,8 @@
     "@codemirror/language": ["@codemirror/language@6.12.3", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA=="],
 
     "@codemirror/lint": ["@codemirror/lint@6.9.6", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.42.0", "crelt": "^1.0.5" } }, "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A=="],
+
+    "@codemirror/merge": ["@codemirror/merge@6.12.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/highlight": "^1.0.0", "style-mod": "^4.1.0" } }, "sha512-GA8hBq2T+IFM0sb5fk8CunTrqOulA3zurJmHtzcU15EMnL8aYpVINfJ5bkfd53M4ikwoew4Y1ydtSaAlk6+B1w=="],
 
     "@codemirror/search": ["@codemirror/search@6.7.0", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.37.0", "crelt": "^1.0.5" } }, "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg=="],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@codemirror/commands": "^6.10.3",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.3",
+    "@codemirror/merge": "^6.12.1",
     "@codemirror/search": "^6.7.0",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.43.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,6 +93,10 @@ const getWordCount = (text: string): number => {
 const IS_MAC = typeof navigator !== "undefined" && /mac/i.test(navigator.platform || navigator.userAgent || "");
 const AI_SHORTCUT = IS_MAC ? "⌘J" : "Alt+J";
 
+// Width of the right-side AI panel; the editor/preview area reserves this much
+// padding-right when it's open so content reflows beside it (not under it).
+const AI_PANEL_WIDTH = 400;
+
 /**
  * Returns a value that lags behind `value` by `delay` ms. Each new `value`
  * resets the timer, so during continuous typing the returned value is stable
@@ -1092,7 +1096,14 @@ function AppContent() {
           {/* Split-aware layout. Both views always mounted; CSS toggles their display
               and width so editor/preview state (scroll, selection) is preserved across
               mode switches. */}
-          <div ref={splitContainerRef} className="flex-1 overflow-hidden flex flex-row">
+          <div
+            ref={splitContainerRef}
+            className="flex-1 overflow-hidden flex flex-row"
+            // Reserve space on the right for the AI panel so editor/preview reflow
+            // beside it instead of being covered. The panel itself is fixed at
+            // right-0 (above the status bar), which keeps window controls at the edge.
+            style={{ paddingRight: showAIPanel ? AI_PANEL_WIDTH : 0, transition: "padding-right 0.15s ease" }}
+          >
             <div
               data-split-left
               className="overflow-hidden flex flex-col"
@@ -1161,7 +1172,7 @@ function AppContent() {
             </div>
           </div>
 
-          <ModeToggle mode={mode} onSetMode={setMode} />
+          <ModeToggle mode={mode} onSetMode={setMode} aiPanelOpen={showAIPanel} />
 
           {/* Sidebar Panels — only mount when actually open so they don't
               load their module until first use. */}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,6 +156,8 @@ function AppContent() {
   const [showFileExplorer, setShowFileExplorer] = useState(false);
   const [showTOC, setShowTOC] = useState(false);
   const [showAIPanel, setShowAIPanel] = useState(false);
+  // Proposed document from Agent mode, shown as an inline diff for accept/reject.
+  const [proposedDoc, setProposedDoc] = useState<string | null>(null);
 
   // Preview scroll position
   const [previewLine, setPreviewLine] = useState(1);
@@ -619,6 +621,19 @@ function AppContent() {
 
   // Toggle the right-side AI assistant panel.
   const handleToggleAI = useCallback(() => setShowAIPanel((v) => !v), []);
+
+  // Agent proposed an edited document → show it as a diff to accept/reject.
+  // Ensure the editor (where the diff renders) is visible.
+  const handleProposeEdit = useCallback((doc: string) => {
+    setProposedDoc(doc);
+    setMode((m) => (m === "preview" ? "split" : m));
+  }, []);
+
+  // Review finished: commit the accepted document (or keep the original on reject).
+  const handleReviewResolve = useCallback((finalDoc: string | null) => {
+    if (finalDoc != null) setContent(finalDoc);
+    setProposedDoc(null);
+  }, []);
 
   // Close all panels
   const closeAllPanels = useCallback(() => {
@@ -1131,6 +1146,8 @@ function AppContent() {
                 wordWrap={wordWrapEnabled}
                 spellCheck={spellCheckEnabled}
                 aiConfig={aiConfig}
+                reviewDoc={proposedDoc}
+                onReviewResolve={handleReviewResolve}
               />
             </div>
 
@@ -1208,6 +1225,7 @@ function AppContent() {
                 fileName={fileName || ""}
                 selectionText={content.slice(selectionRange.start, selectionRange.end)}
                 aiConfig={aiConfig}
+                onProposeEdit={handleProposeEdit}
               />
             </Suspense>
           )}

--- a/src/components/AIPanel.tsx
+++ b/src/components/AIPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { streamChat, buildAskMessages, type ChatMessage } from "../utils/aiChat";
+import { streamChat, buildAskMessages, buildAgentMessages, parseEdits, type ChatMessage } from "../utils/aiChat";
 import type { AIConfig } from "../utils/aiAssist";
 
 interface AIPanelProps {
@@ -13,6 +13,8 @@ interface AIPanelProps {
     /** Currently-selected text in the editor, if any. */
     selectionText: string;
     aiConfig: AIConfig;
+    /** Called (Agent mode) with the proposed document to review in the editor. */
+    onProposeEdit?: (proposedDoc: string) => void;
 }
 
 interface UIMessage {
@@ -24,9 +26,10 @@ interface UIMessage {
 // itself is attached only to the latest turn inside buildAskMessages).
 const MAX_HISTORY_TURNS = 8;
 
-export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConfig }: AIPanelProps) {
+export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConfig, onProposeEdit }: AIPanelProps) {
     const [messages, setMessages] = useState<UIMessage[]>([]);
     const [input, setInput] = useState("");
+    const [mode, setMode] = useState<"ask" | "agent">("ask");
     const [busy, setBusy] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const abortRef = useRef<AbortController | null>(null);
@@ -63,8 +66,10 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
         const ctrl = new AbortController();
         abortRef.current = ctrl;
         try {
-            const msgs = buildAskMessages(history, note, selectionText, text);
-            await streamChat(msgs, aiConfig, {
+            const msgs = mode === "agent"
+                ? buildAgentMessages(history, note, selectionText, text)
+                : buildAskMessages(history, note, selectionText, text);
+            const full = await streamChat(msgs, aiConfig, {
                 signal: ctrl.signal,
                 onToken: (delta) => {
                     setMessages((prev) => {
@@ -75,6 +80,27 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
                     });
                 },
             });
+            // Agent mode: if the reply was edit blocks, apply them and hand the
+            // proposed document to the editor for review (replacing the raw blocks
+            // that briefly streamed into the bubble with a clean summary).
+            if (mode === "agent") {
+                const res = parseEdits(full, note);
+                if (res.hasEdits) {
+                    let summary: string;
+                    if (res.applied > 0) {
+                        onProposeEdit?.(res.proposedDoc);
+                        summary = `${res.explanation ? res.explanation + "\n\n" : ""}**Proposed ${res.applied} change${res.applied !== 1 ? "s" : ""}.** Review and Accept/Reject them in the editor.${res.failed ? `\n\n⚠️ ${res.failed} change${res.failed !== 1 ? "s" : ""} couldn't be applied — the text may have shifted. Try again.` : ""}`;
+                    } else {
+                        summary = "I drafted changes but none matched the current document (it may have changed since). Please try again.";
+                    }
+                    setMessages((prev) => {
+                        const copy = prev.slice();
+                        if (copy[assistantIdx]) copy[assistantIdx] = { role: "assistant", content: summary };
+                        return copy;
+                    });
+                }
+                // No edit blocks → it was an answer; the streamed text stays as-is.
+            }
         } catch (e) {
             if ((e as Error).name !== "AbortError") setError((e as Error).message);
             // Drop the empty assistant bubble if nothing streamed in.
@@ -83,7 +109,7 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
             setBusy(false);
             abortRef.current = null;
         }
-    }, [input, busy, configured, messages, note, selectionText, aiConfig]);
+    }, [input, busy, configured, messages, note, selectionText, aiConfig, mode, onProposeEdit]);
 
     const stop = useCallback(() => abortRef.current?.abort(), []);
     const clear = useCallback(() => { abortRef.current?.abort(); setMessages([]); setError(null); }, []);
@@ -121,13 +147,25 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
                 </div>
             </div>
 
-            {/* Context indicator */}
-            <div className="px-3 py-1.5 shrink-0 border-b border-[var(--border-subtle)] text-[11px] text-[var(--text-muted)] flex items-center gap-1.5">
-                <span className="material-symbols-outlined text-[13px]">description</span>
-                <span className="truncate">{fileName || "Untitled"}</span>
+            {/* Context indicator + Ask/Agent mode toggle */}
+            <div className="px-3 py-1.5 shrink-0 border-b border-[var(--border-subtle)] flex items-center gap-1.5">
+                <span className="material-symbols-outlined text-[13px] text-[var(--text-muted)]">description</span>
+                <span className="truncate text-[11px] text-[var(--text-muted)] min-w-0">{fileName || "Untitled"}</span>
                 {selectionText.trim() && (
-                    <span className="ml-auto px-1.5 py-0.5 rounded bg-[var(--bg-hover)] text-[var(--accent)]">selection</span>
+                    <span className="px-1.5 py-0.5 rounded bg-[var(--bg-hover)] text-[var(--accent)] text-[11px] shrink-0">selection</span>
                 )}
+                <div className="ml-auto flex items-center gap-0.5 bg-[var(--bg-input)] rounded-[var(--radius-sm)] p-0.5 border border-[var(--border-subtle)] shrink-0">
+                    {(["ask", "agent"] as const).map((md) => (
+                        <button
+                            key={md}
+                            onClick={() => setMode(md)}
+                            title={md === "ask" ? "Ask questions (read-only)" : "Make edits (review before applying)"}
+                            className={`px-2 py-0.5 text-[11px] rounded-[var(--radius-sm)] capitalize transition-colors ${mode === md ? "bg-[var(--accent)] text-[var(--accent-text)]" : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"}`}
+                        >
+                            {md}
+                        </button>
+                    ))}
+                </div>
             </div>
 
             {/* Messages */}
@@ -147,7 +185,7 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
                     <div className="flex flex-col items-center justify-center h-full text-center gap-2 text-sm text-[var(--text-secondary)] px-4">
                         <span className="material-symbols-outlined text-[32px] opacity-40">forum</span>
                         <p>Ask anything about <strong>{fileName || "this note"}</strong> — summarize it, find something, or get suggestions.</p>
-                        <p className="text-[11px] text-[var(--text-muted)]">Editing your note from here is coming in the next update.</p>
+                        <p className="text-[11px] text-[var(--text-muted)]">Switch to <strong>Agent</strong> mode to make edits — you'll review each change before it's applied.</p>
                     </div>
                 ) : (
                     messages.map((m, i) => (
@@ -188,7 +226,7 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
                             onChange={(e) => setInput(e.target.value)}
                             onKeyDown={onKeyDown}
                             rows={1}
-                            placeholder="Ask about this note…  (Enter to send, Shift+Enter for newline)"
+                            placeholder={mode === "agent" ? "Tell the AI what to change…" : "Ask about this note…"}
                             className="flex-1 bg-transparent text-sm text-[var(--text-primary)] outline-none resize-none max-h-32 placeholder:text-[var(--text-muted)]"
                         />
                         {busy ? (

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -14,6 +14,7 @@ import { history, defaultKeymap, historyKeymap } from "@codemirror/commands";
 import { markdown } from "@codemirror/lang-markdown";
 import { syntaxHighlighting, HighlightStyle } from "@codemirror/language";
 import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
+import { unifiedMergeView } from "@codemirror/merge";
 import { tags as t } from "@lezer/highlight";
 import { getImageFromClipboard, saveImageToFile, createMarkdownImage } from "../utils/imageUtils";
 import {
@@ -47,6 +48,12 @@ interface CodeEditorProps {
     wordWrap?: boolean;
     spellCheck?: boolean;
     aiConfig?: { endpoint: string; model: string; apiKey: string };
+    /** When non-null, show this proposed document as an inline diff (CodeMirror
+     *  merge view) for the user to accept/reject. Null = no review in progress. */
+    reviewDoc?: string | null;
+    /** Called when the user finishes a review: the final document (accept) or
+     *  null (rejected everything — keep the original). */
+    onReviewResolve?: (finalDoc: string | null) => void;
 }
 
 const EDITOR_FONT_FAMILY =
@@ -142,6 +149,8 @@ function CodeEditorImpl({
     wordWrap = true,
     spellCheck = false,
     aiConfig,
+    reviewDoc,
+    onReviewResolve,
 }: CodeEditorProps) {
     const containerRef = useRef<HTMLDivElement>(null);
     const viewRef = useRef<EditorView | null>(null);
@@ -152,6 +161,7 @@ function CodeEditorImpl({
     const [slashState, setSlashState] = useState<{ from: number; pos: { x: number; y: number } } | null>(null);
     const [slashQuery, setSlashQuery] = useState("");
     const [aiBubble, setAIBubble] = useState<{ x: number; y: number; selStart: number; selEnd: number; text: string } | null>(null);
+    const [reviewActive, setReviewActive] = useState(false);
 
     // Latest props read by the once-created CodeMirror extensions, kept in refs so
     // the view never has to be torn down and rebuilt on a callback/flag change.
@@ -175,6 +185,11 @@ function CodeEditorImpl({
     // Reconfigurable extensions.
     const wrapCompRef = useRef(new Compartment());
     const spellCompRef = useRef(new Compartment());
+    // AI review (merge view) state.
+    const mergeCompRef = useRef(new Compartment());
+    const reviewingRef = useRef(false);
+    const reviewOriginalRef = useRef("");
+    const lastReviewRef = useRef<string | null>(null);
 
     const openAIBubble = useCallback(() => {
         const view = viewRef.current;
@@ -197,6 +212,7 @@ function CodeEditorImpl({
 
         const wrapComp = wrapCompRef.current;
         const spellComp = spellCompRef.current;
+        const mergeComp = mergeCompRef.current;
 
         const editingKeymap = Prec.highest(keymap.of([
             { key: "Tab", run: (v) => runAction(v, (st) => handleTab(st, false)), shift: (v) => runAction(v, (st) => handleTab(st, true)) },
@@ -226,7 +242,9 @@ function CodeEditorImpl({
         ]));
 
         const updateListener = EditorView.updateListener.of((update: ViewUpdate) => {
-            if (update.docChanged) {
+            // Suppress propagation while an AI review is active — the doc shows the
+            // PROPOSED text then, which mustn't be committed until accept/reject.
+            if (update.docChanged && !reviewingRef.current) {
                 const value = update.state.doc.toString();
                 lastEmittedRef.current = value;
                 onChangeRef.current?.(value);
@@ -272,6 +290,7 @@ function CodeEditorImpl({
                     editorTheme,
                     wrapComp.of(wordWrap ? EditorView.lineWrapping : []),
                     spellComp.of(EditorView.contentAttributes.of(spellAttrs(spellCheck))),
+                    mergeComp.of([]),
                     editingKeymap,
                     keymap.of([...closeBracketsKeymap, ...defaultKeymap, ...historyKeymap]),
                     updateListener,
@@ -393,6 +412,57 @@ function CodeEditorImpl({
         viewRef.current?.dispatch({ effects: spellCompRef.current.reconfigure(EditorView.contentAttributes.of(spellAttrs(spellCheck))) });
     }, [spellCheck]);
 
+    // Enter / refresh / exit the AI review (CodeMirror unified merge view). The
+    // original side is the document as it was BEFORE the proposal; the editor doc
+    // becomes the proposed text, and the merge view shows per-change ✓/✗ controls.
+    useEffect(() => {
+        const view = viewRef.current;
+        if (!view) return;
+        if (reviewDoc != null) {
+            if (reviewingRef.current && reviewDoc === lastReviewRef.current) return;
+            if (!reviewingRef.current) reviewOriginalRef.current = view.state.doc.toString();
+            reviewingRef.current = true;
+            lastReviewRef.current = reviewDoc;
+            setReviewActive(true);
+            view.dispatch({
+                changes: { from: 0, to: view.state.doc.length, insert: reviewDoc },
+                effects: mergeCompRef.current.reconfigure(unifiedMergeView({ original: reviewOriginalRef.current })),
+            });
+        } else if (reviewingRef.current) {
+            reviewingRef.current = false;
+            lastReviewRef.current = null;
+            setReviewActive(false);
+            view.dispatch({ effects: mergeCompRef.current.reconfigure([]) });
+        }
+    }, [reviewDoc]);
+
+    const acceptAllChanges = useCallback(() => {
+        const view = viewRef.current;
+        if (!view) return;
+        const final = view.state.doc.toString();
+        reviewingRef.current = false;
+        lastReviewRef.current = null;
+        setReviewActive(false);
+        view.dispatch({ effects: mergeCompRef.current.reconfigure([]) });
+        lastEmittedRef.current = final; // keep the App content-sync from re-dispatching
+        onReviewResolve?.(final);
+    }, [onReviewResolve]);
+
+    const rejectAllChanges = useCallback(() => {
+        const view = viewRef.current;
+        if (!view) return;
+        const orig = reviewOriginalRef.current;
+        reviewingRef.current = false;
+        lastReviewRef.current = null;
+        setReviewActive(false);
+        view.dispatch({
+            changes: { from: 0, to: view.state.doc.length, insert: orig },
+            effects: mergeCompRef.current.reconfigure([]),
+        });
+        lastEmittedRef.current = orig;
+        onReviewResolve?.(null);
+    }, [onReviewResolve]);
+
     // Scroll-fraction sync (rAF-throttled — PREVIEW-04) + imperative scroller.
     const scrollRafRef = useRef(0);
     useEffect(() => {
@@ -478,6 +548,17 @@ function CodeEditorImpl({
 
     return (
         <main className="flex-1 flex flex-col overflow-hidden relative">
+            {reviewActive && (
+                <div className="flex items-center gap-2 px-3 h-9 shrink-0 bg-[var(--bg-secondary)] border-b border-[var(--accent)] text-xs no-select">
+                    <span className="material-symbols-outlined text-[16px] text-[var(--accent)]">auto_awesome</span>
+                    <span className="text-[var(--text-primary)] font-medium">AI suggested changes</span>
+                    <span className="text-[var(--text-muted)] hidden sm:inline">— review each, or:</span>
+                    <div className="ml-auto flex items-center gap-2">
+                        <button onClick={rejectAllChanges} className="px-2 py-1 rounded-[var(--radius-sm)] text-[var(--danger)] hover:bg-[var(--danger)]/10 transition-colors">Reject all</button>
+                        <button onClick={acceptAllChanges} className="px-2 py-1 rounded-[var(--radius-sm)] bg-[var(--accent)] text-[var(--accent-text)] hover:opacity-90 transition-colors">Accept all</button>
+                    </div>
+                </div>
+            )}
             {showToolbar && (
                 <FormatToolbar getState={getState} apply={applyResult} insert={insertAtCaret} onAIAssist={openAIBubble} />
             )}

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -3,14 +3,21 @@ export type ViewMode = "preview" | "code" | "split";
 interface ModeToggleProps {
     mode: ViewMode;
     onSetMode: (mode: ViewMode) => void;
+    /** Shift left when the AI panel is open so the toggle isn't hidden behind it. */
+    aiPanelOpen?: boolean;
 }
 
 const buttonBase =
     "btn-press flex items-center gap-2 px-3 py-2 rounded-full transition-all duration-200";
 
-export function ModeToggle({ mode, onSetMode }: ModeToggleProps) {
+export function ModeToggle({ mode, onSetMode, aiPanelOpen }: ModeToggleProps) {
     return (
-        <div className="fixed bottom-8 right-8 z-50" role="group" aria-label="View mode toggle">
+        <div
+            className="fixed bottom-8 z-50"
+            style={{ right: aiPanelOpen ? "calc(400px + 2rem)" : "2rem", transition: "right 0.15s ease" }}
+            role="group"
+            aria-label="View mode toggle"
+        >
             <div className="bg-[var(--bg-secondary)] border border-[var(--border)] rounded-full p-1.5 flex items-center shadow-2xl backdrop-blur-sm transition-colors animate-fade-in">
                 <button
                     onClick={() => onSetMode("preview")}

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -159,7 +159,7 @@ function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, onSa
                                     aria-pressed={aiActive}
                                     title="AI assistant"
                                     className={`flex items-center gap-1 px-2 py-1 rounded-[var(--radius-md)] transition-colors text-xs ${aiActive
-                                        ? "bg-[var(--accent)] text-[var(--accent-text)]"
+                                        ? "bg-[var(--bg-hover)] text-[var(--accent)]"
                                         : "hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
                                         }`}
                                 >

--- a/src/utils/aiChat.test.ts
+++ b/src/utils/aiChat.test.ts
@@ -1,5 +1,53 @@
 import { describe, it, expect } from "vitest";
-import { buildAskMessages } from "./aiChat";
+import { buildAskMessages, parseEdits } from "./aiChat";
+
+describe("parseEdits", () => {
+    const block = (s: string, r: string) => `<<<<<<< SEARCH\n${s}\n=======\n${r}\n>>>>>>> REPLACE`;
+
+    it("applies a single SEARCH/REPLACE block", () => {
+        const doc = "# Title\n\nHello world.\n";
+        const res = parseEdits(block("Hello world.", "Hello, brave new world!"), doc);
+        expect(res.hasEdits).toBe(true);
+        expect(res.applied).toBe(1);
+        expect(res.failed).toBe(0);
+        expect(res.proposedDoc).toBe("# Title\n\nHello, brave new world!\n");
+    });
+
+    it("applies multiple blocks in order", () => {
+        const doc = "alpha\nbravo\ncharlie\n";
+        const resp = block("alpha", "ALPHA") + "\n" + block("charlie", "CHARLIE");
+        const res = parseEdits(resp, doc);
+        expect(res.applied).toBe(2);
+        expect(res.proposedDoc).toBe("ALPHA\nbravo\nCHARLIE\n");
+    });
+
+    it("counts a non-matching block as failed and leaves it out", () => {
+        const doc = "one two three";
+        const res = parseEdits(block("nonexistent", "x"), doc);
+        expect(res.applied).toBe(0);
+        expect(res.failed).toBe(1);
+        expect(res.proposedDoc).toBe(doc);
+    });
+
+    it("treats a plain answer (no blocks) as not-an-edit", () => {
+        const res = parseEdits("This document is about robots.", "anything");
+        expect(res.hasEdits).toBe(false);
+        expect(res.explanation).toContain("robots");
+    });
+
+    it("separates the summary sentence from the blocks", () => {
+        const resp = "Tightened the intro.\n" + block("old", "new");
+        const res = parseEdits(resp, "old text");
+        expect(res.applied).toBe(1);
+        expect(res.explanation).toBe("Tightened the intro.");
+    });
+
+    it("rewrites the whole document when SEARCH is the entire doc", () => {
+        const doc = "completely\nold\ncontent";
+        const res = parseEdits(block(doc, "brand new content"), doc);
+        expect(res.proposedDoc).toBe("brand new content");
+    });
+});
 
 describe("buildAskMessages", () => {
     it("puts the system prompt first and the document only in the latest turn", () => {

--- a/src/utils/aiChat.ts
+++ b/src/utils/aiChat.ts
@@ -147,3 +147,80 @@ export function buildAskMessages(
         { role: "user", content: `${ctx}\n\n---\nQuestion: ${userInput}` },
     ];
 }
+
+// ===== Agent / Edit mode =====
+
+export const AGENT_SYSTEM_PROMPT =
+    "You are the agent inside MarkLite, a Markdown editor, working on the user's current document.\n\n" +
+    "Decide what the user wants:\n" +
+    "- If they ask a QUESTION, answer concisely in Markdown. Do NOT output edit blocks.\n" +
+    "- If they ask you to CHANGE the document (edit, rewrite, add, fix, restructure), respond with edit blocks ONLY. You may put at most one short sentence of summary before the blocks.\n\n" +
+    "Edit block format — one per change, EXACTLY:\n" +
+    "<<<<<<< SEARCH\n" +
+    "(text to find, copied verbatim from the document including whitespace; minimal but unique)\n" +
+    "=======\n" +
+    "(replacement text)\n" +
+    ">>>>>>> REPLACE\n\n" +
+    "Rules:\n" +
+    "- SEARCH must match the current document character-for-character.\n" +
+    "- Use several blocks for several changes.\n" +
+    "- To INSERT, SEARCH a nearby existing line and repeat it unchanged in REPLACE with the new text added around it.\n" +
+    "- To REWRITE the whole document, use ONE block whose SEARCH is the entire current document.\n" +
+    "- Preserve the user's Markdown style, heading levels, and voice.\n" +
+    "- Never wrap blocks in ``` fences. Output nothing after the final block.";
+
+export function buildAgentMessages(
+    history: ChatMessage[],
+    note: string,
+    selection: string,
+    userInput: string
+): ChatMessage[] {
+    const ctx = selection.trim()
+        ? `Current document:\n${asDocument(note)}\n\nThe user's current selection:\n${asDocument(selection)}`
+        : `Current document:\n${asDocument(note)}`;
+    return [
+        { role: "system", content: AGENT_SYSTEM_PROMPT },
+        ...history,
+        { role: "user", content: `${ctx}\n\n---\nRequest: ${userInput}` },
+    ];
+}
+
+export interface EditResult {
+    /** Document after applying every block that matched. */
+    proposedDoc: string;
+    applied: number;
+    failed: number;
+    /** Any prose the model wrote outside the edit blocks. */
+    explanation: string;
+    /** True when the response contained at least one well-formed edit block. */
+    hasEdits: boolean;
+}
+
+const EDIT_BLOCK_RE = /<<<<<<<[ \t]*SEARCH[ \t]*\r?\n([\s\S]*?)\r?\n=======[ \t]*\r?\n([\s\S]*?)\r?\n>>>>>>>[ \t]*REPLACE/g;
+
+/**
+ * Parse SEARCH/REPLACE blocks out of an agent response and apply them to the
+ * current document, in order. Each SEARCH is matched literally (first
+ * occurrence). Blocks whose SEARCH isn't found are counted as failed and skipped.
+ */
+export function parseEdits(response: string, currentDoc: string): EditResult {
+    const blocks: Array<[string, string]> = [];
+    EDIT_BLOCK_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = EDIT_BLOCK_RE.exec(response)) !== null) {
+        blocks.push([m[1], m[2]]);
+    }
+
+    let doc = currentDoc;
+    let applied = 0;
+    let failed = 0;
+    for (const [search, replace] of blocks) {
+        const idx = doc.indexOf(search);
+        if (idx === -1) { failed++; continue; }
+        doc = doc.slice(0, idx) + replace + doc.slice(idx + search.length);
+        applied++;
+    }
+
+    const explanation = response.replace(EDIT_BLOCK_RE, "").trim();
+    return { proposedDoc: doc, applied, failed, explanation, hasEdits: blocks.length > 0 };
+}


### PR DESCRIPTION
Addresses the feedback on the merged Phase 1, and completes the editing feature.

**Layout/UI fixes**
- Panel now PUSHES the editor/preview (reserved right-padding) instead of covering it; status bar stays full-width; ModeToggle shifts so it isn't hidden.
- Softer AI toggle button (subtle active state matching Open/Export).

**Phase 2 — Agent editing with inline accept/reject**
- Ask/Agent toggle in the panel. Ask = read-only Q&A; Agent = propose edits.
- Hybrid edit protocol (SEARCH/REPLACE blocks + whole-doc rewrite), parsed + applied, then shown as an inline diff in the editor via CodeMirror's merge view — **per-change ✓/✗ plus Accept all / Reject all**. Nothing commits until you resolve.
- Proposing switches preview→split so the diff is visible.

tsc + 68 tests green; CI verifies build on Windows + Linux. Needs runtime verification of the edit/diff UX (agent + accept/reject).