### PR TITLE
Add live GitHub stats band (stars + downloads)

### DIFF
--- a/docs/src/components/Stats.astro
+++ b/docs/src/components/Stats.astro
@@ -1,0 +1,111 @@
+---
+import { Icon } from "astro-icon/components";
+
+// Baked fallbacks (the no-JS / crawler floor). The client script below
+// refreshes these live from the GitHub API and counts up on scroll-in.
+const stats = [
+  { icon: "lucide:star", value: "20", live: "stars", label: "GitHub stars" },
+  { icon: "lucide:download", value: "201", live: "downloads", label: "Downloads" },
+  { icon: "lucide:eye-off", value: "0", label: "Trackers" },
+  { icon: "lucide:wifi-off", value: "100%", label: "Offline" },
+];
+---
+
+<section class="py-16 md:py-20" data-stats>
+  <div class="mx-auto max-w-5xl px-5">
+    <div
+      class="card grid grid-cols-2 gap-px overflow-hidden md:grid-cols-4"
+      data-reveal
+      style="background: var(--color-line)"
+    >
+      {stats.map((s) => (
+        <div class="flex flex-col items-center gap-2 bg-ink-900 px-6 py-9 text-center">
+          <Icon name={s.icon} class="h-5 w-5 text-brand" />
+          <div class="text-3xl font-extrabold tracking-tight md:text-4xl">
+            {s.live ? (
+              <span data-stat={s.live} data-fallback={s.value}>{s.value}</span>
+            ) : (
+              s.value
+            )}
+          </div>
+          <div class="text-sm text-fg-muted">{s.label}</div>
+        </div>
+      ))}
+    </div>
+  </div>
+</section>
+
+<script>
+  const REPO = "Razee4315/MarkLite";
+  const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const band = document.querySelector("[data-stats]");
+
+  if (band) {
+    const nodes: Record<string, HTMLElement | null> = {
+      stars: band.querySelector('[data-stat="stars"]'),
+      downloads: band.querySelector('[data-stat="downloads"]'),
+    };
+    const fmt = (n: number) => n.toLocaleString();
+
+    const countTo = (el: HTMLElement, to: number) => {
+      if (reduce) {
+        el.textContent = fmt(to);
+        return;
+      }
+      const dur = 1200;
+      const t0 = performance.now();
+      const step = (t: number) => {
+        const p = Math.min(1, (t - t0) / dur);
+        const eased = 1 - Math.pow(1 - p, 3);
+        el.textContent = fmt(Math.round(to * eased));
+        if (p < 1) requestAnimationFrame(step);
+      };
+      requestAnimationFrame(step);
+    };
+
+    const fetchStats = async () => {
+      const out: { stars?: number; downloads?: number } = {};
+      try {
+        const r = await fetch(`https://api.github.com/repos/${REPO}`);
+        if (r.ok) out.stars = (await r.json()).stargazers_count;
+      } catch {}
+      try {
+        const r = await fetch(`https://api.github.com/repos/${REPO}/releases?per_page=100`);
+        if (r.ok) {
+          const rels = await r.json();
+          out.downloads = rels.reduce(
+            (s: number, rel: any) =>
+              s + (rel.assets || []).reduce((a: number, x: any) => a + (x.download_count || 0), 0),
+            0,
+          );
+        }
+      } catch {}
+      return out;
+    };
+
+    let done = false;
+    const run = async () => {
+      if (done) return;
+      done = true;
+      const live = await fetchStats();
+      (["stars", "downloads"] as const).forEach((k) => {
+        const el = nodes[k];
+        if (!el) return;
+        const target = live[k] ?? (Number(el.dataset.fallback) || 0);
+        countTo(el, target);
+      });
+    };
+
+    const io = new IntersectionObserver(
+      (entries) =>
+        entries.forEach((e) => {
+          if (e.isIntersecting) {
+            run();
+            io.disconnect();
+          }
+        }),
+      { threshold: 0.25 },
+    );
+    io.observe(band);
+  }
+</script>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -8,6 +8,7 @@ import EditorShowcase from "../components/EditorShowcase.astro";
 import Themes from "../components/Themes.astro";
 import PowerFeatures from "../components/PowerFeatures.astro";
 import AIShowcase from "../components/AIShowcase.astro";
+import Stats from "../components/Stats.astro";
 import Download from "../components/Download.astro";
 import OpenSource from "../components/OpenSource.astro";
 import Faq from "../components/Faq.astro";
@@ -24,6 +25,7 @@ import Footer from "../components/Footer.astro";
     <Themes />
     <PowerFeatures />
     <AIShowcase />
+    <Stats />
     <Download />
     <OpenSource />
     <Faq />


### PR DESCRIPTION
## Summary
Adds a social-proof stats strip before the Download CTA.

- **GitHub stars** and **total release downloads** fetched live from the GitHub API, counting up on scroll-into-view.
- Plus two value-prop stats: **0 trackers**, **100% offline**.
- Baked fallbacks (20 stars / 201 downloads) keep the bar populated for no-JS visitors and crawlers; the client refreshes to live numbers. Reduced-motion shows final numbers without the count animation.
- Pure client-side fetch (no backend); unauthenticated GitHub API is well within rate limits for a landing page, and failures fall back to the baked numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
