### PR TITLE
feat: add Dracula theme

### DIFF
--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -6,6 +6,7 @@ const themes: { id: Theme; name: string; colors: [string, string]; textColor: st
     { id: 'light', name: 'Light', colors: ['#ffffff', '#f5f5f5'], textColor: '#171717' },
     { id: 'paper', name: 'Paper', colors: ['#f5f0e6', '#ebe5d8'], textColor: '#3d3d3d' },
     { id: 'github', name: 'GitHub', colors: ['#ffffff', '#f6f8fa'], textColor: '#1f2328', icon: 'github' },
+    { id: "dracula", name: "Dracula", colors: ["#282a36", "#44475a"], textColor: "#f8f8f2",},
 ];
 
 const fonts: { id: FontFamily; name: string; family: string }[] = [

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -34,6 +34,7 @@ const themes: Array<{ id: Theme; name: string; colors: [string, string]; textCol
     { id: "light", name: "Light", colors: ["#ffffff", "#f5f5f5"], textColor: "#171717" },
     { id: "paper", name: "Paper", colors: ["#f5f0e6", "#ebe5d8"], textColor: "#3d3d3d" },
     { id: "github", name: "GitHub", colors: ["#ffffff", "#f6f8fa"], textColor: "#1f2328", icon: "github" },
+    { id: "dracula", name: "Dracula", colors: ["#282a36", "#44475a"], textColor: "#f8f8f2",},
 ];
 
 // `stack` mirrors the --font-body value each `[data-font]` sets in index.css, so

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { ensureFontLoaded } from '../fonts';
 
-export type Theme = 'dark' | 'light' | 'paper' | 'github';
+export type Theme = 'dark' | 'light' | 'paper' | 'github'| "dracula" 
 export type FontFamily = 'inter' | 'merriweather' | 'lora' | 'source-serif' | 'fira-sans';
 export type FontSize = 'small' | 'medium' | 'large';
 
@@ -21,7 +21,7 @@ const FONT_STORAGE_KEY = 'marklite-font';
 const FONT_SIZE_STORAGE_KEY = 'marklite-font-size';
 
 // Valid values for validation against corrupted localStorage
-const VALID_THEMES: Theme[] = ['dark', 'light', 'paper', 'github'];
+const VALID_THEMES: Theme[] = ['dark', 'light', 'paper', 'github','dracula'];
 const VALID_FONTS: FontFamily[] = ['inter', 'merriweather', 'lora', 'source-serif', 'fira-sans'];
 const VALID_FONT_SIZES: FontSize[] = ['small', 'medium', 'large'];
 

--- a/src/index.css
+++ b/src/index.css
@@ -191,6 +191,54 @@
   --selection-text: #ffffff;
 }
 
+/* Dracula Theme */
+[data-theme="dracula"] {
+  --bg-primary: #282a36;
+  --bg-secondary: #343746;
+  --bg-titlebar: #21222c;
+  --bg-editor: #282a36;
+  --bg-gutter: #21222c;
+  --bg-hover: #44475a;
+  --bg-input: #343746;
+
+  --text-primary: #f8f8f2;
+  --text-secondary: #d6d6d6;
+  --text-muted: #6272a4;
+
+  --accent: #bd93f9;
+  --accent-hover: #a679f7;
+  --accent-text: #f8f8f2;
+
+  --border: #44475a;
+  --border-subtle: #3a3d4d;
+
+  --code-bg: #21222c;
+  --code-text: #f8f8f2;
+  --blockquote-bg: rgba(68, 71, 90, 0.35);
+
+  --syntax-h1: #ff79c6;
+  --syntax-h2: #ff79c6;
+  --syntax-h3: #bd93f9;
+  --syntax-link: #8be9fd;
+  --syntax-bold: #f8f8f2;
+  --syntax-list: #ffb86c;
+  --syntax-number: #bd93f9;
+  --syntax-quote: #6272a4;
+  --syntax-code: #50fa7b;
+
+  --status-saved: #50fa7b;
+  --status-unsaved: #ffb86c;
+  --danger: #ff5555;
+
+  --scrollbar-track: #21222c;
+  --scrollbar-thumb: #44475a;
+  --scrollbar-hover: #6272a4;
+
+  --selection-bg: #44475a;
+  --selection-text: #f8f8f2;
+}
+
+
 /* ===== Design Tokens ===== */
 :root {
   /* Radius scale — replace ad-hoc rounded-{lg,xl,full} usage with these */

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -69,6 +69,22 @@ const themeColors: Record<Theme, Record<string, string>> = {
         syntaxLink: '#0969da',
         syntaxBold: '#1f2328',
     },
+    dracula: {
+        bgPrimary: '#282a36',
+        bgSecondary: '#343746',
+        textPrimary: '#f8f8f2',
+        textSecondary: '#d6d6d6',
+        border: '#44475a',
+        codeBg: '#21222c',
+        codeText: '#f8f8f2',
+        blockquoteBg: 'rgba(68, 71, 90, 0.35)',
+        accent: '#bd93f9',
+        syntaxH1: '#ff79c6',
+        syntaxH2: '#ff79c6',
+        syntaxH3: '#bd93f9',
+        syntaxLink: '#8be9fd',
+        syntaxBold: '#f8f8f2',
+    },
 };
 
 // Font family definitions


### PR DESCRIPTION
## Summary

Closes #46 by adding a new Dracula theme to MarkLite.

### Changes

* Added Dracula theme variables in `src/index.css`
* Registered the Dracula theme in `ThemeContext`
* Added Dracula to the Appearance settings theme selector
* Applied Dracula styling across the editor, preview, syntax highlighting, and AI diff views
* Verified theme selection persists across application restarts

### Testing

* [x] Dracula theme appears in Settings → Appearance
* [x] Theme can be selected and applied successfully
* [x] Theme preference persists across restarts
* [x] Editor renders correctly with Dracula colors
* [x] Preview renders correctly with Dracula colors
* [x] AI diff colors render correctly
* [x] Build passes successfully

### Screenshots
<img width="1918" height="1033" alt="ssss" src="https://github.com/user-attachments/assets/a359b2fd-db2a-42a6-a0ae-c3c5c73a75ef" />

