### PR TITLE
fix: small-screen responsiveness and settings menu stacking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1262,7 +1262,9 @@ function AppContent() {
             // Reserve space on the right for the AI panel so editor/preview reflow
             // beside it instead of being covered. The panel itself is fixed at
             // right-0 (above the status bar), which keeps window controls at the edge.
-            style={{ paddingRight: showAIPanel ? AI_PANEL_WIDTH : 0, transition: "padding-right 0.15s ease" }}
+            // min() mirrors the panel's own w-[400px] max-w-[90vw] so a narrow
+            // window reserves only as much space as the panel actually takes.
+            style={{ paddingRight: showAIPanel ? `min(${AI_PANEL_WIDTH}px, 90vw)` : 0, transition: "padding-right 0.15s ease" }}
           >
             <div
               data-split-left

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -93,19 +93,19 @@ export function ExportMenu({ fileName, getExportHtml, onSuccess, onError }: Expo
                 {isExporting ? (
                     <>
                         <span className="material-symbols-outlined text-[16px] animate-spin">progress_activity</span>
-                        <span>Exporting...</span>
+                        <span className="hidden sm:inline">Exporting...</span>
                     </>
                 ) : (
                     <>
                         <span className="material-symbols-outlined text-[16px]">download</span>
-                        <span>Export</span>
+                        <span className="hidden sm:inline">Export</span>
                     </>
                 )}
             </button>
 
             {/* Simple Dropdown Menu */}
             {isOpen && !disabled && (
-                <div role="menu" aria-label="Export formats" className="absolute left-0 top-full mt-1 w-40 bg-[var(--bg-secondary)] border border-[var(--border)] rounded-lg shadow-xl overflow-hidden z-50 animate-fade-in-down">
+                <div role="menu" aria-label="Export formats" className="absolute left-0 top-full mt-1 w-40 bg-[var(--bg-secondary)] border border-[var(--border)] rounded-lg shadow-xl overflow-hidden z-[70] animate-fade-in-down">
                     <button
                         role="menuitem"
                         onClick={() => handleExport('html')}

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -14,7 +14,7 @@ export function ModeToggle({ mode, onSetMode, aiPanelOpen }: ModeToggleProps) {
     return (
         <div
             className="fixed bottom-8 z-50"
-            style={{ right: aiPanelOpen ? "calc(400px + 2rem)" : "2rem", transition: "right 0.15s ease" }}
+            style={{ right: aiPanelOpen ? "calc(min(400px, 90vw) + 2rem)" : "2rem", transition: "right 0.15s ease" }}
             role="group"
             aria-label="View mode toggle"
             data-tour="mode-toggle"

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -58,9 +58,12 @@ export function SettingsMenu() {
                 <span className="material-symbols-outlined text-[18px]">settings</span>
             </button>
 
-            {/* Dropdown Menu */}
+            {/* Dropdown Menu. z-[70] keeps it above the floating Reader/Code
+                mode toggle (z-50, mounted later in the DOM so it wins z-index
+                ties); the max-height lets the menu scroll on short screens
+                instead of running underneath it. */}
             {isOpen && (
-                <div role="menu" aria-label="Settings" className="absolute right-0 top-full mt-2 w-80 bg-[var(--bg-secondary)] border border-[var(--border)] rounded-xl shadow-2xl overflow-hidden z-50 animate-fade-in-down">
+                <div role="menu" aria-label="Settings" className="absolute right-0 top-full mt-2 w-80 bg-[var(--bg-secondary)] border border-[var(--border)] rounded-xl shadow-2xl overflow-y-auto max-h-[calc(100vh-5rem)] z-[70] animate-fade-in-down">
                     {/* Theme Section */}
                     <div className="p-4 border-b border-[var(--border)]">
                         <div className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider mb-3">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -171,8 +171,9 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                 ref={dialogRef}
                 className="relative z-10 w-[820px] max-w-[95vw] h-[600px] max-h-[90vh] flex bg-[var(--bg-primary)] border border-[var(--border)] rounded-[var(--radius-lg)] shadow-2xl overflow-hidden animate-fade-in"
             >
-                {/* Sidebar */}
-                <aside className="w-48 shrink-0 bg-[var(--bg-secondary)] border-r border-[var(--border)] flex flex-col">
+                {/* Sidebar — narrower below `sm` so the content pane keeps a
+                    usable width when the 95vw modal shrinks on small screens. */}
+                <aside className="w-36 sm:w-48 shrink-0 bg-[var(--bg-secondary)] border-r border-[var(--border)] flex flex-col">
                     <div className="px-4 py-3 border-b border-[var(--border)]">
                         <input
                             type="text"

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -97,13 +97,13 @@ function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, getE
                     <div className="flex items-center justify-center w-5 h-5">
                         <img src="/icon.svg" alt="Paperling" className="w-full h-full" />
                     </div>
-                    <div className="flex items-center gap-2 text-sm text-[var(--text-secondary)]">
+                    <div className="flex items-center gap-2 text-sm text-[var(--text-secondary)] min-w-0">
                         {parentFolder && (
                             <>
-                                <span className="opacity-60">{parentFolder} /</span>
+                                <span className="opacity-60 hidden md:inline">{parentFolder} /</span>
                             </>
                         )}
-                        <span className="text-[var(--text-primary)] font-semibold tracking-tight">
+                        <span className="text-[var(--text-primary)] font-semibold tracking-tight truncate max-w-[28vw]">
                             {fileName || "Paperling"}
                         </span>
                         {!fileName && (
@@ -126,7 +126,7 @@ function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, getE
                                     title="New File (Ctrl+N)"
                                 >
                                     <span className="material-symbols-outlined text-[16px]">edit_note</span>
-                                    <span>New</span>
+                                    <span className="hidden sm:inline">New</span>
                                 </button>
                             )}
                             <button
@@ -136,7 +136,7 @@ function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, getE
                                 title="Open File (Ctrl+O)"
                             >
                                 <span className="material-symbols-outlined text-[16px]">folder_open</span>
-                                <span>Open</span>
+                                <span className="hidden sm:inline">Open</span>
                             </button>
                             <ExportMenu
                                 fileName={fileName || 'document.md'}

--- a/src/components/UpdateDialog.tsx
+++ b/src/components/UpdateDialog.tsx
@@ -73,7 +73,7 @@ export function UpdateDialog() {
         <div className="fixed inset-0 z-[120] flex items-center justify-center" role="dialog" aria-modal="true" aria-label="Update available">
             <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" aria-hidden="true" />
 
-            <div className="relative z-10 w-[440px] max-w-[92vw] bg-[var(--bg-primary)] border border-[var(--border)] rounded-[var(--radius-lg)] shadow-2xl overflow-hidden animate-fade-in">
+            <div className="relative z-10 w-[440px] max-w-[92vw] max-h-[90vh] overflow-y-auto bg-[var(--bg-primary)] border border-[var(--border)] rounded-[var(--radius-lg)] shadow-2xl animate-fade-in">
                 <div className="px-5 pt-5 pb-4">
                     <div className="flex items-start gap-3">
                         <div className="w-10 h-10 shrink-0 rounded-[var(--radius-md)] bg-[var(--bg-hover)] flex items-center justify-center">


### PR DESCRIPTION
Follow-up to #71 — these fixes were pushed to that branch right after it was merged, so they're re-sent here on a clean branch off current `main`.

## Fixes

### Settings dropdown rendered underneath the Reader/Code mode toggle
The settings dropdown and the floating mode toggle both used `z-50`; ties are broken by DOM order, and the toggle mounts later, so on short screens the (long) dropdown slid underneath it. The dropdown is now `z-[70]` (above the toggle, still below modals at `z-[100]+`) and gets `max-h-[calc(100vh-5rem)] overflow-y-auto` so it scrolls on short screens instead of clipping. The Export dropdown had the same latent tie and was raised to match.

### Small-window responsiveness
- **Title bar:** New / Open / Export text labels collapse to icons below the `sm` breakpoint, the file name truncates with an ellipsis (`max-w-[28vw]`), and the folder breadcrumb hides below `md` — so nothing overflows at the 600px minimum window width.
- **AI panel:** the editor's reserved `padding-right` and the mode toggle's offset now clamp to `min(400px, 90vw)`, mirroring the panel's own `max-w-[90vw]`, so opening the panel in a narrow window no longer crushes the editor.
- **Settings modal:** sidebar narrows to `w-36` below `sm` so the content pane keeps usable width when the modal shrinks to `95vw`.
- **Update dialog:** scrolls (`max-h-[90vh]`) if taller than the viewport.

## Verification
- `bun run build` ✅  ·  `bun run test` 122/122 ✅