### PR TITLE
feat: auto-updater popup, AI enable/disable setting, shimmery AI button icon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,13 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Updater artifact signing — the matching pubkey lives in
+          # tauri.conf.json. Without these the build still succeeds but
+          # latest.json gets no signatures and in-app updates won't install.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          # The signing key was generated without a password; GitHub refuses
+          # empty-valued secrets, so the empty password is set inline here.
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
         with:
           tauriScript: bun run tauri
           tagName: v__VERSION__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Auto-updater.** Paperling now checks GitHub Releases on launch and shows a
+  popup when a newer version is available, with "Update now" (download with
+  progress, install, restart), "Skip this version" (remembered per version),
+  and "Later". Update packages are signed; the updater verifies the signature
+  before installing.
+- **AI on/off switch.** A new "Enable AI" toggle in Settings → AI (on by
+  default). Turning it off hides every AI surface: the title-bar AI button,
+  the AI side panel, the formatting-toolbar sparkle, Alt+J, and the command
+  palette entry.
+- **Shimmery AI button.** The title-bar AI button now carries the familiar
+  sparkle icon with a subtle shimmer animation.
 - **Visual table editor.** A floating toolbar appears when the caret is inside a
   Markdown table, with buttons to insert or delete rows and columns, set
   per-column alignment, and tidy (re-align) the layout. Built on a pure,

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,8 @@
         "@tauri-apps/plugin-dialog": "^2.4.2",
         "@tauri-apps/plugin-fs": "^2.4.4",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "jspdf": "^4.0.0",
         "katex": "^0.16.45",
         "material-symbols": "^0.44.6",
@@ -418,6 +420,10 @@
     "@tauri-apps/plugin-fs": ["@tauri-apps/plugin-fs@2.4.4", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-MTorXxIRmOnOPT1jZ3w96vjSuScER38ryXY88vl5F0uiKdnvTKKTtaEjTEo8uPbl4e3gnUtfsDVwC7h77GQLvQ=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-ei/yRRoCklWHImwpCcDK3VhNXx+QXM9793aQ64YxpqVF0BDuuIlXhZgiAkc15wnPVav+IbkYhmDJIv5R326Mew=="],
+
+    "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
@@ -1206,6 +1212,10 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tauri-apps/plugin-process/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
+
+    "@tauri-apps/plugin-updater/@tauri-apps/api": ["@tauri-apps/api@2.11.0", "", {}, "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA=="],
 
     "@testing-library/jest-dom/aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "@tauri-apps/plugin-dialog": "^2.4.2",
     "@tauri-apps/plugin-fs": "^2.4.4",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "jspdf": "^4.0.0",
     "katex": "^0.16.45",
     "material-symbols": "^0.44.6",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -59,6 +59,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "ashpd"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +756,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1032,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1303,8 +1333,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1314,9 +1346,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1591,6 +1625,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2051,6 +2101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,6 +2163,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2481,6 +2543,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.12.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,6 +2640,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2592,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "paperling"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "keyring",
  "serde",
@@ -2602,7 +2690,9 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
  "thiserror 2.0.17",
  "tokio",
 ]
