### PR TITLE
Polish hero + FAQ: cleaner animated headline, ambient glow, smooth accordion

### DIFF
--- a/docs/src/components/Faq.astro
+++ b/docs/src/components/Faq.astro
@@ -48,7 +48,9 @@ const faqs = [
               class="h-5 w-5 shrink-0 text-fg-dim transition-transform duration-300 group-open:rotate-45"
             />
           </summary>
-          <p class="mt-3 text-[15px] leading-relaxed text-fg-muted">{f.a}</p>
+          <div class="faq-content overflow-hidden">
+            <p class="pt-3 text-[15px] leading-relaxed text-fg-muted">{f.a}</p>
+          </div>
         </details>
       ))}
     </div>
@@ -64,6 +66,44 @@ const faqs = [
     acceptedAnswer: { "@type": "Answer", text: f.a },
   })),
 })} />
+
+<script>
+  // Smooth open/close for the native <details> accordion via the Web Animations
+  // API. Falls back to the instant native toggle under reduced-motion.
+  const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  document.querySelectorAll<HTMLDetailsElement>("details.faq").forEach((d) => {
+    const summary = d.querySelector("summary");
+    const content = d.querySelector<HTMLElement>(".faq-content");
+    if (!summary || !content) return;
+    let anim: Animation | null = null;
+    const easing = "cubic-bezier(0.16, 1, 0.3, 1)";
+
+    summary.addEventListener("click", (e) => {
+      if (reduce) return; // native toggle
+      e.preventDefault();
+      anim?.cancel();
+      if (!d.open) {
+        d.open = true;
+        const h = content.offsetHeight;
+        anim = content.animate(
+          [{ height: "0px", opacity: 0 }, { height: `${h}px`, opacity: 1 }],
+          { duration: 300, easing },
+        );
+        anim.onfinish = () => (content.style.height = "");
+      } else {
+        const h = content.offsetHeight;
+        anim = content.animate(
+          [{ height: `${h}px`, opacity: 1 }, { height: "0px", opacity: 0 }],
+          { duration: 240, easing },
+        );
+        anim.onfinish = () => {
+          d.open = false;
+          content.style.height = "";
+        };
+      }
+    });
+  });
+</script>
 
 <style>
   .faq summary::-webkit-details-marker {

--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -11,6 +11,7 @@ const releases = "https://github.com/Razee4315/MarkLite/releases/latest";
 <header id="top" class="relative overflow-hidden pt-32 pb-20 md:pt-40 md:pb-28">
   <div class="aurora" data-parallax="6"></div>
   <div class="grid-bg"></div>
+  <div class="hero-spot" data-hero-spot></div>
 
   <div class="relative z-10 mx-auto max-w-6xl px-5 text-center">
     <a
@@ -29,7 +30,7 @@ const releases = "https://github.com/Razee4315/MarkLite/releases/latest";
       data-reveal
     >
       The markdown editor that
-      <span class="font-serif-display italic text-gradient">stays out of your way</span>
+      <span class="font-serif-display italic text-gradient text-gradient-flow">stays out of your way</span>
     </h1>
 
     <p class="mx-auto mt-6 max-w-2xl text-balance text-lg text-fg-muted md:text-xl" data-reveal>

--- a/docs/src/scripts/motion.ts
+++ b/docs/src/scripts/motion.ts
@@ -92,6 +92,21 @@ export function initMotion(): void {
     }
   }
 
