### PR TITLE
Fix hero text clipping, remove em dashes, add Search Console verification

### DIFF
--- a/docs/public/google0d979f7b74e3dae0.html
+++ b/docs/public/google0d979f7b74e3dae0.html
@@ -1,0 +1,1 @@
+google-site-verification: google0d979f7b74e3dae0.html

--- a/docs/src/components/AIShowcase.astro
+++ b/docs/src/components/AIShowcase.astro
@@ -6,12 +6,12 @@ const points = [
   {
     icon: "lucide:message-circle",
     title: "Ask mode",
-    desc: "Chat about the current document — summarize, find, or explain. Answers stream in live.",
+    desc: "Chat about the current document: summarize, find, or explain. Answers stream in live.",
   },
   {
     icon: "lucide:wand-sparkles",
     title: "Agent mode",
-    desc: "Describe a change in plain language; edits appear as an inline diff you review and accept or reject — per change, or all at once.",
+    desc: "Describe a change in plain language; edits appear as an inline diff you review and accept or reject, per change, or all at once.",
   },
   {
     icon: "lucide:text-cursor-input",
@@ -21,7 +21,7 @@ const points = [
   {
     icon: "lucide:key-round",
     title: "Bring your own model",
-    desc: "Any OpenAI-compatible endpoint — OpenAI, Gemini, Ollama, llama.cpp. Your key lives in the OS keychain.",
+    desc: "Any OpenAI-compatible endpoint: OpenAI, Gemini, Ollama, llama.cpp. Your key lives in the OS keychain.",
   },
 ];
 ---
@@ -41,7 +41,7 @@ const points = [
       </h2>
       <p class="mt-4 text-lg text-fg-muted">
         Most editors bolt on a chatbot. MarkLite's Agent proposes real edits to your document as a
-        diff you stay in control of — nothing is written until you say so.
+        diff you stay in control of. Nothing is written until you say so.
       </p>
 
       <ul class="mt-8 space-y-5">
@@ -61,7 +61,7 @@ const points = [
 
     <!-- Live Agent inline-diff mock -->
     <div data-reveal>
-      <AppWindow label="notes.md — Agent">
+      <AppWindow label="notes.md, Agent">
         <div class="bg-ink-900 p-3 font-mono text-[13px] leading-relaxed">
           <!-- composer -->
           <div class="ai-composer-demo mb-3 flex items-center gap-2 rounded-lg border border-line bg-ink-850 px-3 py-2">

--- a/docs/src/components/AppWindow.astro
+++ b/docs/src/components/AppWindow.astro
@@ -1,7 +1,7 @@
 ---
 // Frame for product screenshots and the AI mock. The captured screenshots
 // already include MarkLite's own title bar + window controls, so this is just
-// a rounded, shadowed bezel — no duplicate (and non-native) chrome on top.
+// a rounded, shadowed bezel, no duplicate (and non-native) chrome on top.
 interface Props {
   label?: string; // accepted for caller compatibility; not rendered
   class?: string;

--- a/docs/src/components/Download.astro
+++ b/docs/src/components/Download.astro
@@ -25,8 +25,8 @@ const platforms = [
   {
     icon: "lucide:apple",
     os: "macOS",
-    note: "No prebuilt binary yet — build from source in a couple of commands.",
-    formats: "Tauri supports macOS — help us ship a build!",
+    note: "No prebuilt binary yet. Build from source in a couple of commands.",
+    formats: "Tauri supports macOS. Help us ship a build!",
     href: `${repo}#development`,
     cta: "Build from source",
     primary: false,
@@ -40,10 +40,10 @@ const platforms = [
     <div class="mx-auto max-w-2xl text-center" data-reveal>
       <p class="eyebrow justify-center">Download</p>
       <h2 class="mt-3 text-4xl font-extrabold tracking-tight md:text-5xl">
-        Get MarkLite — it's free
+        Get MarkLite, it's free
       </h2>
       <p class="mt-4 text-lg text-fg-muted">
-        Free for personal use. Grab the latest release for your platform — no account required.
+        Free for personal use. Grab the latest release for your platform. No account required.
       </p>
     </div>
 

--- a/docs/src/components/EditorShowcase.astro
+++ b/docs/src/components/EditorShowcase.astro
@@ -20,13 +20,13 @@ const chips = [
         Type Markdown. Watch it <span class="text-gradient">come alive.</span>
       </h2>
       <p class="mt-4 text-lg text-fg-muted">
-        Equations, chemical reactions, diagrams, and code — all rendered live in the preview as you
+        Equations, chemical reactions, diagrams, and code: all rendered live in the preview as you
         write, with the raw source one keystroke away.
       </p>
     </div>
 
     <div class="relative mx-auto mt-14 max-w-5xl" data-reveal>
-      <AppWindow label=".shots / Getting Started.md — Split view">
+      <AppWindow label=".shots / Getting Started.md, Split view">
         <Image
           src={showcase}
           alt="MarkLite preview rendering an integral equation, a balanced chemical reaction, a Mermaid flowchart, and a syntax-highlighted TypeScript code block"

--- a/docs/src/components/Faq.astro
+++ b/docs/src/components/Faq.astro
@@ -4,15 +4,15 @@ import { Icon } from "astro-icon/components";
 const faqs = [
   {
     q: "Is MarkLite really free?",
-    a: "Yes — free for personal use, with no account and no telemetry. It's source-available; commercial use requires written permission from the author.",
+    a: "Yes. Free for personal use, with no account and no telemetry. It's source-available; commercial use requires written permission from the author.",
   },
   {
     q: "Which platforms are supported?",
-    a: "Prebuilt binaries ship for Windows (10/11) and Linux (.deb, .rpm, .AppImage). macOS isn't prebuilt yet, but Tauri supports it — you can build from source in a couple of commands.",
+    a: "Prebuilt binaries ship for Windows (10/11) and Linux (.deb, .rpm, .AppImage). macOS isn't prebuilt yet, but Tauri supports it, you can build from source in a couple of commands.",
   },
   {
     q: "Does it send my notes anywhere?",
-    a: "No. MarkLite is a native app that works fully offline and your files stay on your machine. The only network calls are ones you opt into — like connecting an AI provider.",
+    a: "No. MarkLite is a native app that works fully offline and your files stay on your machine. The only network calls are ones you opt into, like connecting an AI provider.",
   },
   {
     q: "Do I need an API key to use the AI features?",
@@ -20,7 +20,7 @@ const faqs = [
   },
   {
     q: "What Markdown features does it support?",
-    a: "GitHub Flavored Markdown, KaTeX math, mhchem chemistry, Mermaid diagrams, syntax-highlighted code, task lists, tables, wikilinks, slash commands, and frontmatter — rendered live as you type.",
+    a: "GitHub Flavored Markdown, KaTeX math, mhchem chemistry, Mermaid diagrams, syntax-highlighted code, task lists, tables, wikilinks, slash commands, and frontmatter, all rendered live as you type.",
   },
   {
     q: "How is it so small and fast?",

--- a/docs/src/components/Features.astro
+++ b/docs/src/components/Features.astro
@@ -4,8 +4,8 @@ import { Icon } from "astro-icon/components";
 const features = [
   {
     icon: "lucide:sparkles",
-    title: "AI assistant — Ask & Agent",
-    desc: "Chat about your document, or let Agent mode propose edits as an inline diff you accept or reject — per change. Bring your own model: OpenAI, Gemini, Ollama, llama.cpp.",
+    title: "AI assistant: Ask & Agent",
+    desc: "Chat about your document, or let Agent mode propose edits as an inline diff you accept or reject, per change. Bring your own model: OpenAI, Gemini, Ollama, llama.cpp.",
     span: true,
     accent: "cyan",
   },
@@ -17,7 +17,7 @@ const features = [
   {
     icon: "lucide:sigma",
     title: "Math & chemistry",
-    desc: "KaTeX for inline and block math, plus mhchem for equations, ions, and isotopes — rare in a lightweight editor.",
+    desc: "KaTeX for inline and block math, plus mhchem for equations, ions, and isotopes, rare in a lightweight editor.",
   },
   {
     icon: "lucide:workflow",
@@ -27,7 +27,7 @@ const features = [
   {
     icon: "lucide:slash",
     title: "Slash commands",
-    desc: "Type / for headings, lists, tables, math, callouts, and more — no syntax to memorize.",
+    desc: "Type / for headings, lists, tables, math, callouts, and more. No syntax to memorize.",
   },
   {
     icon: "lucide:link",
@@ -47,7 +47,7 @@ const features = [
   {
     icon: "lucide:zap",
     title: "Native & private",
-    desc: "Built with Tauri + Rust — small, fast, offline. No accounts, no tracking, files stay local.",
+    desc: "Built with Tauri + Rust: small, fast, offline. No accounts, no tracking, files stay local.",
   },
 ];
 ---
@@ -60,7 +60,7 @@ const features = [
         Everything you need, nothing you don't
       </h2>
       <p class="mt-4 text-lg text-fg-muted">
-        A focused writing surface with the power features pros expect — and a few you won't find
+        A focused writing surface with the power features pros expect, and a few you won't find
         elsewhere.
       </p>
     </div>

--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -26,7 +26,7 @@ const releases = "https://github.com/Razee4315/MarkLite/releases/latest";
     </a>
 
     <h1
-      class="mx-auto max-w-4xl text-balance text-5xl font-extrabold leading-[1.04] tracking-tight md:text-7xl"
+      class="mx-auto max-w-4xl text-balance pb-1 text-5xl font-extrabold leading-[1.2] tracking-tight md:text-7xl"
       data-reveal
     >
       The markdown editor that
@@ -35,7 +35,7 @@ const releases = "https://github.com/Razee4315/MarkLite/releases/latest";
 
     <p class="mx-auto mt-6 max-w-2xl text-balance text-lg text-fg-muted md:text-xl" data-reveal>
       MarkLite renders your Markdown beautifully while keeping the raw text one keystroke away.
-      Live preview, split view, math, diagrams, and an optional AI assistant — in a fast native
+      Live preview, split view, math, diagrams, and an optional AI assistant, in a fast native
       app, not a browser tab.
     </p>
 

--- a/docs/src/components/OpenSource.astro
+++ b/docs/src/components/OpenSource.astro
@@ -13,7 +13,7 @@ const tech = ["Tauri", "Rust", "React", "TypeScript", "Vite", "CodeMirror 6"];
           <Icon name="lucide:git-fork" class="h-4 w-4" /> Open source
         </p>
         <h2 class="mt-4 text-3xl font-extrabold tracking-tight md:text-4xl">
-          Built in the open — contributions welcome
+          Built in the open, contributions welcome
         </h2>
         <p class="mx-auto mt-4 max-w-xl text-lg text-fg-muted">
           MarkLite is source-available and free for personal use. Star it, file an issue, or pick

--- a/docs/src/components/PowerFeatures.astro
+++ b/docs/src/components/PowerFeatures.astro
@@ -10,7 +10,7 @@ const shots = [
     img: commandPalette,
     icon: "lucide:command",
     title: "Command palette",
-    desc: "Ctrl+P to run any command, jump to a file or heading, and toggle modes — without leaving the keyboard.",
+    desc: "Ctrl+P to run any command, jump to a file or heading, and toggle modes, without leaving the keyboard.",
     alt: "MarkLite command palette listing New file, Open, Save, Reveal in folder, and mode-switch commands",
   },
   {
@@ -29,7 +29,7 @@ const shots = [
       <p class="eyebrow justify-center">Power-user touches</p>
       <h2 class="mt-3 text-4xl font-extrabold tracking-tight md:text-5xl">Fast hands stay fast</h2>
       <p class="mt-4 text-lg text-fg-muted">
-        The small things that add up — a keyboard-first command palette and a folder-aware file
+        The small things that add up: a keyboard-first command palette and a folder-aware file
         explorer.
       </p>
     </div>
@@ -37,7 +37,7 @@ const shots = [
     <div class="mt-12 grid gap-6 md:grid-cols-2">
       {shots.map((s) => (
         <figure data-reveal>
-          <AppWindow label={`${s.title} — MarkLite`}>
+          <AppWindow label={`${s.title}, MarkLite`}>
             <Image
               src={s.img}
               alt={s.alt}

--- a/docs/src/components/Themes.astro
+++ b/docs/src/components/Themes.astro
@@ -22,7 +22,7 @@ const themes = [
         Four themes. Five fonts. Your call.
       </h2>
       <p class="mt-4 text-lg text-fg-muted">
-        Dark, Light, Paper, and a pixel-accurate GitHub theme — plus focus and typewriter modes for
+        Dark, Light, Paper, and a pixel-accurate GitHub theme, plus focus and typewriter modes for
         when you really need to think.
       </p>
     </div>
@@ -45,7 +45,7 @@ const themes = [
     </div>
 
     <div class="relative mx-auto mt-8 max-w-5xl" data-reveal>
-      <AppWindow label="Getting Started.md — Reader">
+      <AppWindow label="Getting Started.md, Reader">
         <div class="relative aspect-[1920/1030] w-full bg-ink-900">
           {themes.map((t, i) => (
             <Image

--- a/docs/src/components/TrustBar.astro
+++ b/docs/src/components/TrustBar.astro
@@ -3,7 +3,7 @@ import { Icon } from "astro-icon/components";
 const items = [
   { icon: "lucide:wifi-off", label: "Works fully offline" },
   { icon: "lucide:eye-off", label: "No telemetry, ever" },
-  { icon: "lucide:cpu", label: "Native — Tauri + Rust" },
+  { icon: "lucide:cpu", label: "Native, Tauri + Rust" },
   { icon: "lucide:git-fork", label: "Open source" },
   { icon: "lucide:bot", label: "Bring your own AI model" },
 ];

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -9,7 +9,7 @@ interface Props {
 }
 
 const {
-  title = "MarkLite — The minimal markdown editor that stays out of your way",
+  title = "MarkLite: The minimal markdown editor that stays out of your way",
   description = "A fast, native, open-source Markdown editor with live preview, split view, KaTeX math, chemistry equations, Mermaid diagrams, slash commands, and an optional AI assistant. Free for Windows & Linux. Built with Tauri + Rust + React.",
 } = Astro.props;
 
@@ -47,7 +47,7 @@ const version = "1.0.0";
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="MarkLite" />
-    <meta property="og:title" content="MarkLite — Minimal Open-Source Markdown Editor" />
+    <meta property="og:title" content="MarkLite: Minimal Open-Source Markdown Editor" />
     <meta property="og:description" content={description} />
     <meta property="og:url" content={canonical} />
     <meta property="og:image" content={ogImage} />
@@ -56,11 +56,11 @@ const version = "1.0.0";
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="MarkLite — Minimal Open-Source Markdown Editor" />
+    <meta name="twitter:title" content="MarkLite: Minimal Open-Source Markdown Editor" />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
 
-    <!-- Structured data — only facts we can stand behind, no fabricated ratings. -->
+    <!-- Structured data, only facts we can stand behind, no fabricated ratings. -->
     <script type="application/ld+json" set:html={JSON.stringify({
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -1,12 +1,12 @@
 @import "tailwindcss";
 
 /* ============================================================
-   MarkLite — landing page design system
+   MarkLite, landing page design system
    Dark, editorial, with the brand's orange (#FF8C00) + cyan (#00E5FF).
    ============================================================ */
 
 @theme {
-  /* Ink / surfaces — a warm near-black, layered */
+  /* Ink / surfaces, a warm near-black, layered */
   --color-ink-950: #060608;
   --color-ink-900: #0a0a0d;
   --color-ink-850: #0f0f14;
@@ -87,7 +87,7 @@ canvas {
   max-width: 100%;
 }
 
-/* Custom scrollbar — matches the dark surface */
+/* Custom scrollbar, matches the dark surface */
 ::-webkit-scrollbar {
   width: 12px;
   height: 12px;
@@ -175,7 +175,7 @@ canvas {
   mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, #000 30%, transparent 75%);
 }
 
-/* Cursor-reactive glow in the hero — positioned by motion.ts on pointer move */
+/* Cursor-reactive glow in the hero, positioned by motion.ts on pointer move */
 .hero-spot {
   position: absolute;
   top: 0;
@@ -314,7 +314,7 @@ canvas {
 
 /* ===== Scroll-reveal (driven by GSAP) =====
    Only hide when JS is confirmed (the .js class is set synchronously in <head>
-   before first paint). No-JS users — and search crawlers — get visible content. */
+   before first paint). No-JS users, and search crawlers, get visible content. */
 .js [data-reveal] {
   opacity: 0;
   transform: translateY(24px);


### PR DESCRIPTION
## Summary
- **Hero text clipping fixed.** Bumped the headline line-height (1.04 → 1.2) so the gradient text-fill no longer clips the italic descenders of "stays out of your way".
- **Em dashes removed.** Every em dash in the site copy is now a comma, colon, or period.
- **Google Search Console verification.** Added the verification HTML at the site root, served at `https://razee4315.github.io/MarkLite/google0d979f7b74e3dae0.html`.

## Test plan
- `cd docs && bun run build` passes; verification file present in `dist/`
- Verified in preview: headline descenders render fully, no em dashes in rendered copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
