### PR TITLE
v1.0.0 — live diff preview, auto-growing AI input, polished Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marklite",
   "private": true,
-  "version": "0.6.22",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "marklite"
-version = "0.6.12"
+version = "1.0.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marklite"
-version = "0.6.22"
+version = "1.0.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MarkLite",
-  "version": "0.6.22",
+  "version": "1.0.0",
   "identifier": "com.saqla.marklite",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/components/AIPanel.tsx
+++ b/src/components/AIPanel.tsx
@@ -45,6 +45,18 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
     }, [messages]);
     useEffect(() => () => abortRef.current?.abort(), []);
 
+    // Auto-grow the composer as the user types more lines (up to a max, then
+    // scroll). Without this the single-row textarea just scrolls internally and
+    // hides earlier lines. Reset to one row when cleared.
+    const AI_INPUT_MAX_PX = 168;
+    useEffect(() => {
+        const el = inputRef.current;
+        if (!el) return;
+        el.style.height = "auto";
+        el.style.height = Math.min(el.scrollHeight, AI_INPUT_MAX_PX) + "px";
+        el.style.overflowY = el.scrollHeight > AI_INPUT_MAX_PX ? "auto" : "hidden";
+    }, [input]);
+
     const send = useCallback(async () => {
         const text = input.trim();
         if (!text || busy) return;
@@ -231,7 +243,7 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
                             onKeyDown={onKeyDown}
                             rows={1}
                             placeholder={mode === "agent" ? "Describe the change…" : "Ask about this note…"}
-                            className="flex-1 bg-transparent text-sm leading-relaxed text-[var(--text-primary)] outline-none focus:outline-none focus-visible:outline-none resize-none max-h-40 placeholder:text-[var(--text-muted)] py-0.5"
+                            className="flex-1 block w-full bg-transparent text-sm leading-relaxed text-[var(--text-primary)] outline-none focus:outline-none focus-visible:outline-none resize-none placeholder:text-[var(--text-muted)] py-0.5"
                         />
                         {busy ? (
                             <button onClick={stop} title="Stop" aria-label="Stop generating" className="shrink-0 w-8 h-8 rounded-[var(--radius-md)] bg-[var(--bg-hover)] text-[var(--text-primary)] flex items-center justify-center hover:bg-[var(--border)] transition-colors">

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -14,7 +14,7 @@ import { history, defaultKeymap, historyKeymap } from "@codemirror/commands";
 import { markdown } from "@codemirror/lang-markdown";
 import { syntaxHighlighting, HighlightStyle } from "@codemirror/language";
 import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
-import { unifiedMergeView, getChunks } from "@codemirror/merge";
+import { unifiedMergeView, getChunks, getOriginalDoc } from "@codemirror/merge";
 import { tags as t } from "@lezer/highlight";
 import { getImageFromClipboard, saveImageToFile, createMarkdownImage } from "../utils/imageUtils";
 import {
@@ -242,9 +242,20 @@ function CodeEditorImpl({
         ]));
 
         const updateListener = EditorView.updateListener.of((update: ViewUpdate) => {
-            // Suppress propagation while an AI review is active — the doc shows the
-            // PROPOSED text then, which mustn't be committed until accept/reject.
-            if (update.docChanged && !reviewingRef.current) {
+            if (reviewingRef.current) {
+                // During an AI review the editor shows the full PROPOSED text, but
+                // the preview should show "original + the changes accepted so far".
+                // @codemirror/merge's acceptChunk folds an accepted change into its
+                // original document (rejectChunk reverts the editor doc instead), so
+                // getOriginalDoc() IS exactly that running result — sync it to the
+                // preview so accepting/rejecting a single change updates it live.
+                let accepted: string | null = null;
+                try { accepted = getOriginalDoc(update.state).toString(); } catch { /* merge field not ready */ }
+                if (accepted !== null && accepted !== lastEmittedRef.current) {
+                    lastEmittedRef.current = accepted;
+                    onChangeRef.current?.(accepted);
+                }
+            } else if (update.docChanged) {
                 const value = update.state.doc.toString();
                 lastEmittedRef.current = value;
                 onChangeRef.current?.(value);
@@ -471,7 +482,10 @@ function CodeEditorImpl({
             effects: mergeCompRef.current.reconfigure([]),
         });
         lastEmittedRef.current = orig;
-        onReviewResolve?.(null);
+        // Pass the original explicitly (not null): the preview was live-tracking the
+        // accepted-so-far document during review, so we must reset it all the way
+        // back, not leave it on a partially-accepted state.
+        onReviewResolve?.(orig);
     }, [onReviewResolve]);
 
     // Scroll-fraction sync (rAF-throttled — PREVIEW-04) + imperative scroller.

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -36,18 +36,20 @@ const themes: Array<{ id: Theme; name: string; colors: [string, string]; textCol
     { id: "github", name: "GitHub", colors: ["#ffffff", "#f6f8fa"], textColor: "#1f2328", icon: "github" },
 ];
 
-const fonts: Array<{ id: FontFamily; name: string }> = [
-    { id: "inter", name: "Inter" },
-    { id: "merriweather", name: "Merriweather" },
-    { id: "lora", name: "Lora" },
-    { id: "source-serif", name: "Source Serif" },
-    { id: "fira-sans", name: "Fira Sans" },
+// `stack` mirrors the --font-body value each `[data-font]` sets in index.css, so
+// each option can preview itself in its own typeface.
+const fonts: Array<{ id: FontFamily; name: string; kind: string; stack: string }> = [
+    { id: "inter", name: "Inter", kind: "Sans-serif", stack: "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" },
+    { id: "merriweather", name: "Merriweather", kind: "Serif", stack: "'Merriweather', Georgia, 'Times New Roman', serif" },
+    { id: "lora", name: "Lora", kind: "Serif", stack: "'Lora', Georgia, 'Times New Roman', serif" },
+    { id: "source-serif", name: "Source Serif", kind: "Serif", stack: "'Source Serif 4', Georgia, 'Times New Roman', serif" },
+    { id: "fira-sans", name: "Fira Sans", kind: "Sans-serif", stack: "'Fira Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" },
 ];
 
-const fontSizes: Array<{ id: FontSize; name: string }> = [
-    { id: "small", name: "Small" },
-    { id: "medium", name: "Medium" },
-    { id: "large", name: "Large" },
+const fontSizes: Array<{ id: FontSize; name: string; sample: number }> = [
+    { id: "small", name: "Small", sample: 13 },
+    { id: "medium", name: "Medium", sample: 16 },
+    { id: "large", name: "Large", sample: 19 },
 ];
 
 interface ToggleRowProps {
@@ -64,14 +66,18 @@ function ToggleRow({ label, description, checked, onChange }: ToggleRowProps) {
             role="switch"
             aria-checked={checked}
             onClick={() => onChange(!checked)}
-            className="w-full flex items-center justify-between gap-4 px-3 py-2.5 rounded-[var(--radius-md)] hover:bg-[var(--bg-hover)] transition-colors text-left"
+            className="group w-full flex items-center justify-between gap-4 px-3.5 py-3 hover:bg-[var(--bg-hover)] transition-colors text-left"
         >
             <div className="flex flex-col items-start min-w-0">
-                <span className="text-sm text-[var(--text-primary)]">{label}</span>
-                <span className="text-[11px] text-[var(--text-muted)]">{description}</span>
+                <span className="text-sm font-medium text-[var(--text-primary)]">{label}</span>
+                <span className="text-[11px] text-[var(--text-muted)] mt-0.5">{description}</span>
             </div>
-            <span className={`relative inline-block w-9 h-5 rounded-full shrink-0 transition-colors ${checked ? "bg-[var(--accent)]" : "bg-[var(--border)]"}`}>
-                <span className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white transition-transform ${checked ? "translate-x-4" : ""}`} />
+            <span
+                className={`relative inline-block w-[42px] h-[24px] rounded-full shrink-0 transition-colors duration-200 ${checked ? "bg-[var(--accent)]" : "bg-[var(--text-muted)]/45 group-hover:bg-[var(--text-muted)]/60"}`}
+            >
+                <span
+                    className={`absolute top-[3px] left-[3px] w-[18px] h-[18px] rounded-full bg-white shadow-[0_1px_2px_rgba(0,0,0,0.3)] transition-transform duration-200 ease-out ${checked ? "translate-x-[18px]" : "translate-x-0"}`}
+                />
             </span>
         </button>
     );
@@ -236,33 +242,50 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                     <section>
                                         <h3 className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider mb-2">Font</h3>
                                         <div className="grid grid-cols-2 gap-2">
-                                            {fonts.map((f) => (
-                                                <button
-                                                    key={f.id}
-                                                    onClick={() => setFont(f.id)}
-                                                    className={`px-3 py-2 rounded-[var(--radius-md)] text-sm text-left transition-colors ${font === f.id
-                                                        ? "bg-[var(--accent)] text-[var(--accent-text)]"
-                                                        : "hover:bg-[var(--bg-hover)] text-[var(--text-primary)]"
-                                                        }`}
-                                                >{f.name}</button>
-                                            ))}
+                                            {fonts.map((f) => {
+                                                const active = font === f.id;
+                                                return (
+                                                    <button
+                                                        key={f.id}
+                                                        onClick={() => setFont(f.id)}
+                                                        aria-pressed={active}
+                                                        className={`flex items-center justify-between gap-2 px-3 py-2.5 rounded-[var(--radius-md)] border text-left transition-all ${active
+                                                            ? "border-[var(--accent)] bg-[var(--bg-hover)] ring-1 ring-[var(--accent)]"
+                                                            : "border-[var(--border)] hover:border-[var(--text-muted)] hover:bg-[var(--bg-hover)]"
+                                                            }`}
+                                                    >
+                                                        <span className="min-w-0">
+                                                            <span className="block text-[15px] leading-tight text-[var(--text-primary)] truncate" style={{ fontFamily: f.stack }}>{f.name}</span>
+                                                            <span className="block text-[10px] text-[var(--text-muted)] mt-0.5">{f.kind}</span>
+                                                        </span>
+                                                        {active && <span className="material-symbols-outlined text-[18px] text-[var(--accent)] shrink-0">check</span>}
+                                                    </button>
+                                                );
+                                            })}
                                         </div>
                                     </section>
                                 )}
                                 {matches("size") && (
                                     <section>
                                         <h3 className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider mb-2">Font size</h3>
-                                        <div className="flex gap-2">
-                                            {fontSizes.map((s) => (
-                                                <button
-                                                    key={s.id}
-                                                    onClick={() => setFontSize(s.id)}
-                                                    className={`flex-1 px-3 py-2 rounded-[var(--radius-md)] text-sm transition-colors ${fontSize === s.id
-                                                        ? "bg-[var(--accent)] text-[var(--accent-text)]"
-                                                        : "hover:bg-[var(--bg-hover)] text-[var(--text-primary)]"
-                                                        }`}
-                                                >{s.name}</button>
-                                            ))}
+                                        <div className="grid grid-cols-3 gap-2">
+                                            {fontSizes.map((s) => {
+                                                const active = fontSize === s.id;
+                                                return (
+                                                    <button
+                                                        key={s.id}
+                                                        onClick={() => setFontSize(s.id)}
+                                                        aria-pressed={active}
+                                                        className={`flex flex-col items-center justify-center gap-1 py-3 rounded-[var(--radius-md)] border transition-all ${active
+                                                            ? "border-[var(--accent)] bg-[var(--bg-hover)] ring-1 ring-[var(--accent)]"
+                                                            : "border-[var(--border)] hover:border-[var(--text-muted)] hover:bg-[var(--bg-hover)]"
+                                                            }`}
+                                                    >
+                                                        <span className="leading-none text-[var(--text-primary)]" style={{ fontSize: s.sample }}>Aa</span>
+                                                        <span className="text-[11px] text-[var(--text-secondary)]">{s.name}</span>
+                                                    </button>
+                                                );
+                                            })}
                                         </div>
                                     </section>
                                 )}
@@ -270,7 +293,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                         )}
 
                         {section === "editor" && (
-                            <>
+                            <div className="rounded-[var(--radius-lg)] border border-[var(--border)] divide-y divide-[var(--border-subtle)] overflow-hidden">
                                 {matches("typewriter") && (
                                     <ToggleRow label="Typewriter mode" description="Keep caret vertically centered" checked={typewriter}
                                         onChange={(v) => { setTypewriterLocal(v); setTypewriterMode(v); fire("marklite:typewriter-toggle", v); }} />
@@ -287,7 +310,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                     <ToggleRow label="Spell check" description="Underline misspelled words while you type" checked={spellCheck}
                                         onChange={(v) => { setSpellCheckLocal(v); setSpellCheck(v); fire("marklite:spellcheck-toggle", v); }} />
                                 )}
-                            </>
+                            </div>
                         )}
 
                         {section === "ai" && (


### PR DESCRIPTION
Addresses the latest round of feedback, and bumps MarkLite to **v1.0.0**. 🎉

### 1. AI input grows with your text
The composer was a fixed single row, so a second line pushed the first out of view. It now **auto-grows** as you type (up to a max height, then scrolls).

### 2. Per-change accept now updates the preview live
Previously the preview only changed when you clicked **Accept all** — accepting an individual change in the diff did nothing visible in the preview.

Root cause + fix: during review the editor shows the *full proposed* text, but the preview should show **“original + the changes you’ve accepted so far.”** `@codemirror/merge`'s `acceptChunk` folds an accepted change into its **original** document (while `rejectChunk` reverts the editor doc), so `getOriginalDoc()` is exactly that running result. We now sync it to the preview on every review update:
- Accept one change → it appears in the preview immediately.
- Reject one → it stays out.
- **Reject all** resets fully (discards any individually-accepted changes too).

### 3. Settings polish (toggles + fonts)
- **Toggle switches** redesigned — larger, smoother animation, and visible on every theme (the old “off” state was nearly invisible on dark).
- **Font picker** now previews each option **in its own typeface**, with a Serif/Sans label and a check on the active one.
- **Font size** shows an `Aa` scale preview.
- Editor toggles grouped into one clean bordered list (they were floating far apart).

### 4. Version → 1.0.0
Bumped `tauri.conf.json`, `package.json`, `Cargo.toml`, `Cargo.lock`. **Merging this releases v1.0.0** (no `v1.0.0` tag exists yet, so the release workflow ships it as-is rather than auto-bumping).

### Verification
- `tsc --noEmit` clean · all **68 tests** pass.
- ⚠️ The live-preview-during-review behavior depends on `@codemirror/merge` runtime internals, which I can't exercise headlessly — **please runtime-check** Agent mode: accept one change → preview updates; reject all → reverts.