@@ -2959,6 +3049,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3172,16 +3317,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3191,6 +3341,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3219,6 +3370,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,6 +3409,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3870,6 +4076,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4069,6 +4286,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-single-instance"
 version = "2.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4081,6 +4308,38 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
  "zbus 5.12.0",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27cbc31740f4d507712550694749572ec0e43bdd66992db7599b89fbfd6b167b"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.17",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -4290,6 +4549,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4303,6 +4577,16 @@ dependencies = [
  "socket2",
  "tracing",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4595,6 +4879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4856,6 +5146,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webkit2gtk"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4897,6 +5197,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5476,6 +5785,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5718,6 +6037,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.112",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.12.1",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,3 +33,9 @@ tokio = { version = "1", features = ["fs"] }
 # Credential Manager, macOS Keychain, and Linux Secret Service (zbus + crypto-rust,
 # no system C libs needed at build time).
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service", "crypto-rust"] }
+
+# Auto-update from GitHub Releases (latest.json) + relaunch after install.
+# Desktop-only: the updater has no mobile implementation.
+[target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -22,6 +22,8 @@
     "dialog:default",
     "dialog:allow-open",
     "dialog:allow-save",
+    "updater:default",
+    "process:allow-restart",
     {
       "identifier": "fs:scope",
       "allow": [{ "path": "**" }]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,6 +49,17 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
+        .setup(|app| {
+            // Updater (GitHub latest.json) + process (relaunch after install)
+            // are desktop-only plugins, hence registered here behind cfg
+            // instead of in the unconditional plugin chain above.
+            #[cfg(desktop)]
+            {
+                app.handle().plugin(tauri_plugin_updater::Builder::new().build())?;
+                app.handle().plugin(tauri_plugin_process::init())?;
+            }
+            Ok(())
+        })
         .manage(CliFile(Mutex::new(cli_file)))
         .invoke_handler(tauri::generate_handler![
             read_file,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,9 +31,18 @@
       }
     }
   },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDA5RDRBQjJENTc0MUI3QzAKUldUQXQwRlhMYXZVQ1FsZUtpWlFNWEFRQ0hKSDdsY0UxSllFTGJhcVZLTkFWbm9WU0lpUWdiSXgK",
+      "endpoints": [
+        "https://github.com/Razee4315/Paperling/releases/latest/download/latest.json"
+      ]
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,10 +55,16 @@ const UnsavedChangesDialog = lazy(() =>
 const AIPanel = lazy(() =>
     import("./components/AIPanel").then((m) => ({ default: m.AIPanel }))
 );
+// Update popup — mounts on every launch, renders nothing unless a newer
+// signed release is found on GitHub (and the user hasn't skipped it).
+const UpdateDialog = lazy(() =>
+    import("./components/UpdateDialog").then((m) => ({ default: m.UpdateDialog }))
+);
 import { getRecentFiles } from "./utils/persistence";
 import {
   addRecentFile,
   getAIConfig,
+  getAIEnabled,
   initAIKey,
   getLastFile,
   getSavedViewMode,
@@ -68,6 +74,7 @@ import {
   getTourDone,
   getTypewriterMode,
   getWordWrap,
+  setAIEnabled,
   setLastFile,
   setSavedViewMode,
   setSpellCheck,
@@ -152,6 +159,7 @@ function AppContent() {
   const [showStats, setShowStats] = useState(false);
   const [splitRatio, setSplitRatioState] = useState<number>(() => getSplitRatio());
   const [aiConfig, setAiConfigState] = useState(() => getAIConfig());
+  const [aiEnabled, setAiEnabledState] = useState<boolean>(() => getAIEnabled());
   const [typewriterModeEnabled, setTypewriterModeEnabled] = useState<boolean>(() => getTypewriterMode());
   const [toolbarVisible, setToolbarVisible] = useState<boolean>(() => getToolbarEnabled());
   const [wordWrapEnabled, setWordWrapEnabled] = useState<boolean>(() => getWordWrap());
@@ -307,6 +315,7 @@ function AppContent() {
   useEffect(() => { setToolbarEnabled(toolbarVisible); }, [toolbarVisible]);
   useEffect(() => { setWordWrap(wordWrapEnabled); }, [wordWrapEnabled]);
   useEffect(() => { setSpellCheck(spellCheckEnabled); }, [spellCheckEnabled]);
+  useEffect(() => { setAIEnabled(aiEnabled); }, [aiEnabled]);
 
   // Cross-component event listeners — settings menu and command palette toggle these
   useEffect(() => {
@@ -319,7 +328,16 @@ function AppContent() {
       ["paperling:open-settings", () => setShowSettings(true)],
       // Alt+J with no selection opens the docked AI side panel. The editor's
       // ai-assist handler decides bubble (selection) vs panel (no selection).
-      ["paperling:toggle-ai-panel", () => setShowAIPanel((v) => !v)],
+      // Reads the persisted flag live (this effect mounts once) so the panel
+      // can't be opened while AI is switched off in Settings.
+      ["paperling:toggle-ai-panel", () => { if (getAIEnabled()) setShowAIPanel((v) => !v); }],
+      // Settings master switch for all AI surfaces; closing the panel here
+      // keeps it from lingering open after AI is turned off.
+      ["paperling:ai-enabled-toggle", (e) => {
+        const enabled = !!(e as CustomEvent).detail?.enabled;
+        setAiEnabledState(enabled);
+        if (!enabled) setShowAIPanel(false);
+      }],
     ];
     handlers.forEach(([k, h]) => window.addEventListener(k, h));
 
@@ -914,11 +932,12 @@ function AppContent() {
       });
     }
 
-    // === AI === only when a buffer exists. The command palette is the
-    // always-reachable entry point for AI assist (the toolbar AI button is
-    // hidden when the toolbar is off). Dispatches a window event the editor
-    // listens for; if AI isn't configured the editor shows a guiding notice.
-    if (hasFile) {
+    // === AI === only when a buffer exists and AI is enabled in Settings.
+    // The command palette is the always-reachable entry point for AI assist
+    // (the toolbar AI button is hidden when the toolbar is off). Dispatches a
+    // window event the editor listens for; if AI isn't configured the editor
+    // shows a guiding notice.
+    if (hasFile && aiEnabled) {
       items.push({
         id: "ai.assist",
         label: "AI assist on selection",
@@ -1003,7 +1022,7 @@ function AppContent() {
     handleNewFile, handleOpenFile, handleSaveFile, handleSaveAs,
     handleToggleSplit, handleToggleFileExplorer, handleToggleTOC,
     loadFile, filePath, hasFile, showToast,
-    typewriterModeEnabled, toolbarVisible,
+    typewriterModeEnabled, toolbarVisible, aiEnabled,
   ]);
 
   // Heading items are recomputed only while the palette is actually open.
@@ -1062,9 +1081,14 @@ function AppContent() {
         getExportHtml={getExportHtml}
         onExportSuccess={handleExportSuccess}
         onExportError={handleExportError}
-        onToggleAI={handleToggleAI}
+        onToggleAI={aiEnabled ? handleToggleAI : undefined}
         aiActive={showAIPanel}
       />
+
+      {/* Startup update check; invisible unless an update is actually available. */}
+      <Suspense fallback={null}>
+        <UpdateDialog />
+      </Suspense>
 
       {!hasFile ? (
         booting ? (
@@ -1193,7 +1217,7 @@ function AppContent() {
 
           {/* Right-side AI assistant panel. Reads the live document + current
               selection; chat is read-only for now (edit/agent flow is next). */}
-          {showAIPanel && (
+          {aiEnabled && showAIPanel && (
             <Suspense fallback={null}>
               <AIPanel
                 isOpen={showAIPanel}

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -31,6 +31,7 @@ import { SlashMenu, type SlashCommand } from "./SlashMenu";
 import { AIBubble } from "./AIBubble";
 import { TableToolbar } from "./TableToolbar";
 import { pasteUrlOnSelection, pasteUrlAutolink, pasteTsvAsTable, htmlToMarkdown } from "../utils/smartPaste";
+import { getAIEnabled } from "../utils/persistence";
 import { applyTableOp, findTableAt, locateCell, type Align } from "../utils/tableModel";
 import type { Scroller } from "../utils/scrollSync";
 
@@ -549,6 +550,9 @@ function CodeEditorImpl({
     // App owns the panel's open state, so we ask it to toggle via an event.
     useEffect(() => {
         const handler = () => {
+            // AI can be switched off entirely in Settings — Alt+J and the
+            // command palette dispatch this event regardless, so gate here.
+            if (!getAIEnabled()) return;
             const view = viewRef.current;
             if (!view) return;
             const sel = view.state.selection.main;
@@ -562,6 +566,16 @@ function CodeEditorImpl({
         window.addEventListener("paperling:ai-assist", handler);
         return () => window.removeEventListener("paperling:ai-assist", handler);
     }, [openAIBubble]);
+
+    // Mirror of the Settings "Enable AI" switch; drives whether the format
+    // toolbar shows its AI sparkle. Event-synced so flipping the setting
+    // updates an already-mounted editor.
+    const [aiEnabled, setAiEnabled] = useState(getAIEnabled);
+    useEffect(() => {
+        const h = (e: Event) => setAiEnabled(!!(e as CustomEvent).detail?.enabled);
+        window.addEventListener("paperling:ai-enabled-toggle", h);
+        return () => window.removeEventListener("paperling:ai-enabled-toggle", h);
+    }, []);
 
     // === Imperative helpers for child UI (toolbar, find/replace, slash, AI) ===
     const getState = useCallback((): EditorState | null => {
@@ -618,7 +632,7 @@ function CodeEditorImpl({
                 </div>
             )}
             {showToolbar && (
-                <FormatToolbar getState={getState} apply={applyResult} insert={insertAtCaret} onAIAssist={openAIBubble} />
+                <FormatToolbar getState={getState} apply={applyResult} insert={insertAtCaret} onAIAssist={aiEnabled ? openAIBubble : undefined} />
             )}
             <div className="flex-1 overflow-hidden relative">
                 <div ref={containerRef} className="absolute inset-0 [&_.cm-editor]:h-full [&_.cm-editor]:outline-none" />

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -4,6 +4,7 @@ import {
     getTypewriterMode, setTypewriterMode,
     getToolbarEnabled, setToolbarEnabled,
     getAIConfig, setAIConfig,
+    getAIEnabled, setAIEnabled,
     getWordWrap, setWordWrap,
     getSpellCheck, setSpellCheck,
 } from "../utils/persistence";
@@ -97,6 +98,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     const [spellCheck, setSpellCheckLocal] = useState(getSpellCheck);
 
     const [ai, setAi] = useState(getAIConfig);
+    const [aiEnabled, setAiEnabledLocal] = useState(getAIEnabled);
     const aiEndpointInvalid = ai.endpoint.length > 0 && !isValidEndpoint(ai.endpoint);
     const aiConfigured = !!ai.endpoint && !aiEndpointInvalid && !!ai.model;
 
@@ -317,6 +319,10 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
 
                         {section === "ai" && (
                             <>
+                                <div className="rounded-[var(--radius-lg)] border border-[var(--border)] overflow-hidden">
+                                    <ToggleRow label="Enable AI" description="Show the AI button and assistant in the editor" checked={aiEnabled}
+                                        onChange={(v) => { setAiEnabledLocal(v); setAIEnabled(v); fire("paperling:ai-enabled-toggle", v); }} />
+                                </div>
                                 <div className="flex items-start justify-between gap-3">
                                     <p className="text-sm text-[var(--text-secondary)]">
                                         Configure an OpenAI-compatible endpoint to enable inline AI assist

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -187,11 +187,12 @@ function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, onSa
                                     aria-label="AI assistant"
                                     aria-pressed={aiActive}
                                     title="AI assistant"
-                                    className={`flex items-center px-2.5 py-1 rounded-[var(--radius-md)] transition-colors text-xs font-semibold tracking-wide ${aiActive
+                                    className={`flex items-center gap-1 px-2.5 py-1 rounded-[var(--radius-md)] transition-colors text-xs font-semibold tracking-wide ${aiActive
                                         ? "bg-[var(--bg-hover)] text-[var(--accent)]"
                                         : "hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
                                         }`}
                                 >
+                                    <span className="material-symbols-outlined text-[15px] ai-shimmer" aria-hidden="true">auto_awesome</span>
                                     <span>AI</span>
                                 </button>
                             )}

--- a/src/components/UpdateDialog.tsx
+++ b/src/components/UpdateDialog.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from "react";
+import { check, type Update } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+import { getSkippedUpdateVersion, setSkippedUpdateVersion } from "../utils/persistence";
+
+type Phase = "available" | "downloading" | "installed" | "error";
+
+/**
+ * Checks GitHub Releases (latest.json) once on startup and, if a newer signed
+ * build exists, offers Update / Skip-this-version / Later. "Skip" is remembered
+ * per version; "Later" just dismisses until the next launch. The check is
+ * silent on failure — dev builds and offline machines must never see an error
+ * popup they can't act on.
+ */
+export function UpdateDialog() {
+    const [update, setUpdate] = useState<Update | null>(null);
+    const [phase, setPhase] = useState<Phase>("available");
+    // 0..1 once the content length is known; -1 = indeterminate.
+    const [progress, setProgress] = useState(0);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const upd = await check();
+                if (cancelled || !upd) return;
+                if (getSkippedUpdateVersion() === upd.version) return;
+                setUpdate(upd);
+            } catch {
+                /* offline / dev build without updater config — stay silent */
+            }
+        })();
+        return () => { cancelled = true; };
+    }, []);
+
+    if (!update) return null;
+
+    const dismiss = () => setUpdate(null);
+
+    const skipVersion = () => {
+        setSkippedUpdateVersion(update.version);
+        dismiss();
+    };
+
+    const install = async () => {
+        setPhase("downloading");
+        let total = 0;
+        let received = 0;
+        try {
+            await update.downloadAndInstall((event) => {
+                if (event.event === "Started") {
+                    total = event.data.contentLength ?? 0;
+                    setProgress(total ? 0 : -1);
+                } else if (event.event === "Progress") {
+                    received += event.data.chunkLength;
+                    if (total) setProgress(Math.min(received / total, 1));
+                } else if (event.event === "Finished") {
+                    setProgress(1);
+                }
+            });
+            setPhase("installed");
+            await relaunch();
+        } catch (e) {
+            setError(e instanceof Error ? e.message : String(e));
+            setPhase("error");
+        }
+    };
+
+    const busy = phase === "downloading" || phase === "installed";
+
+    return (
+        <div className="fixed inset-0 z-[120] flex items-center justify-center" role="dialog" aria-modal="true" aria-label="Update available">
+            <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" aria-hidden="true" />
+
+            <div className="relative z-10 w-[440px] max-w-[92vw] bg-[var(--bg-primary)] border border-[var(--border)] rounded-[var(--radius-lg)] shadow-2xl overflow-hidden animate-fade-in">
+                <div className="px-5 pt-5 pb-4">
+                    <div className="flex items-start gap-3">
+                        <div className="w-10 h-10 shrink-0 rounded-[var(--radius-md)] bg-[var(--bg-hover)] flex items-center justify-center">
+                            <span className="material-symbols-outlined text-[22px] text-[var(--accent)]">system_update_alt</span>
+                        </div>
+                        <div className="min-w-0">
+                            <h2 className="text-base font-semibold text-[var(--text-primary)]">Update available</h2>
+                            <p className="text-sm text-[var(--text-secondary)] mt-0.5">
+                                Paperling <span className="font-semibold text-[var(--text-primary)]">v{update.version}</span> is ready
+                                — you're on v{update.currentVersion}.
+                            </p>
+                        </div>
+                    </div>
+
+                    {update.body && phase === "available" && (
+                        <div className="mt-3 max-h-36 overflow-y-auto px-3 py-2 text-[12px] leading-relaxed text-[var(--text-secondary)] whitespace-pre-wrap bg-[var(--bg-secondary)] border border-[var(--border-subtle)] rounded-[var(--radius-md)]">
+                            {update.body}
+                        </div>
+                    )}
+
+                    {busy && (
+                        <div className="mt-4">
+                            <div className="h-1.5 w-full rounded-full bg-[var(--bg-hover)] overflow-hidden">
+                                <div
+                                    className={`h-full rounded-full bg-[var(--accent)] transition-[width] duration-200 ${progress < 0 ? "w-full animate-pulse" : ""}`}
+                                    style={progress >= 0 ? { width: `${Math.round(progress * 100)}%` } : undefined}
+                                />
+                            </div>
+                            <p className="mt-2 text-[12px] text-[var(--text-muted)]">
+                                {phase === "installed"
+                                    ? "Installed — restarting…"
+                                    : progress >= 0
+                                        ? `Downloading… ${Math.round(progress * 100)}%`
+                                        : "Downloading…"}
+                            </p>
+                        </div>
+                    )}
+
+                    {phase === "error" && (
+                        <p className="mt-3 text-[12px] text-[var(--danger)] break-words">
+                            Update failed: {error}
+                        </p>
+                    )}
+                </div>
+
+                <div className="flex items-center justify-end gap-2 px-5 py-3 bg-[var(--bg-secondary)] border-t border-[var(--border)]">
+                    {phase === "available" && (
+                        <>
+                            <button
+                                type="button"
+                                onClick={skipVersion}
+                                className="px-3 py-1.5 text-sm rounded-[var(--radius-md)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors"
+                            >
+                                Skip this version
+                            </button>
+                            <button
+                                type="button"
+                                onClick={dismiss}
+                                className="px-3 py-1.5 text-sm rounded-[var(--radius-md)] border border-[var(--border)] text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors"
+                            >
+                                Later
+                            </button>
+                            <button
+                                type="button"
+                                onClick={install}
+                                className="px-3.5 py-1.5 text-sm font-medium rounded-[var(--radius-md)] bg-[var(--accent)] text-[var(--accent-text)] hover:opacity-90 transition-opacity"
+                            >
+                                Update now
+                            </button>
+                        </>
+                    )}
+                    {phase === "error" && (
+                        <button
+                            type="button"
+                            onClick={dismiss}
+                            className="px-3 py-1.5 text-sm rounded-[var(--radius-md)] border border-[var(--border)] text-[var(--text-primary)] hover:bg-[var(--bg-hover)] transition-colors"
+                        >
+                            Close
+                        </button>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -561,6 +561,32 @@ select:focus-visible,
   }
 }
 
+/* Shimmering AI sparkle — a soft accent highlight sweeps across the glyph.
+   background-clip:text can't use currentColor (the fill must be transparent),
+   so the gradient mixes the muted text tone with the accent explicitly. */
+@keyframes aiShimmer {
+  0% {
+    background-position: 150% 0;
+  }
+
+  100% {
+    background-position: -50% 0;
+  }
+}
+
+.ai-shimmer {
+  background-image: linear-gradient(105deg,
+      var(--text-secondary) 35%,
+      var(--accent) 50%,
+      var(--text-secondary) 65%);
+  background-size: 220% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: aiShimmer 2.6s linear infinite;
+}
+
 /* Animation utility classes */
 .animate-fade-in {
   animation: fadeIn 0.2s ease-out forwards;

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -100,6 +100,20 @@ export const setWordWrap = (v: boolean): void => safeSet(KEY_WORD_WRAP, v);
 export const getSpellCheck = (): boolean => safeGet<boolean>(KEY_SPELL_CHECK, false);
 export const setSpellCheck = (v: boolean): void => safeSet(KEY_SPELL_CHECK, v);
 
+// Master switch for every AI surface (title-bar button, side panel, toolbar
+// sparkle, Alt+J, command palette entry). On by default; flipped in Settings.
+const KEY_AI_ENABLED = "paperling:aiEnabled";
+export const getAIEnabled = (): boolean => safeGet<boolean>(KEY_AI_ENABLED, true);
+export const setAIEnabled = (v: boolean): void => safeSet(KEY_AI_ENABLED, v);
+
+// Version the user chose to skip in the update popup, so we don't nag about
+// it on every launch. A newer release has a different version string and
+// prompts again.
+const KEY_SKIPPED_UPDATE = "paperling:skippedUpdateVersion";
+export const getSkippedUpdateVersion = (): string | null =>
+    safeGet<string | null>(KEY_SKIPPED_UPDATE, null);
+export const setSkippedUpdateVersion = (v: string): void => safeSet(KEY_SKIPPED_UPDATE, v);
+
 const KEY_AI_ENDPOINT = "paperling:aiEndpoint";
 const KEY_AI_MODEL = "paperling:aiModel";
 const KEY_AI_API_KEY = "paperling:aiApiKey";


### PR DESCRIPTION
## What this adds

### 1. Auto-updater (popup with Update / Skip / Later)
- `tauri-plugin-updater` + `tauri-plugin-process` registered on desktop; `updater:default` / `process:allow-restart` capabilities granted.
- On every launch the app checks `https://github.com/Razee4315/Paperling/releases/latest/download/latest.json`. If a newer signed build exists, a popup offers **Update now** (download with progress bar → install → relaunch), **Skip this version** (remembered per version, never nags again), or **Later** (asks next launch). Silent when offline or in dev builds.
- `createUpdaterArtifacts: true` in `tauri.conf.json`; `release.yml` now passes `TAURI_SIGNING_PRIVATE_KEY` to tauri-action so `latest.json` gets signatures.

### 2. AI on/off switch in Settings
New **Enable AI** toggle at the top of Settings → AI (on by default). When off, every AI surface disappears or goes inert: title-bar AI button, AI side panel, formatting-toolbar sparkle, Alt+J, and the command-palette entry. Persisted as `paperling:aiEnabled`.

### 3. Shimmery icon on the title-bar AI button
The AI button now shows the `auto_awesome` sparkle (same icon as everywhere else) with a subtle accent shimmer sweep (`ai-shimmer` in `index.css`).

## ⚠️ Action needed before merging (maintainer)

The updater verifies signatures against the `pubkey` in `tauri.conf.json`. For updates to work from this repo's releases you need the matching private key:

1. Get the private key file from @AleenaTahir1 (shared privately — it must never be committed), **or** generate your own pair with `bun run tauri signer generate` and replace `plugins.updater.pubkey` in `tauri.conf.json` with your new public key.
2. Add it as the `TAURI_SIGNING_PRIVATE_KEY` repository secret (paste the full file contents). The key has no password — `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` is hardcoded to `""` in the workflow since GitHub rejects empty secrets.
3. Whichever key is used, **keep it safe**: losing it means shipped builds can no longer update.

Note: users on v1.0.21 and older don't have the updater built in, so they install the next release manually once; everyone from then on updates in-app.

## Verification
- `bun run build` ✅  ·  `bun run test` 112/112 ✅  ·  `cargo check` ✅