### PR TITLE
ci: add macOS release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,8 @@ jobs:
             args: ''
           - platform: ubuntu-24.04
             args: ''
+          - platform: macos-latest
+            args: ''
 
     runs-on: ${{ matrix.platform }}
 
@@ -136,6 +138,7 @@ jobs:
             ### Installation
             - **Windows:** `.msi` (recommended) or `.exe` (NSIS installer)
             - **Linux:** `.deb` or `.AppImage`
+            - **macOS:** `.dmg`
 
             See the [CHANGELOG](https://github.com/Razee4315/MarkLite/blob/main/CHANGELOG.md) for details.
           args: ${{ matrix.args }}


### PR DESCRIPTION
## Summary

closes #47 

Add macOS builds to the release workflow by including `macos-latest` in the release matrix. This allows Tauri to generate and upload macOS release artifacts alongside the existing Windows and Linux builds.

## Changes

* Added `macos-latest` to the release workflow matrix in `.github/workflows/release.yml`
* Updated release notes to include macOS installation artifacts (`.dmg`)

## Expected Result

Future releases will include a macOS `.dmg` asset, enabling macOS users to download and run MarkLite without building from source.

