### PR TITLE
Hero headline: clean sans gradient (drop serif italic)

### DIFF
--- a/docs/src/components/Hero.astro
+++ b/docs/src/components/Hero.astro
@@ -30,7 +30,7 @@ const releases = "https://github.com/Razee4315/MarkLite/releases/latest";
       data-reveal
     >
       The markdown editor that
-      <span class="font-serif-display italic text-gradient text-gradient-flow">stays out of your way</span>
+      <span class="text-gradient text-gradient-flow">stays out of your way</span>
     </h1>
 
     <p class="mx-auto mt-6 max-w-2xl text-balance text-lg text-fg-muted md:text-xl" data-reveal>

--- a/docs/src/layouts/Base.astro
+++ b/docs/src/layouts/Base.astro
@@ -1,6 +1,5 @@
 ---
 import "@fontsource-variable/inter";
-import "@fontsource/instrument-serif";
 import "../styles/global.css";
 
 interface Props {


### PR DESCRIPTION
Renders "stays out of your way" in the same Inter weight as the rest of the headline (keeping the animated gradient) instead of the Instrument Serif italic. Removes the disliked serif look and fixes the italic "y" swash that was clipping at the right edge. Also drops the now-unused serif font import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
