### PR TITLE
AI panel polish: visible diff review, modern composer, smoother file-open

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ I wanted a simple, lightweight solution that renders markdown beautifully while 
 - **Wikilinks** `[[other-file]]` resolve in the same folder
 - **Frontmatter** rendered as an editable Properties card
 
+### AI assistant
+
+- **AI side panel** — open it from the **AI** button next to Export (or `Alt+J` / `⌘J`). A VS Code-style chat docked on the right; content reflows beside it.
+- **Ask mode** — chat about the current document: summarize it, find something, ask questions. Answers stream in live.
+- **Agent mode** — describe a change in plain language and the AI proposes edits. They appear as an **inline diff in the editor** (green added / red removed) which you **review and accept or reject** — per change, or all at once. Nothing is written until you approve.
+- **Selection assist** — select text and press `Alt+J` / `⌘J` to rewrite, shorten, expand, continue, or translate it in place.
+- **Bring your own model** — works with any OpenAI-compatible endpoint: OpenAI, Google Gemini (OpenAI-compat), Ollama, llama.cpp, and more. Configure it in **Settings → AI**; your API key is stored in the OS keychain.
+
 ### Files & workflow
 
 - **Command palette** (Ctrl+P) — search commands, files, headings, toggles
@@ -92,7 +100,6 @@ I wanted a simple, lightweight solution that renders markdown beautifully while 
 - **Five fonts** — Inter, Merriweather, Lora, Source Serif, Fira Sans
 - **Three font sizes**
 - **WCAG-friendly** — visible focus rings, `prefers-reduced-motion` respected
-- **AI assist** (optional) — Ctrl+J on a selection; configure any OpenAI-compatible endpoint (Ollama, llama.cpp, OpenAI, etc.) in Settings → AI
 
 ### Platform
 
@@ -152,7 +159,7 @@ A few essentials — press `?` inside the app for the full searchable list.
 | Find / Replace | Ctrl+F / Ctrl+H |
 | Bold / Italic / Link | Ctrl+B / Ctrl+I / Ctrl+K |
 | Toggle blockquote | Ctrl+/ |
