### PR TITLE
fix: welcome mascot no longer jumps, blinks only on hover

### DIFF
--- a/src/components/MascotIdle.tsx
+++ b/src/components/MascotIdle.tsx
@@ -1,87 +1,29 @@
-import { useEffect, useRef, useState } from "react";
-import mascotWave from "../assets/mascot/mascot-wave.png";
+import { useState } from "react";
 import blinkOpen from "../assets/mascot/mascot-blink-open.png";
 import blinkClosed from "../assets/mascot/mascot-blink-closed.png";
-import bounceUp from "../assets/mascot/mascot-bounce-up.png";
-import bounceMid from "../assets/mascot/mascot-bounce-mid.png";
-import bounceDown from "../assets/mascot/mascot-bounce-down.png";
 
 interface MascotIdleProps {
     className?: string;
 }
 
-/** [frame, duration ms] pairs for the hover bounce. */
-const BOUNCE: Array<[string, number]> = [
-    [bounceDown, 110],
-    [bounceUp, 150],
-    [bounceMid, 110],
-    [bounceDown, 90],
-    [bounceMid, 110],
-];
-
 /**
- * The living welcome mascot: waves on mount, settles into an idle loop with
- * occasional blinks, and does a squash-and-stretch bounce on hover.
- * Pure frame swaps on a single <img>, no JS animation loop while idle.
- * Honors prefers-reduced-motion by staying on the static wave.
+ * The welcome mascot. Completely still, with one micro-interaction: its eyes
+ * close while hovered. An earlier version waved on mount, blinked on a timer,
+ * and did a squash-and-stretch bounce on hover, but the pose frames have
+ * slightly different proportions, so every swap read as a glitchy jump
+ * instead of an animation. The two same-pose blink frames are the only swap
+ * that is pixel-stable, so that's all that remains.
  */
 export function MascotIdle({ className }: MascotIdleProps) {
-    const [src, setSrc] = useState<string>(mascotWave);
-    const timers = useRef<number[]>([]);
-    const bouncing = useRef(false);
-    const reducedMotion = useRef(
-        typeof window !== "undefined" &&
-        window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
-    );
-
-    const later = (fn: () => void, ms: number) => {
-        timers.current.push(window.setTimeout(fn, ms));
-    };
-
-    useEffect(() => {
-        if (reducedMotion.current) return;
-
-        // Wave hello for a beat, then settle into the idle blink loop.
-        const scheduleBlink = () => {
-            later(() => {
-                if (!bouncing.current) {
-                    setSrc(blinkClosed);
-                    later(() => {
-                        if (!bouncing.current) setSrc(blinkOpen);
-                    }, 140);
-                }
-                scheduleBlink();
-            }, 3200 + Math.random() * 2600);
-        };
-        later(() => {
-            setSrc(blinkOpen);
-            scheduleBlink();
-        }, 2000);
-
-        const t = timers.current;
-        return () => t.forEach(clearTimeout);
-    }, []);
-
-    const handleHover = () => {
-        if (reducedMotion.current || bouncing.current) return;
-        bouncing.current = true;
-        let at = 0;
-        for (const [frame, ms] of BOUNCE) {
-            later(() => setSrc(frame), at);
-            at += ms;
-        }
-        later(() => {
-            setSrc(blinkOpen);
-            bouncing.current = false;
-        }, at);
-    };
+    const [hovered, setHovered] = useState(false);
 
     return (
         <img
-            src={src}
+            src={hovered ? blinkClosed : blinkOpen}
             alt="Paperling mascot"
             draggable={false}
-            onMouseEnter={handleHover}
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
             className={`object-contain select-none ${className ?? ""}`}
         />
     );


### PR DESCRIPTION
User feedback: the welcome mascot looked like it was glitch-jumping. Root cause: the wave/bounce pose frames have slightly different proportions, so frame swaps read as jumps rather than animation.

Removed the mount wave, the timed idle blink, and the hover bounce. The mascot is now perfectly still with one micro-interaction: eyes close while hovered (the blink pair is the only pixel-stable frame swap).

Browser-verified: zero frame changes over 6s idle, closed on hover, open on leave. Build + 121 tests green.