### PR TITLE
Polish landing: remove faux window chrome and hero hover-tilt

### DIFF
--- a/docs/src/components/AppWindow.astro
+++ b/docs/src/components/AppWindow.astro
@@ -1,20 +1,14 @@
 ---
+// Frame for product screenshots and the AI mock. The captured screenshots
+// already include MarkLite's own title bar + window controls, so this is just
+// a rounded, shadowed bezel — no duplicate (and non-native) chrome on top.
 interface Props {
-  label?: string;
+  label?: string; // accepted for caller compatibility; not rendered
   class?: string;
-  tilt?: boolean;
 }
-const { label = "MarkLite", class: klass = "", tilt = false } = Astro.props;
+const { class: klass = "" } = Astro.props;
 ---
 
-<div class={`window ${klass}`} data-tilt={tilt ? "" : undefined}>
-  <div class="window-bar no-select">
-    <span class="window-dot" style="background:#ff5f57"></span>
-    <span class="window-dot" style="background:#febc2e"></span>
-    <span class="window-dot" style="background:#28c840"></span>
-    <span class="ml-2 truncate text-xs text-fg-dim">{label}</span>
-  </div>
-  <div class="relative">
-    <slot />
-  </div>
+<div class={`window ${klass}`}>
+  <slot />
 </div>

--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -52,8 +52,8 @@ const releases = "https://github.com/Razee4315/MarkLite/releases/latest";
   </div>
 
   <!-- Product shot -->
-  <div class="relative z-10 mx-auto mt-16 max-w-5xl px-5 [perspective:1800px]" data-reveal>
-    <AppWindow label=".shots / Getting Started.md — MarkLite" tilt={true} class="mx-auto">
+  <div class="relative z-10 mx-auto mt-16 max-w-5xl px-5" data-reveal>
+    <AppWindow class="mx-auto">
       <Image
         src={splitDark}
         alt="MarkLite in split view: syntax-highlighted Markdown source on the left, live-rendered preview with a table, task list and callout on the right"

--- a/docs/src/scripts/motion.ts
+++ b/docs/src/scripts/motion.ts
@@ -92,27 +92,6 @@ export function initMotion(): void {
     }
   }
 
-  /* ---- Subtle 3D tilt on the hero window (pointer only) ---- */
-  if (window.matchMedia("(pointer: fine)").matches) {
-    gsap.utils.toArray<HTMLElement>("[data-tilt]").forEach((el) => {
-      const rotX = gsap.quickTo(el, "rotationX", { duration: 0.6, ease: "power3.out" });
-      const rotY = gsap.quickTo(el, "rotationY", { duration: 0.6, ease: "power3.out" });
-      gsap.set(el, { transformPerspective: 1800, transformOrigin: "center" });
-      const area = el.parentElement || el;
-      area.addEventListener("pointermove", (e) => {
-        const r = area.getBoundingClientRect();
-        const px = (e.clientX - r.left) / r.width - 0.5;
-        const py = (e.clientY - r.top) / r.height - 0.5;
-        rotY(px * 6);
-        rotX(-py * 5);
-      });
-      area.addEventListener("pointerleave", () => {
-        rotY(0);
-        rotX(0);
-      });
-    });
-  }
-
   /* Recalculate once fonts settle to avoid trigger drift */
   if (document.fonts?.ready) document.fonts.ready.then(() => ScrollTrigger.refresh());
 }

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -301,21 +301,6 @@ canvas {
     0 12px 40px -20px color-mix(in srgb, var(--color-brand) 22%, transparent);
   overflow: hidden;
 }
-.window-bar {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  height: 38px;
-  padding: 0 0.85rem;
-  border-bottom: 1px solid var(--color-line-soft);
-  background: color-mix(in srgb, var(--color-ink-900) 80%, #000);
-}
-.window-dot {
-  width: 11px;
-  height: 11px;
-  border-radius: 999px;
-}
-
 /* ===== Reduced motion ===== */
 @media (prefers-reduced-motion: reduce) {
   html {


### PR DESCRIPTION
## Summary
Two design fixes on the landing site, from review feedback:

- **No more hover-tilt on the hero.** The product shot used a 3D tilt that shifted the image on mouse-move; it felt unstable. The hero is now static.
- **Removed the faux macOS title bar (traffic-light dots) from every framed screenshot.** The captured shots already include MarkLite's own title bar and window controls, so the dots were duplicate, off-brand (macOS-style) chrome. Each screenshot now sits in a clean rounded bezel showing its real app chrome.

Also removes the now-dead `.window-bar`/`.window-dot` CSS and the tilt handler in `motion.ts`.

## Test plan
- `cd docs && bun run build` passes; no `window-dot`/`data-tilt` left in output
- Verified hero + editor sections render the screenshots in a clean frame with no top dots and no hover motion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
