### PR TITLE
fix: OS-opened files no longer lose the race against session restore

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,7 +76,7 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
- "zbus",
+ "zbus 5.12.0",
 ]
 
 [[package]]
@@ -254,9 +265,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 dependencies = [
  "serde_core",
 ]
@@ -266,6 +277,15 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -346,7 +366,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -405,6 +425,15 @@ checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
  "toml 0.9.10+spec-1.1.0",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -469,6 +498,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +544,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -525,8 +574,8 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.12.1",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -538,8 +587,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.12.1",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -659,6 +708,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +767,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -724,7 +803,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "block2",
  "libc",
  "objc2",
@@ -1278,7 +1357,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1423,6 +1502,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"
@@ -1695,6 +1792,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,9 +1925,25 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -1872,6 +1995,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,7 +2019,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "libc",
 ]
 
@@ -1926,8 +2058,9 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "marklite"
-version = "1.0.0"
+version = "1.0.16"
 dependencies = [
+ "keyring",
  "serde",
  "serde_json",
  "tauri",
@@ -1935,6 +2068,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "thiserror 2.0.17",
  "tokio",
 ]
@@ -2039,7 +2173,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -2071,11 +2205,24 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.12.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2089,10 +2236,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2141,7 +2352,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "block2",
  "libc",
  "objc2",
@@ -2162,7 +2373,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2173,7 +2384,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -2184,7 +2395,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "dispatch2",
  "objc2",
 ]
@@ -2195,7 +2406,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -2218,7 +2429,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2230,7 +2441,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2258,7 +2469,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "block2",
  "libc",
  "objc2",
@@ -2271,7 +2482,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2292,7 +2503,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2304,7 +2515,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2315,7 +2526,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -2327,7 +2538,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -2884,7 +3095,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -3022,7 +3233,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3112,6 +3323,61 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "sha2",
+ "zbus 4.4.0",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.12.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.12.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3312,6 +3578,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3470,6 +3747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3541,9 +3824,9 @@ version = "0.34.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -3782,7 +4065,22 @@ dependencies = [
  "thiserror 2.0.17",
  "url",
  "windows",
- "zbus",
+ "zbus 5.12.0",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acba6b5ca527a96cdfcc96ae09b09ccb91ddff5e33978ca6873b96ea16bb404c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.17",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus 5.12.0",
 ]
 
 [[package]]
@@ -4137,7 +4435,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "bytes",
  "futures-util",
  "http",
@@ -4507,7 +4805,7 @@ version = "0.31.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -4519,7 +4817,7 @@ version = "0.32.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.12.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -4829,6 +5127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5169,6 +5476,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5193,6 +5510,38 @@ dependencies = [
 
 [[package]]
 name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus"
 version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b622b18155f7a93d1cd2dc8c01d2d6a44e08fb9ebb7b3f9e6ed101488bad6c91"
@@ -5211,7 +5560,7 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix",
+ "nix 0.30.1",
  "ordered-stream",
  "serde",
  "serde_repr",
@@ -5221,9 +5570,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 0.7.14",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.12.0",
+ "zbus_names 4.2.0",
+ "zvariant 5.8.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -5236,9 +5598,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.112",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.2.0",
+ "zvariant 5.8.0",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -5250,7 +5623,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "winnow 0.7.14",
- "zvariant",
+ "zvariant 5.8.0",
 ]
 
 [[package]]
