### PR TITLE
feat: icon polish round, tour in Settings, big-icon Features, uncropped scenes

### DIFF
--- a/docs/src/components/Download.astro
+++ b/docs/src/components/Download.astro
@@ -49,15 +49,16 @@ const platforms = [
       </p>
     </div>
 
-    <!-- Confetti send-off: the mascot celebrating your download decision -->
-    <div class="mt-10" data-reveal>
+    <!-- Confetti send-off: the mascot celebrating your download decision.
+         Shown UNCROPPED: the scene's own paper background blends with the page. -->
+    <div class="mx-auto mt-10 max-w-3xl" data-reveal>
       <Image
         src={sceneCelebration}
         alt="The MarkLite mascot jumping with confetti and paper planes"
         widths={[760, 1100, 1600]}
-        sizes="(max-width: 1024px) 100vw, 1024px"
+        sizes="(max-width: 1024px) 100vw, 768px"
         loading="lazy"
-        class="aspect-[3/1] w-full rounded-2xl border border-line object-cover"
+        class="w-full rounded-2xl border border-line"
       />
     </div>
 

--- a/docs/src/components/Features.astro
+++ b/docs/src/components/Features.astro
@@ -82,26 +82,53 @@ const rows = [
       </p>
     </div>
 
-    <div class="matrix mt-12" data-reveal>
+    <!-- Big-icon card grid: the illustrated icon set carries the section -->
+    <div class="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {rows.map((r) => (
-        <div class="matrix-row">
-          <div class="flex items-center gap-3">
+        <article class="feature-card card flex flex-col p-6" data-reveal>
+          <div class="flex items-start justify-between gap-3">
             <Image
               src={r.img}
               alt=""
               aria-hidden="true"
-              widths={[80]}
-              sizes="36px"
-              class="h-9 w-9 shrink-0 select-none object-contain"
+              widths={[128, 256]}
+              sizes="64px"
+              class="feature-icon h-16 w-16 shrink-0 select-none object-contain"
             />
-            <h3 class="font-medium tracking-tight">{r.title}</h3>
-          </div>
-          <p class="text-[15px] leading-relaxed text-fg-muted">{r.desc}</p>
-          <div class="md:text-right">
             <span class={`kbd ${r.accent === "cyan" ? "!text-cyan" : ""}`}>{r.kbd}</span>
           </div>
-        </div>
+          <h3 class="mt-4 font-semibold tracking-tight">{r.title}</h3>
+          <p class="mt-1.5 text-[15px] leading-relaxed text-fg-muted">{r.desc}</p>
+        </article>
       ))}
     </div>
   </div>
 </section>
+
+<style>
+  /* Gentle lift + icon wiggle on hover; the icons do the personality work */
+  .feature-card {
+    transition: transform 0.25s var(--ease-out-expo), box-shadow 0.25s ease, border-color 0.25s ease;
+  }
+  .feature-card:hover {
+    transform: translateY(-4px);
+    border-color: color-mix(in srgb, var(--color-brand) 35%, var(--color-line));
+    box-shadow: 0 18px 40px -22px rgba(43, 36, 32, 0.3);
+  }
+  .feature-icon {
+    transition: transform 0.25s var(--ease-out-expo);
+  }
+  .feature-card:hover .feature-icon {
+    transform: rotate(-4deg) scale(1.08);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .feature-card,
+    .feature-icon {
+      transition: none;
+    }
+    .feature-card:hover,
+    .feature-card:hover .feature-icon {
+      transform: none;
+    }
+  }
+</style>

