### PR TITLE
Fix: Linux title bar dragging and Markdown association

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2592,7 +2592,7 @@ dependencies = [
 
 [[package]]
 name = "paperling"
-version = "1.0.18"
+version = "1.0.20"
 dependencies = [
  "keyring",
  "serde",

--- a/src-tauri/linux-desktop.template
+++ b/src-tauri/linux-desktop.template
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Categories=Utility;TextEditor;
+Comment={{comment}}
+Exec={{exec}} %f
+StartupWMClass=paperling
+Icon={{icon}}
+Name={{name}}
+Terminal=false
+Type=Application
+MimeType=text/markdown;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,6 +41,14 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "linux": {
+      "deb": {
+        "desktopTemplate": "linux-desktop.template"
+      },
+      "rpm": {
+        "desktopTemplate": "linux-desktop.template"
+      }
+    },
     "fileAssociations": [
       {
         "ext": [
@@ -48,6 +56,7 @@
           "markdown"
         ],
         "name": "Markdown Document",
+        "mimeType": "text/markdown",
         "description": "Markdown file",
         "role": "Editor"
       }

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,4 +1,5 @@
 import { useState, lazy, Suspense, memo } from "react";
+import type { MouseEvent } from "react";
 import { Window } from "@tauri-apps/api/window";
 import { SettingsMenu } from "./SettingsMenu";
 import { ExportMenu } from "./ExportMenu";
@@ -42,6 +43,25 @@ function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, onSa
             await appWindow.toggleMaximize();
         } catch (e) {
             console.error("Maximize failed:", e);
+        }
+    };
+
+    const handleTitleBarMouseDown = async (event: MouseEvent<HTMLElement>) => {
+        const target = event.target;
+
+        if (
+            event.button !== 0 ||
+            (target instanceof Element &&
+                target.closest("button, a, input, textarea, select, [role='button'], [role='menu'], [role='menuitem']"))
+        ) {
+            return;
+        }
+
+        try {
+            const appWindow = Window.getCurrent();
+            await appWindow.startDragging();
+        } catch (e) {
+            console.error("Window drag failed:", e);
         }
     };
 
@@ -99,7 +119,10 @@ function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, onSa
                     />
                 </Suspense>
             )}
-            <header className="h-12 shrink-0 flex items-center justify-between px-4 bg-[var(--bg-titlebar)] border-b border-[var(--border)] no-select drag-region transition-colors">
+            <header
+                onMouseDown={handleTitleBarMouseDown}
+                className="h-12 shrink-0 flex items-center justify-between px-4 bg-[var(--bg-titlebar)] border-b border-[var(--border)] no-select drag-region transition-colors"
+            >
                 {/* Left: Icon & Title */}
                 <div className="flex items-center gap-3 no-drag">
                     <div className="flex items-center justify-center w-5 h-5">

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -59,7 +59,13 @@ function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, onSa
 
         try {
             const appWindow = Window.getCurrent();
-            await appWindow.startDragging();
+            // Native title bars maximize on double-click; event.detail
+            // counts clicks within the double-click interval.
+            if (event.detail === 2) {
+                await appWindow.toggleMaximize();
+            } else {
+                await appWindow.startDragging();
+            }
         } catch (e) {
             console.error("Window drag failed:", e);
         }


### PR DESCRIPTION
Use Tauri's native drag API for the custom title bar

Register text/markdown MIME metadata for Linux packages

Add deb/rpm desktop entry template with file-opening support

In Simple words, the app window is now draggable and can also now be set as the default app for opening md files. (In linux)