-| AI assist | Ctrl+J (macOS/Linux) · Alt+J (Windows) |
+| AI panel / assist | Alt+J (Windows) · ⌘J (macOS/Linux) |
 
 ## Tech Stack
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -143,6 +143,11 @@ function AppContent() {
   const [wordWrapEnabled, setWordWrapEnabled] = useState<boolean>(() => getWordWrap());
   const [spellCheckEnabled, setSpellCheckEnabled] = useState<boolean>(() => getSpellCheck());
   const [cursorPosition, setCursorPosition] = useState({ line: 1, col: 1 });
+  // True only while the launch-time "restore last file" is still resolving. Lets
+  // us show a neutral splash instead of flashing the WelcomeScreen for a frame
+  // before the restored editor mounts (the "looks broken, then the file appears"
+  // flicker). Starts false when there's nothing to restore.
+  const [booting, setBooting] = useState<boolean>(() => !!getLastFile());
   // Editor selection range. Collapsed (start === end) means no selection;
   // when start < end we surface a "N words selected" chip in the status bar.
   const [selectionRange, setSelectionRange] = useState<{ start: number; end: number }>({ start: 0, end: 0 });
@@ -359,7 +364,10 @@ function AppContent() {
           if (/too large/i.test(msg)) {
             showToast(`Could not restore last file: ${msg}`, "error");
           }
-        });
+        })
+        .finally(() => setBooting(false));
+    } else {
+      setBooting(false);
     }
     // Run only once on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1099,13 +1107,21 @@ function AppContent() {
       />
 
       {!hasFile ? (
-        <WelcomeScreen
-          onOpenFile={handleOpenFile}
-          onNewFile={handleNewFile}
-          onOpenSettings={() => setShowSettings(true)}
-          onFileDrop={handleFileDrop}
-          onOpenRecent={loadFile}
-        />
+        booting ? (
+          // Neutral splash while the last-opened file is being restored — avoids
+          // a one-frame WelcomeScreen flash before the editor mounts.
+          <div className="flex-1 flex items-center justify-center bg-[var(--bg-primary)]">
+            <span className="material-symbols-outlined text-[28px] text-[var(--text-muted)] animate-spin">progress_activity</span>
+          </div>
+        ) : (
+          <WelcomeScreen
+            onOpenFile={handleOpenFile}
+            onNewFile={handleNewFile}
+            onOpenSettings={() => setShowSettings(true)}
+            onFileDrop={handleFileDrop}
+            onOpenRecent={loadFile}
+          />
+        )
       ) : (
         <>
           {/* Split-aware layout. Both views always mounted; CSS toggles their display

--- a/src/components/AIPanel.tsx
+++ b/src/components/AIPanel.tsx
@@ -131,8 +131,7 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
         >
             {/* Header */}
             <div className="h-10 shrink-0 px-3 flex items-center justify-between border-b border-[var(--border)] bg-[var(--bg-titlebar)]">
-                <div className="flex items-center gap-2 text-sm font-semibold text-[var(--text-primary)] no-select">
-                    <span className="material-symbols-outlined text-[18px] text-[var(--accent)]">auto_awesome</span>
+                <div className="flex items-center gap-2 text-sm font-semibold text-[var(--text-primary)] no-select tracking-tight">
                     <span>AI Assistant</span>
                 </div>
                 <div className="flex items-center gap-1">
@@ -182,10 +181,15 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
                         </button>
                     </div>
                 ) : messages.length === 0 ? (
-                    <div className="flex flex-col items-center justify-center h-full text-center gap-2 text-sm text-[var(--text-secondary)] px-4">
-                        <span className="material-symbols-outlined text-[32px] opacity-40">forum</span>
-                        <p>Ask anything about <strong>{fileName || "this note"}</strong> — summarize it, find something, or get suggestions.</p>
-                        <p className="text-[11px] text-[var(--text-muted)]">Switch to <strong>Agent</strong> mode to make edits — you'll review each change before it's applied.</p>
+                    <div className="flex flex-col items-center justify-center h-full text-center gap-1.5 px-6">
+                        <p className="text-sm font-medium text-[var(--text-primary)]">
+                            {mode === "agent" ? "What should I change?" : "Ask about this note"}
+                        </p>
+                        <p className="text-xs text-[var(--text-muted)] leading-relaxed">
+                            {mode === "agent"
+                                ? "I'll propose edits you can review and accept."
+                                : "Summaries, questions, suggestions — anything."}
+                        </p>
                     </div>
                 ) : (
                     messages.map((m, i) => (
@@ -218,27 +222,30 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
 
             {/* Input */}
             {configured && (
-                <div className="shrink-0 border-t border-[var(--border)] p-2">
-                    <div className="flex items-end gap-2 bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-md)] px-2 py-1.5 focus-within:border-[var(--accent)] transition-colors">
+                <div className="shrink-0 p-3 pt-2">
+                    <div className="ai-composer flex items-end gap-2 bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-lg)] px-3 py-2 shadow-sm transition-all duration-150">
                         <textarea
                             ref={inputRef}
                             value={input}
                             onChange={(e) => setInput(e.target.value)}
                             onKeyDown={onKeyDown}
                             rows={1}
-                            placeholder={mode === "agent" ? "Tell the AI what to change…" : "Ask about this note…"}
-                            className="flex-1 bg-transparent text-sm text-[var(--text-primary)] outline-none resize-none max-h-32 placeholder:text-[var(--text-muted)]"
+                            placeholder={mode === "agent" ? "Describe the change…" : "Ask about this note…"}
+                            className="flex-1 bg-transparent text-sm leading-relaxed text-[var(--text-primary)] outline-none focus:outline-none focus-visible:outline-none resize-none max-h-40 placeholder:text-[var(--text-muted)] py-0.5"
                         />
                         {busy ? (
-                            <button onClick={stop} title="Stop" aria-label="Stop generating" className="w-7 h-7 rounded-[var(--radius-sm)] bg-[var(--bg-hover)] text-[var(--text-primary)] flex items-center justify-center">
+                            <button onClick={stop} title="Stop" aria-label="Stop generating" className="shrink-0 w-8 h-8 rounded-[var(--radius-md)] bg-[var(--bg-hover)] text-[var(--text-primary)] flex items-center justify-center hover:bg-[var(--border)] transition-colors">
                                 <span className="material-symbols-outlined text-[18px]">stop</span>
                             </button>
                         ) : (
-                            <button onClick={send} disabled={!input.trim()} title="Send" aria-label="Send" className="w-7 h-7 rounded-[var(--radius-sm)] bg-[var(--accent)] text-[var(--accent-text)] flex items-center justify-center disabled:opacity-40">
+                            <button onClick={send} disabled={!input.trim()} title="Send (Enter)" aria-label="Send" className="shrink-0 w-8 h-8 rounded-[var(--radius-md)] bg-[var(--accent)] text-[var(--accent-text)] flex items-center justify-center enabled:hover:opacity-90 enabled:active:scale-95 transition-all disabled:opacity-30 disabled:cursor-not-allowed">
                                 <span className="material-symbols-outlined text-[18px]">arrow_upward</span>
                             </button>
                         )}
                     </div>
+                    <p className="px-1 pt-1.5 text-[10px] text-[var(--text-muted)] no-select">
+                        <kbd className="font-sans">Enter</kbd> to send · <kbd className="font-sans">Shift+Enter</kbd> for newline
+                    </p>
                 </div>
             )}
         </aside>

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -14,7 +14,7 @@ import { history, defaultKeymap, historyKeymap } from "@codemirror/commands";
 import { markdown } from "@codemirror/lang-markdown";
 import { syntaxHighlighting, HighlightStyle } from "@codemirror/language";
 import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
-import { unifiedMergeView } from "@codemirror/merge";
+import { unifiedMergeView, getChunks } from "@codemirror/merge";
 import { tags as t } from "@lezer/highlight";
 import { getImageFromClipboard, saveImageToFile, createMarkdownImage } from "../utils/imageUtils";
 import {
@@ -428,6 +428,17 @@ function CodeEditorImpl({
                 changes: { from: 0, to: view.state.doc.length, insert: reviewDoc },
                 effects: mergeCompRef.current.reconfigure(unifiedMergeView({ original: reviewOriginalRef.current })),
             });
+            // Bring the first proposed change into view so the user sees the diff
+            // immediately instead of having to hunt for it (the change may be far
+            // down a long document). Runs after the merge field computes chunks.
+            requestAnimationFrame(() => {
+                const v = viewRef.current;
+                if (!v) return;
+                const chunks = getChunks(v.state)?.chunks;
+                if (chunks && chunks.length) {
+                    v.dispatch({ effects: EditorView.scrollIntoView(chunks[0].fromB, { y: "center" }) });
+                }
+            });
         } else if (reviewingRef.current) {
             reviewingRef.current = false;
             lastReviewRef.current = null;
@@ -550,12 +561,12 @@ function CodeEditorImpl({
         <main className="flex-1 flex flex-col overflow-hidden relative">
             {reviewActive && (
                 <div className="flex items-center gap-2 px-3 h-9 shrink-0 bg-[var(--bg-secondary)] border-b border-[var(--accent)] text-xs no-select">
-                    <span className="material-symbols-outlined text-[16px] text-[var(--accent)]">auto_awesome</span>
+                    <span className="w-1.5 h-1.5 rounded-full bg-[var(--accent)] animate-pulse"></span>
                     <span className="text-[var(--text-primary)] font-medium">AI suggested changes</span>
-                    <span className="text-[var(--text-muted)] hidden sm:inline">— review each, or:</span>
-                    <div className="ml-auto flex items-center gap-2">
-                        <button onClick={rejectAllChanges} className="px-2 py-1 rounded-[var(--radius-sm)] text-[var(--danger)] hover:bg-[var(--danger)]/10 transition-colors">Reject all</button>
-                        <button onClick={acceptAllChanges} className="px-2 py-1 rounded-[var(--radius-sm)] bg-[var(--accent)] text-[var(--accent-text)] hover:opacity-90 transition-colors">Accept all</button>
+                    <span className="text-[var(--text-muted)] hidden sm:inline">— accept or reject each below, or all at once:</span>
+                    <div className="ml-auto flex items-center gap-1.5">
+                        <button onClick={rejectAllChanges} className="px-2.5 py-1 rounded-[var(--radius-sm)] font-medium text-[var(--danger)] hover:bg-[var(--danger)]/10 transition-colors">Reject all</button>
+                        <button onClick={acceptAllChanges} className="px-2.5 py-1 rounded-[var(--radius-sm)] font-medium bg-[var(--accent)] text-[var(--accent-text)] hover:opacity-90 transition-colors">Accept all</button>
                     </div>
                 </div>
             )}

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -158,12 +158,11 @@ function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, onSa
                                     aria-label="AI assistant"
                                     aria-pressed={aiActive}
                                     title="AI assistant"
-                                    className={`flex items-center gap-1 px-2 py-1 rounded-[var(--radius-md)] transition-colors text-xs ${aiActive
+                                    className={`flex items-center px-2.5 py-1 rounded-[var(--radius-md)] transition-colors text-xs font-semibold tracking-wide ${aiActive
                                         ? "bg-[var(--bg-hover)] text-[var(--accent)]"
                                         : "hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
                                         }`}
                                 >
-                                    <span className="material-symbols-outlined text-[16px]">auto_awesome</span>
                                     <span>AI</span>
                                 </button>
                             )}

--- a/src/index.css
+++ b/src/index.css
@@ -817,3 +817,115 @@ select:focus-visible,
 .hljs-literal {
   color: var(--syntax-h1);
 }
+
+/* ===== AI composer (panel input) =====
+   A modern focus state: when the textarea inside is focused, the whole composer
+   lifts with an accent border + soft accent glow. We suppress the textarea's own
+   focus-visible outline (the stray "blue box") since the wrapper owns the ring.
+   color-mix gives a theme-tinted glow from the single --accent variable; on the
+   rare webview that lacks it, the property is ignored and the border still
+   highlights — no broken state. */
+.ai-composer:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.ai-composer textarea:focus,
+.ai-composer textarea:focus-visible {
+  outline: none !important;
+  outline-offset: 0 !important;
+}
+
+/* ===== AI inline diff review (@codemirror/merge unified view) =====
+   The merge package injects a base theme whose diff tints are ~8% opacity —
+   essentially invisible on the near-black editor background, which made it look
+   like "nothing changed until you Accept all". We override with clearly visible,
+   theme-agnostic green (added) / red (removed) so the proposed edits read at a
+   glance. Selectors carry a `.cm-editor` ancestor + !important so they win over
+   the runtime-injected base theme regardless of stylesheet insertion order. */
+:root {
+  --diff-add-bg: rgba(46, 160, 67, 0.20);
+  --diff-add-border: #2ea043;
+  --diff-del-bg: rgba(248, 81, 73, 0.18);
+  --diff-del-border: #f85149;
+  --diff-del-text: #ff7b72;
+}
+
+[data-theme="light"],
+[data-theme="github"],
+[data-theme="paper"] {
+  --diff-add-bg: rgba(46, 160, 67, 0.16);
+  --diff-add-border: #2da44e;
+  --diff-del-bg: rgba(207, 34, 46, 0.12);
+  --diff-del-border: #cf222e;
+  --diff-del-text: #cf222e;
+}
+
+/* Inserted / changed lines in the proposed document */
+.cm-editor .cm-changedLine,
+.cm-editor .cm-inlineChangedLine,
+.cm-editor .cm-insertedLine {
+  background-color: var(--diff-add-bg) !important;
+  box-shadow: inset 2px 0 0 var(--diff-add-border);
+}
+
+/* Inline changed text — make the highlight solid, not a thin underline */
+.cm-editor .cm-changedText {
+  background: var(--diff-add-bg) !important;
+  border-radius: 2px;
+}
+
+/* Removed text shown as a block widget above the change */
+.cm-editor .cm-deletedChunk {
+  background-color: var(--diff-del-bg) !important;
+  box-shadow: inset 2px 0 0 var(--diff-del-border);
+  padding: 1px 6px;
+}
+
+.cm-editor .cm-deletedChunk .cm-deletedText,
+.cm-editor .cm-deletedLine {
+  background: transparent !important;
+  color: var(--diff-del-text) !important;
+  text-decoration: line-through;
+  text-decoration-color: var(--diff-del-border);
+}
+
+/* Per-change accept / reject controls inside a deleted chunk */
+.cm-editor .cm-deletedChunk .cm-chunkButtons {
+  gap: 4px;
+}
+
+.cm-editor .cm-deletedChunk .cm-chunkButtons button {
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+  color: #fff;
+  opacity: 0.92;
+  transition: opacity 0.12s ease, transform 0.1s ease;
+}
+
+.cm-editor .cm-deletedChunk .cm-chunkButtons button:hover {
+  opacity: 1;
+  transform: translateY(-1px);
+}
+
+.cm-editor .cm-deletedChunk .cm-chunkButtons button[name="accept"] {
+  background: var(--diff-add-border) !important;
+}
+
+.cm-editor .cm-deletedChunk .cm-chunkButtons button[name="reject"] {
+  background: var(--diff-del-border) !important;
+}
+
+/* Diff gutter markers pick up the accent so they're visible on every theme */
+.cm-editor .cm-changedLineGutter,
+.cm-editor .cm-inlineChangedLineGutter {
+  background-color: var(--diff-add-border);
+}
+
+.cm-editor .cm-deletedLineGutter {
+  background-color: var(--diff-del-border);
+}


### PR DESCRIPTION
Polishes the AI experience and a couple of rough edges, based on user feedback.

## What changed

### 1. Inline diff review is now actually visible (the big one)
Agent-mode edits are shown via `@codemirror/merge`'s unified view, but its base theme tints changes at ~8% opacity — invisible on the near-black editor. It looked like *"nothing changed until I hit Accept all."*
- Added clear green/red diff theming: added/changed lines, changed text, deleted chunks, the per-change accept/reject buttons, and gutters. Theme-aware (dark/light/paper/github).
- Auto-scroll the editor to the **first** proposed change when review begins, so you see it immediately even in a long doc.

### 2. Removed the "star" icon
Dropped `auto_awesome` from the AI button, panel header, and review banner — clean text labels instead.

### 3. Modern composer / input
- Larger rounded input, accent **focus-glow ring**, and the stray textarea focus outline (the "blue box") is suppressed — the wrapper owns the focus state now.
- Subtle `Enter` / `Shift+Enter` hint.

### 4. Minimalistic empty state
One short, mode-aware line ("Ask about this note" / "What should I change?") instead of the two-paragraph blurb.

### 5. Smoother file open
Boot splash on launch while the last file restores — removes the one-frame WelcomeScreen flash before the editor mounts ("looks broken, then the file appears").

### 6. README
Documented the AI side panel (Ask/Agent modes, diff review, bring-your-own model incl. Gemini) and refreshed the shortcut row.

## Verification
- `tsc --noEmit` clean
- All 68 frontend tests pass
- Rust untouched

Runtime check still recommended on your side: Agent mode → request a change → confirm the diff is clearly colored and Accept/Reject work.