@@ -5295,6 +5668,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5335,6 +5728,19 @@ checksum = "aac060176f7020d62c3bcc1cdbcec619d54f48b07ad1963a3f80ce7a0c17755f"
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be61892e4f2b1772727be11630a62664a1826b62efa43a6fe7449521cb8744c"
@@ -5344,8 +5750,21 @@ dependencies = [
  "serde",
  "url",
  "winnow 0.7.14",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.8.0",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -5358,7 +5777,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.112",
- "zvariant_utils",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,9 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"
+# Forward a double-clicked file to the running instance instead of spawning a
+# second app (and racing it for the session-restore state).
+tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,25 +4,53 @@ use commands::{read_file, save_file, get_file_info, list_directory_files, save_i
 use tauri::{Manager, Emitter};
 use std::sync::Mutex;
 
+/// File path passed on the command line (double-clicking a .md in the OS).
+/// Held until the frontend asks for it via `get_cli_file`.
+struct CliFile(Mutex<Option<String>>);
+
+/// First markdown path among the process arguments (skipping argv[0]).
+fn md_arg(args: &[String]) -> Option<String> {
+    args.iter()
+        .skip(1)
+        .find(|a| a.ends_with(".md") || a.ends_with(".markdown"))
+        .cloned()
+}
+
+/// PULL model for the OS-opened file. The old design pushed an event after a
+/// fixed 500 ms sleep, which raced the webview: on slow cold starts the event
+/// fired before the JS listener existed and was silently lost, so the
+/// last-session restore won and the app showed the previous file instead of
+/// the one the user double-clicked. Now the frontend asks for the path when
+/// it is actually ready, before deciding whether to restore the last session.
+/// `take()` so a webview reload doesn't re-open it.
+#[tauri::command]
+fn get_cli_file(state: tauri::State<CliFile>) -> Option<String> {
+    state.0.lock().unwrap().take()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // Store the CLI file path to emit after window is ready
-    let cli_file_path: Mutex<Option<String>> = Mutex::new(None);
-    
-    // Get CLI arguments early
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() > 1 {
-        let file_path = &args[1];
-        if file_path.ends_with(".md") || file_path.ends_with(".markdown") {
-            *cli_file_path.lock().unwrap() = Some(file_path.clone());
-        }
-    }
+    let cli_file = md_arg(&std::env::args().collect::<Vec<_>>());
 
     tauri::Builder::default()
+        // Must be the first plugin so it wins the instance lock race.
+        // A second launch (double-clicking another .md while MarkLite runs)
+        // forwards its argv here and exits; we surface the window and hand
+        // the path to the existing frontend listener.
+        .plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+                if let Some(path) = md_arg(&argv) {
+                    let _ = window.emit("file-open-from-cli", path);
+                }
+            }
+        }))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
-.invoke_handler(tauri::generate_handler![
+        .manage(CliFile(Mutex::new(cli_file)))
+        .invoke_handler(tauri::generate_handler![
             read_file,
             save_file,
             get_file_info,
@@ -30,28 +58,40 @@ pub fn run() {
             save_image,
             read_image_file,
             get_ai_key,
-            set_ai_key
+            set_ai_key,
+            get_cli_file
         ])
-        .setup(move |app| {
-            // Listen for window ready event
-            let file_path = cli_file_path.lock().unwrap().clone();
-            
-            if let Some(path) = file_path {
-                let app_handle = app.handle().clone();
-                
-                // Use a small delay to ensure window is fully ready
-                std::thread::spawn(move || {
-                    std::thread::sleep(std::time::Duration::from_millis(500));
-                    
-                    if let Some(window) = app_handle.get_webview_window("main") {
-                        let _ = window.emit("file-open-from-cli", path);
-                    }
-                });
-            }
-            
-            Ok(())
-        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
 
+#[cfg(test)]
+mod tests {
+    use super::md_arg;
+
+    fn v(args: &[&str]) -> Vec<String> {
+        args.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn md_arg_skips_argv0_and_finds_markdown() {
+        assert_eq!(md_arg(&v(&["marklite.exe", "C:\\notes\\a.md"])), Some("C:\\notes\\a.md".into()));
+        assert_eq!(md_arg(&v(&["marklite.exe", "C:\\notes\\b.markdown"])), Some("C:\\notes\\b.markdown".into()));
+    }
+
+    #[test]
+    fn md_arg_ignores_non_markdown_and_flags() {
+        assert_eq!(md_arg(&v(&["marklite.exe"])), None);
+        assert_eq!(md_arg(&v(&["marklite.exe", "--flag", "notes.txt"])), None);
+        // argv[0] itself never matches, even if the exe path looked odd
+        assert_eq!(md_arg(&v(&["weird.md"])), None);
+    }
+
+    #[test]
+    fn md_arg_takes_first_markdown_among_args() {
+        assert_eq!(
+            md_arg(&v(&["marklite.exe", "--verbose", "x.md", "y.md"])),
+            Some("x.md".into())
+        );
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,7 @@ import {
   setTypewriterMode,
   setWordWrap,
 } from "./utils/persistence";
+import { pickBootFile } from "./utils/boot";
 import { Tour } from "./components/Tour";
 
 interface FileData {
@@ -101,6 +102,13 @@ const AI_SHORTCUT = IS_MAC ? "⌘J" : "Alt+J";
 // Width of the right-side AI panel; the editor/preview area reserves this much
 // padding-right when it's open so content reflows beside it (not under it).
 const AI_PANEL_WIDTH = 400;
+
+// The launch-file resolution must run exactly once per webview load. React
+// StrictMode double-invokes effects in dev: without this guard the second run
+// would find the CLI file already consumed (the backend take()s it) and start
+// a racing last-session restore that can overwrite the just-opened file.
+// Module-level on purpose — StrictMode remounts share module state.
+let bootResolved = false;
 
 /**
  * Returns a value that lags behind `value` by `delay` ms. Each new `value`
@@ -149,11 +157,12 @@ function AppContent() {
   const [wordWrapEnabled, setWordWrapEnabled] = useState<boolean>(() => getWordWrap());
   const [spellCheckEnabled, setSpellCheckEnabled] = useState<boolean>(() => getSpellCheck());
   const [cursorPosition, setCursorPosition] = useState({ line: 1, col: 1 });
-  // True only while the launch-time "restore last file" is still resolving. Lets
-  // us show a neutral splash instead of flashing the WelcomeScreen for a frame
-  // before the restored editor mounts (the "looks broken, then the file appears"
-  // flicker). Starts false when there's nothing to restore.
-  const [booting, setBooting] = useState<boolean>(() => !!getLastFile());
+  // True while the launch-time file resolution (OS-opened CLI file, then
+  // last-session restore) is still in flight. Shows a neutral splash instead
+  // of flashing the WelcomeScreen for a frame. Starts true unconditionally:
+  // whether a CLI file exists is only known after asking the backend, and the
+  // no-file case resolves in a couple of milliseconds anyway.
+  const [booting, setBooting] = useState<boolean>(true);
   // Editor selection range. Collapsed (start === end) means no selection;
   // when start < end we surface a "N words selected" chip in the status bar.
   const [selectionRange, setSelectionRange] = useState<{ start: number; end: number }>({ start: 0, end: 0 });
@@ -355,36 +364,58 @@ function AppContent() {
   }, []);
 
   useEffect(() => {
-    // Restore last opened file once on app launch
-    const last = getLastFile();
-    if (last) {
-      // Fire-and-forget; failures are mostly silent (file may have been moved
-      // / deleted), but we DO surface a toast for the new TooLarge case so a
-      // user who suddenly can't reopen yesterday's file isn't left guessing.
-      invoke<FileData>("read_file", { path: last })
-        .then((fileData) => {
-          setFilePath(fileData.path);
-          setFileName(fileData.name);
-          setContent(fileData.content);
-          setOriginalContent(fileData.content);
-          setFileSize(fileData.size);
-          // Bump the recents entry's timestamp to "now" so it sorts as
-          // most-recent. Previously the restored file kept the stale openedAt
-          // from whenever it was originally opened, which made the welcome
-          // screen show "3d ago" for the file you'd just been editing.
-          addRecentFile(fileData.path, fileData.name);
-        })
-        .catch((err) => {
+    // Resolve the launch file once on app start. PULL model: ask the backend
+    // for an OS-opened file (double-clicked .md → CLI arg) when WE are ready,
+    // instead of the backend pushing an event after an arbitrary delay. The
+    // old push design raced the webview: on slow cold starts the event fired
+    // before the listener existed and was lost, so the last-session restore
+    // won and the app reopened the previous file instead of the clicked one.
+    if (bootResolved) return;
+    bootResolved = true;
+    (async () => {
+      let cliFile: string | null = null;
+      try {
+        cliFile = await invoke<string | null>("get_cli_file");
+      } catch {
+        // Browser dev mode / older backend without the command — restore only.
+      }
+
+      const target = pickBootFile(cliFile, getLastFile());
+      if (!target.path) {
+        setBooting(false);
+        return;
+      }
+
+      try {
+        const fileData = await invoke<FileData>("read_file", { path: target.path });
+        setFilePath(fileData.path);
+        setFileName(fileData.name);
+        setContent(fileData.content);
+        setOriginalContent(fileData.content);
+        setFileSize(fileData.size);
+        // Bump the recents entry's timestamp to "now" so it sorts as
+        // most-recent, and persist as the session file so the next plain
+        // launch restores what the user actually had open.
+        addRecentFile(fileData.path, fileData.name);
+        setLastFile(fileData.path);
+      } catch (err) {
+        const msg = typeof err === "string" ? err : (err as { message?: string })?.message || "";
+        if (target.source === "cli") {
+          // The user explicitly asked for this file — always tell them why
+          // it didn't open (moved/deleted/too large).
+          showToast(`Could not open file: ${msg || target.path}`, "error");
+        } else {
+          // Stale session file (moved / deleted) — fail quietly like before,
+          // except the TooLarge case, which deserves an explanation.
           setLastFile(null);
-          const msg = typeof err === "string" ? err : (err as { message?: string })?.message || "";
           if (/too large/i.test(msg)) {
             showToast(`Could not restore last file: ${msg}`, "error");
           }
-        })
-        .finally(() => setBooting(false));
-    } else {
-      setBooting(false);
-    }
+        }
+      } finally {
+        setBooting(false);
+      }
+    })();
     // Run only once on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -609,7 +640,10 @@ function AppContent() {
     }
   }, [filePath, content, showToast, handleSaveAs]);
 
-  // Listen for file open from CLI (when app is opened with a file by double-click)
+  // Runtime file-open forwards. Cold-start CLI files are handled by the pull
+  // in the boot effect above; this event now arrives only from the
+  // single-instance plugin, when the user double-clicks another .md while
+  // MarkLite is already running and the second launch hands us its path.
   useEffect(() => {
     let mounted = true;
     let unlisten: (() => void) | undefined;

--- a/src/utils/boot.test.ts
+++ b/src/utils/boot.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { pickBootFile } from "./boot";
+
+describe("pickBootFile", () => {
+    // Regression: a double-clicked file must beat the session restore.
+    // Before the fix the app could reopen the previous session's file even
+    // though the user launched it by double-clicking a different one.
+    it("prefers the OS-opened (CLI) file over the last-session file", () => {
+        expect(pickBootFile("C:\\notes\\clicked.md", "C:\\notes\\old.md")).toEqual({
+            path: "C:\\notes\\clicked.md",
+            source: "cli",
+        });
+    });
+
+    it("falls back to the last-session file when no CLI file is present", () => {
+        expect(pickBootFile(null, "C:\\notes\\old.md")).toEqual({
+            path: "C:\\notes\\old.md",
+            source: "last",
+        });
+    });
+
+    it("returns none when there is nothing to open", () => {
+        expect(pickBootFile(null, null)).toEqual({ path: null, source: "none" });
+    });
+});

--- a/src/utils/boot.ts
+++ b/src/utils/boot.ts
@@ -1,0 +1,20 @@
+/**
+ * Decides which file the app should open on launch.
+ *
+ * Priority is the whole bug fix: a file the user just double-clicked in the
+ * OS (CLI arg) must always beat the last-session restore. The old design
+ * raced a delayed backend event against the restore and sometimes lost,
+ * reopening yesterday's file instead of the one the user clicked.
+ */
+export type BootSource = "cli" | "last" | "none";
+
+export interface BootTarget {
+    path: string | null;
+    source: BootSource;
+}
+
+export function pickBootFile(cliFile: string | null, lastFile: string | null): BootTarget {
+    if (cliFile) return { path: cliFile, source: "cli" };
+    if (lastFile) return { path: lastFile, source: "last" };
+    return { path: null, source: "none" };
+}


### PR DESCRIPTION
## Bug

Double-clicking a .md file in Explorer sometimes opened the PREVIOUS session file instead of the clicked one. Drag-and-drop and in-app opening were fine.

## Root cause

`lib.rs` pushed `file-open-from-cli` after a fixed 500 ms sleep. On slow cold starts the webview listener was not registered yet, the event was lost (Tauri does not queue events for late listeners), and the `lastFile` session-restore in `App.tsx` won. Even when the event landed, the restore read raced it and could overwrite the CLI file. There was also no single-instance handling, so a double-click while running spawned a second process.

## Fix

- **Pull model**: new `get_cli_file` command; the boot effect asks for the OS-opened file when the frontend is actually ready and gives it priority over the restore (`pickBootFile`)
- **`tauri-plugin-single-instance`**: a second launch forwards its path to the running window (reusing the existing `file-open-from-cli` listener), unminimizes and focuses it
- **StrictMode guard**: module-level once-flag on the boot effect; dev double-invoke would otherwise consume the CLI file on run 1 and start a racing restore on run 2 (caught this live during verification)

## Verification (live, debug build)

1. Opened file-b, closed app (seeds lastFile=B)
2. Launched exe with file-a -> **file-a opens** (old behavior: sometimes file-b)
3. While running, launched again with file-b -> **same window swaps to file-b, process count stays 1**

Screenshots in the investigation record. Regression tests: `pickBootFile` priority (vitest, 3 tests) + `md_arg` parsing (cargo, 3 tests). Full suites green: 110 vitest, 9 cargo, tsc + vite build clean.