+  /* ---- Cursor-reactive glow in the hero ---- */
+  const spot = document.querySelector<HTMLElement>("[data-hero-spot]");
+  const hero = document.querySelector<HTMLElement>("#top");
+  if (spot && hero && window.matchMedia("(pointer: fine)").matches) {
+    const xTo = gsap.quickTo(spot, "x", { duration: 0.7, ease: "power3.out" });
+    const yTo = gsap.quickTo(spot, "y", { duration: 0.7, ease: "power3.out" });
+    hero.addEventListener("pointermove", (e) => {
+      const r = hero.getBoundingClientRect();
+      xTo(e.clientX - r.left);
+      yTo(e.clientY - r.top);
+      spot.style.opacity = "1";
+    });
+    hero.addEventListener("pointerleave", () => (spot.style.opacity = "0"));
+  }
+
   /* Recalculate once fonts settle to avoid trigger drift */
   if (document.fonts?.ready) document.fonts.ready.then(() => ScrollTrigger.refresh());
 }

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -112,11 +112,29 @@ canvas {
 }
 
 .text-gradient {
-  background: linear-gradient(100deg, var(--color-brand) 0%, var(--color-brand-soft) 40%, var(--color-cyan) 100%);
+  /* Warm -> light -> cool, routed through a light midtone so orange never
+     blends into cyan through a muddy grey-green. */
+  background: linear-gradient(100deg, #ff8c00 0%, #ffb15a 28%, #ffe1bf 47%, #bfeef2 62%, #38d9f0 82%, #00e5ff 100%);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
   color: transparent;
+}
+
+/* Slow flowing variant for the hero headline (palindrome gradient loops seamlessly) */
+.text-gradient-flow {
+  background-image: linear-gradient(100deg, #ff8c00, #ffb15a, #ffe1bf, #bfeef2, #00e5ff, #bfeef2, #ffe1bf, #ffb15a, #ff8c00);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  will-change: background-position;
+  animation: text-flow 12s linear infinite;
+}
+@keyframes text-flow {
+  from { background-position: 0% 50%; }
+  to { background-position: -200% 50%; }
 }
 
 .text-balance {
@@ -133,11 +151,11 @@ canvas {
   pointer-events: none;
   z-index: 0;
   filter: blur(70px);
-  opacity: 0.55;
+  opacity: 0.7;
   background:
-    radial-gradient(40% 50% at 22% 30%, color-mix(in srgb, var(--color-brand) 70%, transparent), transparent 70%),
-    radial-gradient(38% 48% at 78% 28%, color-mix(in srgb, var(--color-cyan) 60%, transparent), transparent 70%),
-    radial-gradient(45% 55% at 50% 70%, color-mix(in srgb, var(--color-brand) 30%, transparent), transparent 75%);
+    radial-gradient(40% 50% at 22% 28%, color-mix(in srgb, var(--color-brand) 75%, transparent), transparent 70%),
+    radial-gradient(38% 48% at 80% 26%, color-mix(in srgb, var(--color-cyan) 62%, transparent), transparent 70%),
+    radial-gradient(50% 60% at 50% 72%, color-mix(in srgb, var(--color-brand) 32%, transparent), transparent 75%);
   animation: aurora-drift 16s var(--ease-out-expo) infinite alternate;
 }
 
@@ -155,6 +173,24 @@ canvas {
   background-image: radial-gradient(circle at 1px 1px, color-mix(in srgb, var(--color-fg) 6%, transparent) 1px, transparent 0);
   background-size: 34px 34px;
   mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, #000 30%, transparent 75%);
+}
+
+/* Cursor-reactive glow in the hero — positioned by motion.ts on pointer move */
+.hero-spot {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 620px;
+  height: 620px;
+  margin: -310px 0 0 -310px;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 0;
+  background: radial-gradient(circle, color-mix(in srgb, var(--color-brand) 18%, transparent), transparent 62%);
+  filter: blur(40px);
+  opacity: 0;
+  transition: opacity 0.6s ease;
+  will-change: transform;
 }
 
 /* Film grain for a tactile, premium feel */


### PR DESCRIPTION
## Summary
Design-polish round from review feedback.

- **Headline gradient fixed + animated.** Orange now flows through a light midtone to cyan instead of a muddy grey-green ("of your" no longer looks olive). Added a slow, subtle flowing animation.
- **Richer hero background.** Stronger aurora glow plus a soft cursor-reactive light that follows the pointer (pointer devices only; the whole motion init is skipped under `prefers-reduced-motion`).
- **Smooth FAQ accordion.** Open/close now animates height + fade via the Web Animations API; the instant native toggle is kept for reduced-motion.

## Test plan
- `cd docs && bun run build` passes
- Verified the headline gradient (no muddy midpoint), the ambient hero glow, and FAQ expand/collapse in a local preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