--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -71,7 +71,7 @@ const links = [
   <!-- editor status line -->
   <div class="border-t border-line-soft bg-ink-950/70">
     <div class="mx-auto flex max-w-6xl flex-wrap items-center gap-x-4 gap-y-1 px-5 py-2.5 font-mono text-[11px] text-fg-dim">
-      <span class="rounded bg-brand/15 px-1.5 py-0.5 font-semibold text-brand-soft">NORMAL</span>
+      <span class="rounded bg-brand/15 px-1.5 py-0.5 font-semibold text-[#b96500]">NORMAL</span>
       <span>readme.md</span>
       <span class="text-fg-dim/40">·</span>
       <span>markdown</span>

--- a/docs/src/components/OpenSource.astro
+++ b/docs/src/components/OpenSource.astro
@@ -1,5 +1,7 @@
 ---
+import { Image } from "astro:assets";
 import { Icon } from "astro-icon/components";
+import iconGithubPaper from "../assets/mascot/icon-github-paper.png";
 const repo = "https://github.com/Razee4315/MarkLite";
 const tech = ["Tauri", "Rust", "React", "TypeScript", "Vite", "CodeMirror 6"];
 ---
@@ -9,6 +11,14 @@ const tech = ["Tauri", "Rust", "React", "TypeScript", "Vite", "CodeMirror 6"];
     <div class="card relative overflow-hidden p-10 md:p-14" data-reveal>
       <div class="grid-bg" style="opacity:.6"></div>
       <div class="relative z-10">
+        <Image
+          src={iconGithubPaper}
+          alt=""
+          aria-hidden="true"
+          widths={[128]}
+          sizes="64px"
+          class="mx-auto mb-4 h-16 w-16 select-none object-contain"
+        />
         <p class="mono-label justify-center">
           <span class="tok-mark">//</span> open source
         </p>
@@ -17,7 +27,7 @@ const tech = ["Tauri", "Rust", "React", "TypeScript", "Vite", "CodeMirror 6"];
         </h2>
         <p class="mx-auto mt-4 max-w-xl text-lg text-fg-muted">
           MarkLite is free and open source under Apache 2.0, for personal and commercial use alike. Star it, file an issue, or pick
-          up a <code class="rounded bg-fg/5 px-1.5 py-0.5 text-sm text-brand-soft">good first issue</code>.
+          up a <code class="rounded bg-fg/5 px-1.5 py-0.5 text-sm text-[#d97700]">good first issue</code>.
         </p>
         <div class="mt-8 flex flex-wrap justify-center gap-3">
           <a href={repo} rel="noopener" class="btn btn-primary text-base">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -537,6 +537,17 @@ function AppContent() {
     }
   }, [content, originalContent, startBlankFile]);
 
