### PR TITLE
ci: make Rust cache step non-fatal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
+        # Caching is an optimization — a flaky GitHub cache service must never
+        # fail the build (it took down a Windows release once).
+        continue-on-error: true
         with:
           workspaces: './src-tauri -> target'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,9 @@ jobs:
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
+        # Caching is an optimization — a flaky GitHub cache service must never
+        # fail the release build (it took down a Windows release once).
+        continue-on-error: true
         with:
           workspaces: './src-tauri -> target'
 


### PR DESCRIPTION
A transient `swatinem/rust-cache` hiccup on the Windows runner failed the v0.6.19 release build (the actual compile never ran). Caching is only a speed optimization, so this marks the Rust-cache step `continue-on-error` in both CI and Release — a flaky cache service can no longer fail a build or release.