+  // "Replay the welcome tour" from Settings → About. The tour spotlights
+  // editor chrome, so make sure a buffer exists before showing it.
+  useEffect(() => {
+    const h = () => {
+      if (!hasFile) handleNewFile();
+      setShowTour(true);
+    };
+    window.addEventListener("marklite:replay-tour", h);
+    return () => window.removeEventListener("marklite:replay-tour", h);
+  }, [hasFile, handleNewFile]);
+
   // Open file dialog
   const handleOpenFile = useCallback(async () => {
     try {

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -1,5 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTheme } from '../context/ThemeContext';
+import iconExportPdf from '../assets/mascot/icon-export-pdf.png';
+import iconPaperPlane from '../assets/mascot/icon-paper-plane.png';
 
 // Heavy export deps (jsPDF pulls in ~200 kB of html2canvas; jsPDF itself is
 // another big bundle) only matter when the user actually exports. We import
@@ -107,17 +109,17 @@ export function ExportMenu({ fileName, getExportHtml, onSuccess, onError }: Expo
                     <button
                         role="menuitem"
                         onClick={() => handleExport('html')}
-                        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left hover:bg-[var(--bg-hover)] transition-colors"
+                        className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left hover:bg-[var(--bg-hover)] transition-colors"
                     >
-                        <span className="material-symbols-outlined text-[18px]">code</span>
+                        <img src={iconPaperPlane} alt="" aria-hidden="true" draggable={false} className="w-6 h-6 object-contain select-none" />
                         <span>HTML</span>
                     </button>
                     <button
                         role="menuitem"
                         onClick={() => handleExport('pdf')}
-                        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left hover:bg-[var(--bg-hover)] transition-colors"
+                        className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left hover:bg-[var(--bg-hover)] transition-colors"
                     >
-                        <span className="material-symbols-outlined text-[18px]">picture_as_pdf</span>
+                        <img src={iconExportPdf} alt="" aria-hidden="true" draggable={false} className="w-6 h-6 object-contain select-none" />
                         <span>PDF</span>
                     </button>
                 </div>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "../utils/persistence";
 import { attachFocusTrap } from "../utils/focusTrap";
 import { isValidEndpoint, runAIAction } from "../utils/aiAssist";
+import mascotWave from "../assets/mascot/mascot-wave.png";
 
 // Platform-aware AI shortcut hint (Windows/Linux: Alt+J; macOS: ⌘J). Windows
 // can't use Ctrl+J because WebView2 reserves it for its Downloads UI.
@@ -406,6 +407,24 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                 </div>
                                 <p>Built with Tauri + React + TypeScript.</p>
                                 <p>Press <kbd className="px-1 font-mono rounded border border-[var(--border)] bg-[var(--bg-input)]">?</kbd> to view all keyboard shortcuts.</p>
+
+                                {/* Replay the first-run tour. The mascot makes the row instantly
+                                    recognizable as "that welcome thing". App.tsx listens for the event. */}
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        onClose();
+                                        window.dispatchEvent(new CustomEvent("marklite:replay-tour"));
+                                    }}
+                                    className="btn-press mt-3 w-full flex items-center gap-3 px-3.5 py-3 rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--bg-secondary)] hover:bg-[var(--bg-hover)] transition-colors text-left"
+                                >
+                                    <img src={mascotWave} alt="" aria-hidden="true" draggable={false} className="w-10 h-10 object-contain select-none shrink-0" />
+                                    <span className="flex flex-col items-start min-w-0">
+                                        <span className="text-sm font-medium text-[var(--text-primary)]">Replay the welcome tour</span>
+                                        <span className="text-[11px] text-[var(--text-muted)] mt-0.5">A 30-second walkthrough of the editor, views, and shortcuts</span>
+                                    </span>
+                                    <span className="material-symbols-outlined ml-auto text-[18px] text-[var(--text-muted)]">arrow_forward</span>
+                                </button>
                             </div>
                         )}
                     </div>

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { attachFocusTrap } from "../utils/focusTrap";
+import iconKeyboard from "../assets/mascot/icon-keyboard.png";
 
 interface ShortcutCheatsheetProps {
     isOpen: boolean;
@@ -146,7 +147,7 @@ export function ShortcutCheatsheet({ isOpen, onClose }: ShortcutCheatsheetProps)
                 className="relative z-10 w-[640px] max-h-[80vh] flex flex-col bg-[var(--bg-primary)] border border-[var(--border)] rounded-[var(--radius-lg)] shadow-2xl overflow-hidden animate-fade-in"
             >
                 <div className="flex items-center gap-3 px-5 py-4 border-b border-[var(--border)]">
-                    <span className="material-symbols-outlined text-[var(--accent)]">keyboard</span>
+                    <img src={iconKeyboard} alt="" aria-hidden="true" draggable={false} className="w-8 h-8 object-contain select-none" />
                     <h2 id="cheatsheet-title" className="text-base font-semibold text-[var(--text-primary)]">Keyboard Shortcuts</h2>
                     <input
                         type="text"

--- a/src/components/StatsDialog.tsx
+++ b/src/components/StatsDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import { computeStats } from "../utils/documentStats";
 import { attachFocusTrap } from "../utils/focusTrap";
+import iconClock from "../assets/mascot/icon-clock.png";
 
 interface StatsDialogProps {
     isOpen: boolean;
@@ -61,7 +62,10 @@ export function StatsDialog({ isOpen, content, onClose }: StatsDialogProps) {
                 className="relative z-10 w-[420px] max-w-[92vw] bg-[var(--bg-primary)] border border-[var(--border)] rounded-[var(--radius-lg)] shadow-2xl overflow-hidden animate-fade-in"
             >
                 <header className="flex items-center justify-between px-5 py-3 border-b border-[var(--border)]">
-                    <h2 className="text-base font-semibold text-[var(--text-primary)]">Document statistics</h2>
+                    <div className="flex items-center gap-3">
+                        <img src={iconClock} alt="" aria-hidden="true" draggable={false} className="w-8 h-8 object-contain select-none" />
+                        <h2 className="text-base font-semibold text-[var(--text-primary)]">Document statistics</h2>
+                    </div>
                     <button
                         type="button"
                         onClick={onClose}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import iconCheckBadge from '../assets/mascot/icon-check-badge.png';
 
 export type ToastType = 'success' | 'error' | 'info';
 
@@ -31,9 +32,7 @@ export function Toast({ message, isVisible, onHide, duration = 2000, type = 'suc
 
     const iconMap = {
         success: (
-            <svg className="w-4 h-4 text-[var(--status-saved)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-            </svg>
+            <img src={iconCheckBadge} alt="" aria-hidden="true" draggable={false} className="w-5 h-5 object-contain select-none" />
         ),
         error: (
             <svg className="w-4 h-4 text-[var(--danger)]" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## What (user feedback round)

### App
- **"Replay the welcome tour" button in Settings -> About** with the waving mascot (was palette-only before); wired via a marklite:replay-tour event that creates a buffer first if none is open
- **Icon set now used inside the app**: keyboard icon in the shortcuts cheatsheet header, clock icon in document statistics, paper-plane + export icons in the Export menu, check-badge in success toasts

### Website
- **Features section rebuilt** from the ruled matrix into a 3-column card grid with the illustrated icons at 64px, hover lift + icon wiggle (reduced-motion safe). The icon set finally shows its full potential
- **Celebration scene no longer cropped**: shown at its natural ratio in a contained max-w-3xl frame (its paper background blends with the page)
- OpenSource card gets the github-paper icon
- Contrast fixes for light theme: brand-soft text deepened in OpenSource code chip and footer NORMAL badge

## Testing
tsc + vite build clean, 107/107 tests pass, Astro build clean. Screenshot-verified Features grid, Download section, and full page.