### PR TITLE
Render inline HTML in markdown + fix garbled PDF export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "@tauri-apps/plugin-opener": "^2.5.4",
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
-        "jspdf": "^4.0.0",
         "katex": "^0.16.45",
         "material-symbols": "^0.44.6",
         "mermaid": "^11.14.0",
@@ -373,6 +372,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3187,19 +3187,6 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
-    "node_modules/@types/pako": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
-      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/raf": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
-      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/react": {
       "version": "19.2.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
@@ -3417,16 +3404,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.17",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.17.tgz",
@@ -3512,26 +3489,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/canvg": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
-      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@types/raf": "^3.4.0",
-        "core-js": "^3.8.3",
-        "raf": "^3.4.1",
-        "regenerator-runtime": "^0.13.7",
-        "rgbcolor": "^1.0.1",
-        "stackblur-canvas": "^2.0.0",
-        "svg-pathdata": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -3636,18 +3593,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/core-js": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
-      "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/cose-base": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
@@ -3662,16 +3607,6 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
-    },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "utrie": "^1.0.2"
-      }
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
@@ -4482,17 +4417,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/fast-png": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
-      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/pako": "^2.0.3",
-        "iobuffer": "^5.3.2",
-        "pako": "^2.1.0"
-      }
-    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4509,12 +4433,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -4869,20 +4787,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -4929,12 +4833,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/iobuffer": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
-      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
-      "license": "MIT"
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -5090,23 +4988,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jspdf": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
-      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "fast-png": "^6.2.0",
-        "fflate": "^0.8.1"
-      },
-      "optionalDependencies": {
-        "canvg": "^3.0.11",
-        "core-js": "^3.6.0",
-        "dompurify": "^3.2.4",
-        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/katex": {
@@ -6434,12 +6315,6 @@
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
     },
-    "node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -6500,13 +6375,6 @@
       "engines": {
         "node": ">= 14.16"
       }
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6606,16 +6474,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
@@ -6696,13 +6554,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/rehype-highlight": {
       "version": "7.0.2",
@@ -6859,16 +6710,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rgbcolor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
-      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8.15"
       }
     },
     "node_modules/robust-predicates": {
@@ -7065,16 +6906,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/stackblur-canvas": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
-      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.14"
-      }
-    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -7139,16 +6970,6 @@
       "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
       "license": "MIT"
     },
-    "node_modules/svg-pathdata": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
-      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -7173,16 +6994,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/tinybench": {
@@ -7510,16 +7321,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paperling",
-  "version": "1.0.18",
+  "version": "1.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paperling",
-      "version": "1.0.18",
+      "version": "1.0.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.2",
@@ -25,10 +25,12 @@
         "@fontsource/source-serif-4": "^5.2.9",
         "@lezer/highlight": "^1.2.3",
         "@tailwindcss/vite": "^4.1.18",
-        "@tauri-apps/api": "^2",
-        "@tauri-apps/plugin-dialog": "^2.4.2",
-        "@tauri-apps/plugin-fs": "^2.4.4",
-        "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/api": "^2.11.0",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
+        "@tauri-apps/plugin-fs": "^2.5.1",
+        "@tauri-apps/plugin-opener": "^2.5.4",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "jspdf": "^4.0.0",
         "katex": "^0.16.45",
         "material-symbols": "^0.44.6",
@@ -38,13 +40,15 @@
         "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
         "rehype-katex": "^7.0.1",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "tailwindcss": "^4.1.18",
         "turndown": "^7.2.4"
       },
       "devDependencies": {
-        "@tauri-apps/cli": "^2",
+        "@tauri-apps/cli": "^2.11.2",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -2471,9 +2475,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.1.tgz",
-      "integrity": "sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -2481,9 +2485,9 @@
       }
     },
     "node_modules/@tauri-apps/cli": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.9.6.tgz",
-      "integrity": "sha512-3xDdXL5omQ3sPfBfdC8fCtDKcnyV7OqyzQgfyT5P3+zY6lcPqIYKQBvUasNvppi21RSdfhy44ttvJmftb0PCDw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.2.tgz",
+      "integrity": "sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==",
       "dev": true,
       "license": "Apache-2.0 OR MIT",
       "bin": {
@@ -2497,23 +2501,23 @@
         "url": "https://opencollective.com/tauri"
       },
       "optionalDependencies": {
-        "@tauri-apps/cli-darwin-arm64": "2.9.6",
-        "@tauri-apps/cli-darwin-x64": "2.9.6",
-        "@tauri-apps/cli-linux-arm-gnueabihf": "2.9.6",
-        "@tauri-apps/cli-linux-arm64-gnu": "2.9.6",
-        "@tauri-apps/cli-linux-arm64-musl": "2.9.6",
-        "@tauri-apps/cli-linux-riscv64-gnu": "2.9.6",
-        "@tauri-apps/cli-linux-x64-gnu": "2.9.6",
-        "@tauri-apps/cli-linux-x64-musl": "2.9.6",
-        "@tauri-apps/cli-win32-arm64-msvc": "2.9.6",
-        "@tauri-apps/cli-win32-ia32-msvc": "2.9.6",
-        "@tauri-apps/cli-win32-x64-msvc": "2.9.6"
+        "@tauri-apps/cli-darwin-arm64": "2.11.2",
+        "@tauri-apps/cli-darwin-x64": "2.11.2",
+        "@tauri-apps/cli-linux-arm-gnueabihf": "2.11.2",
+        "@tauri-apps/cli-linux-arm64-gnu": "2.11.2",
+        "@tauri-apps/cli-linux-arm64-musl": "2.11.2",
+        "@tauri-apps/cli-linux-riscv64-gnu": "2.11.2",
+        "@tauri-apps/cli-linux-x64-gnu": "2.11.2",
+        "@tauri-apps/cli-linux-x64-musl": "2.11.2",
+        "@tauri-apps/cli-win32-arm64-msvc": "2.11.2",
+        "@tauri-apps/cli-win32-ia32-msvc": "2.11.2",
+        "@tauri-apps/cli-win32-x64-msvc": "2.11.2"
       }
     },
     "node_modules/@tauri-apps/cli-darwin-arm64": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.9.6.tgz",
-      "integrity": "sha512-gf5no6N9FCk1qMrti4lfwP77JHP5haASZgVbBgpZG7BUepB3fhiLCXGUK8LvuOjP36HivXewjg72LTnPDScnQQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.2.tgz",
+      "integrity": "sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==",
       "cpu": [
         "arm64"
       ],
@@ -2528,9 +2532,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-darwin-x64": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.9.6.tgz",
-      "integrity": "sha512-oWh74WmqbERwwrwcueJyY6HYhgCksUc6NT7WKeXyrlY/FPmNgdyQAgcLuTSkhRFuQ6zh4Np1HZpOqCTpeZBDcw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.2.tgz",
+      "integrity": "sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==",
       "cpu": [
         "x64"
       ],
@@ -2545,9 +2549,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm-gnueabihf": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.9.6.tgz",
-      "integrity": "sha512-/zde3bFroFsNXOHN204DC2qUxAcAanUjVXXSdEGmhwMUZeAQalNj5cz2Qli2elsRjKN/hVbZOJj0gQ5zaYUjSg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.2.tgz",
+      "integrity": "sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==",
       "cpu": [
         "arm"
       ],
@@ -2562,9 +2566,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-gnu": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.9.6.tgz",
-      "integrity": "sha512-pvbljdhp9VOo4RnID5ywSxgBs7qiylTPlK56cTk7InR3kYSTJKYMqv/4Q/4rGo/mG8cVppesKIeBMH42fw6wjg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.2.tgz",
+      "integrity": "sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==",
       "cpu": [
         "arm64"
       ],
@@ -2579,9 +2583,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-arm64-musl": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.9.6.tgz",
-      "integrity": "sha512-02TKUndpodXBCR0oP//6dZWGYcc22Upf2eP27NvC6z0DIqvkBBFziQUcvi2n6SrwTRL0yGgQjkm9K5NIn8s6jw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.2.tgz",
+      "integrity": "sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==",
       "cpu": [
         "arm64"
       ],
@@ -2596,9 +2600,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-riscv64-gnu": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.9.6.tgz",
-      "integrity": "sha512-fmp1hnulbqzl1GkXl4aTX9fV+ubHw2LqlLH1PE3BxZ11EQk+l/TmiEongjnxF0ie4kV8DQfDNJ1KGiIdWe1GvQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.2.tgz",
+      "integrity": "sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2613,9 +2617,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-gnu": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.9.6.tgz",
-      "integrity": "sha512-vY0le8ad2KaV1PJr+jCd8fUF9VOjwwQP/uBuTJvhvKTloEwxYA/kAjKK9OpIslGA9m/zcnSo74czI6bBrm2sYA==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.2.tgz",
+      "integrity": "sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==",
       "cpu": [
         "x64"
       ],
@@ -2630,9 +2634,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-linux-x64-musl": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.9.6.tgz",
-      "integrity": "sha512-TOEuB8YCFZTWVDzsO2yW0+zGcoMiPPwcUgdnW1ODnmgfwccpnihDRoks+ABT1e3fHb1ol8QQWsHSCovb3o2ENQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.2.tgz",
+      "integrity": "sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==",
       "cpu": [
         "x64"
       ],
@@ -2647,9 +2651,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-arm64-msvc": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.9.6.tgz",
-      "integrity": "sha512-ujmDGMRc4qRLAnj8nNG26Rlz9klJ0I0jmZs2BPpmNNf0gM/rcVHhqbEkAaHPTBVIrtUdf7bGvQAD2pyIiUrBHQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.2.tgz",
+      "integrity": "sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==",
       "cpu": [
         "arm64"
       ],
@@ -2664,9 +2668,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-ia32-msvc": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.9.6.tgz",
-      "integrity": "sha512-S4pT0yAJgFX8QRCyKA1iKjZ9Q/oPjCZf66A/VlG5Yw54Nnr88J1uBpmenINbXxzyhduWrIXBaUbEY1K80ZbpMg==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.2.tgz",
+      "integrity": "sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==",
       "cpu": [
         "ia32"
       ],
@@ -2681,9 +2685,9 @@
       }
     },
     "node_modules/@tauri-apps/cli-win32-x64-msvc": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.9.6.tgz",
-      "integrity": "sha512-ldWuWSSkWbKOPjQMJoYVj9wLHcOniv7diyI5UAJ4XsBdtaFB0pKHQsqw/ItUma0VXGC7vB4E9fZjivmxur60aw==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.2.tgz",
+      "integrity": "sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==",
       "cpu": [
         "x64"
       ],
@@ -2698,30 +2702,48 @@
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.6.0.tgz",
-      "integrity": "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.8.0"
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@tauri-apps/plugin-fs": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.4.5.tgz",
-      "integrity": "sha512-dVxWWGE6VrOxC7/jlhyE+ON/Cc2REJlM35R3PJX3UvFw2XwYhLGQVAIyrehenDdKjotipjYEVc4YjOl3qq90fA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.5.1.tgz",
+      "integrity": "sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.4.tgz",
+      "integrity": "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
       }
     },
-    "node_modules/@tauri-apps/plugin-opener": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
-      "integrity": "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==",
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.8.0"
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -4649,6 +4671,70 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-raw/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -4670,6 +4756,25 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4752,6 +4857,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/html2canvas": {
@@ -6619,6 +6734,35 @@
         "katex": "^0.16.0",
         "unist-util-visit-parents": "^6.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "rehype-katex": "^7.0.1",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "tailwindcss": "^4.1.18",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
-    "jspdf": "^4.0.0",
     "katex": "^0.16.45",
     "material-symbols": "^0.44.6",
     "mermaid": "^11.14.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,8 +22,8 @@ import { useGlobalShortcuts } from "./hooks/useGlobalShortcuts";
 // === Lazy-loaded screens / dialogs ===
 //
 // Cold-start budget: the welcome screen is what the user sees first, and it
-// doesn't need react-markdown, jspdf, the settings modal, the command
-// palette, or any sidebar panel to render. Importing them eagerly meant
+// doesn't need react-markdown, the export module, the settings modal, the
+// command palette, or any sidebar panel to render. Importing them eagerly meant
 // 300 kB+ of JS had to parse before the welcome screen could paint. Each of
 // these is now its own chunk, fetched only when its surface is mounted.
 //

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -3,10 +3,9 @@ import { useTheme } from '../context/ThemeContext';
 import iconExportPdf from '../assets/mascot/icon-export-pdf.png';
 import iconPaperPlane from '../assets/mascot/icon-paper-plane.png';
 
-// Heavy export deps (jsPDF pulls in ~200 kB of html2canvas; jsPDF itself is
-// another big bundle) only matter when the user actually exports. We import
-// the module on demand so the main chunk doesn't ship them. Caching the
-// promise means a second click — or HTML-then-PDF — reuses the first load.
+// The export module isn't needed for first paint, so we import it on demand to
+// keep it out of the main chunk. Caching the promise means a second click — or
+// HTML-then-PDF — reuses the first load.
 type ExportModule = typeof import('../utils/exportUtils');
 let exportModulePromise: Promise<ExportModule> | null = null;
 const loadExportModule = (): Promise<ExportModule> => {

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -1,7 +1,9 @@
 import { useRef, useEffect, useCallback, useMemo, useState, useTransition, memo, createContext, useContext } from "react";
-import Markdown from "react-markdown";
+import Markdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { parseFrontmatter, serializeFrontmatter, type FrontmatterValue } from "../utils/frontmatter";
@@ -21,6 +23,39 @@ const hasMath = (s: string): boolean => MATH_DETECTION_REGEX.test(s);
 // highlighted; untagged blocks render plain. Unknown language tags are ignored
 // gracefully by the plugin (no throw). PREVIEW-02.
 const HIGHLIGHT_OPTIONS = { detect: false } as const;
+
+// Inline/raw HTML support (GitHub-style). react-markdown ignores raw HTML by
+// default; rehype-raw reparses it into real nodes, and rehype-sanitize then
+// strips anything dangerous. Order matters: raw FIRST (it produces the unsafe
+// tree), sanitize immediately AFTER (the rule is "sanitize after the last
+// unsafe thing"), and the trusted markup generators (KaTeX, highlight.js) and
+// the source-line stamper run LAST so sanitize can't strip their output. A
+// booby-trapped downloaded .md is a real vector in a desktop app that exposes
+// a Tauri IPC bridge, so sanitizing is not optional even for "local" files.
+//
+// The schema is GitHub's defaultSchema plus two narrow additions:
+//  - `math`/`math-inline`/`math-display` classes on span/div, so remark-math's
+//    markers survive sanitize and rehype-katex (which runs after) can find them;
+//  - the `wikilink:` href protocol, so our internal links aren't stripped.
+const SANITIZE_SCHEMA = {
+    ...defaultSchema,
+    attributes: {
+        ...defaultSchema.attributes,
+        span: [...(defaultSchema.attributes?.span ?? []), ["className", "math", "math-inline", "math-display"]],
+        div: [...(defaultSchema.attributes?.div ?? []), ["className", "math", "math-inline", "math-display"]],
+    },
+    protocols: {
+        ...defaultSchema.protocols,
+        href: [...(defaultSchema.protocols?.href ?? []), "wikilink"],
+    },
+} as typeof defaultSchema;
+
+// react-markdown's default urlTransform drops any href whose scheme isn't in a
+// small safe list — which silently kills our internal `wikilink:` links (the
+// click handler keys off that exact scheme). Pass those through; defer
+// everything else to the default, which still blocks javascript:, etc.
+const mdUrlTransform = (url: string): string =>
+    url.startsWith("wikilink:") ? url : defaultUrlTransform(url);
 
 // rehype plugin: stamp each top-level rendered block with the source line it came
 // from (data-source-line). Lets the preview report the ACCURATE top-visible line
@@ -756,8 +791,8 @@ function MarkdownPreviewImpl({
     );
     const rehypePlugins = useMemo(
         () => (mathPlugins
-            ? [[rehypeHighlight, HIGHLIGHT_OPTIONS], mathPlugins.rehype, rehypeSourceLine]
-            : [[rehypeHighlight, HIGHLIGHT_OPTIONS], rehypeSourceLine]),
+            ? [rehypeRaw, [rehypeSanitize, SANITIZE_SCHEMA], mathPlugins.rehype, [rehypeHighlight, HIGHLIGHT_OPTIONS], rehypeSourceLine]
+            : [rehypeRaw, [rehypeSanitize, SANITIZE_SCHEMA], [rehypeHighlight, HIGHLIGHT_OPTIONS], rehypeSourceLine]),
         [mathPlugins]
     );
 
@@ -902,6 +937,7 @@ function MarkdownPreviewImpl({
                             remarkPlugins={remarkPlugins as any}
                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
                             rehypePlugins={rehypePlugins as any}
+                            urlTransform={mdUrlTransform}
                             components={components}
                         >
                             {renderedBody}

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -1,7 +1,6 @@
 import { Theme, FontFamily, FontSize } from '../context/ThemeContext';
 import { save } from '@tauri-apps/plugin-dialog';
-import { writeTextFile, writeFile } from '@tauri-apps/plugin-fs';
-import { jsPDF } from 'jspdf';
+import { writeTextFile } from '@tauri-apps/plugin-fs';
 
 // Theme color definitions for export
 const themeColors: Record<Theme, Record<string, string>> = {
@@ -136,11 +135,33 @@ function generateExportCSS(theme: Theme, font: FontFamily, fontSize: FontSize): 
             margin: 0 auto;
         }
 
+        @page {
+            margin: 18mm 16mm;
+        }
+
         @media print {
+            html, body {
+                background: #ffffff;
+            }
             body {
                 padding: 0;
-                background: white;
+                max-width: none;
                 color: #171717;
+            }
+            /* Browsers drop background fills when printing unless asked; keep
+               code blocks, table headers and blockquote tints visible. */
+            pre, code, th, blockquote, .hljs {
+                -webkit-print-color-adjust: exact;
+                print-color-adjust: exact;
+            }
+            /* Keep atomic blocks and their headings from splitting awkwardly. */
+            pre, blockquote, table, img, tr {
+                page-break-inside: avoid;
+                break-inside: avoid;
+            }
+            h1, h2, h3, h4, h5, h6 {
+                page-break-after: avoid;
+                break-after: avoid;
             }
         }
 
@@ -432,467 +453,134 @@ export async function exportToHTML(
     }
 }
 
-// PDF font size mappings
-const pdfFontSizes: Record<FontSize, { base: number; h1: number; h2: number; h3: number; code: number; lineHeight: number }> = {
-    small: { base: 10, h1: 20, h2: 16, h3: 12, code: 9, lineHeight: 1.4 },
-    medium: { base: 11, h1: 22, h2: 18, h3: 14, code: 10, lineHeight: 1.5 },
-    large: { base: 12, h1: 24, h2: 20, h3: 16, code: 11, lineHeight: 1.6 },
-};
+// ---------------------------------------------------------------------------
+// PDF export
+//
+// We deliberately do NOT rasterize or hand-roll a PDF layout. Instead we render
+// the same standalone HTML we produce for HTML export inside an isolated,
+// off-screen iframe and drive the webview's own print pipeline ("Save as PDF" /
+// "Microsoft Print to PDF"). That yields a vector PDF that matches the preview
+// exactly: real Unicode and color emoji, selectable/searchable text and working
+// links — none of which the old jsPDF standard-font path could do (it encoded
+// text as single-byte WinAnsi, so anything outside Latin-1 — emoji, smart
+// quotes, em dashes — printed as garbage).
+// ---------------------------------------------------------------------------
 
-// Parse HTML and extract structured content for PDF
-interface PDFElement {
-    type: 'h1' | 'h2' | 'h3' | 'p' | 'li' | 'code' | 'blockquote' | 'hr' | 'pre' | 'table';
-    text: string;
-    indent?: number;
-    ordered?: boolean;
-    index?: number;
-    rows?: string[][];  // For table elements: array of rows, each row is array of cells
-    hasHeader?: boolean;
+const PRINT_FRAME_ID = '__paperling_print_frame';
+
+// Resolve once every <img> has finished loading (or failed) so the print job
+// never captures half-decoded images. Sources are inlined as data: URIs by
+// prepareExportHtml, so this usually settles almost immediately.
+function waitForImages(doc: Document): Promise<void> {
+    const imgs = Array.from(doc.images ?? []);
+    return Promise.all(
+        imgs.map((img) =>
+            img.complete
+                ? Promise.resolve()
+                : new Promise<void>((resolve) => {
+                      img.addEventListener('load', () => resolve(), { once: true });
+                      img.addEventListener('error', () => resolve(), { once: true });
+                  })
+        )
+    ).then(() => undefined);
 }
 
-function parseHTMLForPDF(htmlContent: string): PDFElement[] {
-    const elements: PDFElement[] = [];
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(`<div>${htmlContent}</div>`, 'text/html');
-    const container = doc.body.firstChild as HTMLElement;
+// Render `html` in a hidden iframe and invoke the webview's native print dialog.
+// Resolves once printing has been triggered and cleaned up (or the dialog was
+// dismissed). A webview that never fires `afterprint` is cleaned up by the
+// fallback timer so we don't leak frames.
+function printHtmlDocument(html: string): Promise<void> {
+    return new Promise((resolve) => {
+        // Remove any frame left over from a previous (e.g. cancelled) export.
+        document.getElementById(PRINT_FRAME_ID)?.remove();
 
-    function processNode(node: Node, listIndent: number = 0, orderedList: boolean = false, listIndex: number = 0): void {
-        if (node.nodeType === Node.TEXT_NODE) {
-            const text = node.textContent?.trim();
-            if (text) {
-                // Text node outside of elements - treat as paragraph
-                elements.push({ type: 'p', text });
+        const iframe = document.createElement('iframe');
+        iframe.id = PRINT_FRAME_ID;
+        iframe.setAttribute('aria-hidden', 'true');
+        iframe.setAttribute('tabindex', '-1');
+        Object.assign(iframe.style, {
+            position: 'fixed',
+            left: '-9999px',
+            top: '0',
+            // A4-ish width at 96dpi so on-screen layout is sane before the print
+            // engine re-flows to the real page size.
+            width: '794px',
+            height: '0',
+            border: '0',
+            opacity: '0',
+            pointerEvents: 'none',
+        });
+
+        let settled = false;
+        const finish = () => {
+            if (!settled) {
+                settled = true;
+                resolve();
             }
-            return;
-        }
+        };
 
-        if (node.nodeType !== Node.ELEMENT_NODE) return;
-
-        const el = node as HTMLElement;
-        const tagName = el.tagName.toLowerCase();
-
-        switch (tagName) {
-            case 'h1':
-                elements.push({ type: 'h1', text: el.textContent || '' });
-                break;
-            case 'h2':
-                elements.push({ type: 'h2', text: el.textContent || '' });
-                break;
-            case 'h3':
-            case 'h4':
-            case 'h5':
-            case 'h6':
-                elements.push({ type: 'h3', text: el.textContent || '' });
-                break;
-            case 'p':
-                elements.push({ type: 'p', text: el.textContent || '' });
-                break;
-            case 'pre':
-                const codeEl = el.querySelector('code');
-                elements.push({ type: 'pre', text: codeEl?.textContent || el.textContent || '' });
-                break;
-            case 'blockquote':
-                elements.push({ type: 'blockquote', text: el.textContent || '' });
-                break;
-            case 'hr':
-                elements.push({ type: 'hr', text: '' });
-                break;
-            case 'table': {
-                const rows: string[][] = [];
-                let hasHeader = false;
-                // Process thead
-                const thead = el.querySelector('thead');
-                if (thead) {
-                    hasHeader = true;
-                    thead.querySelectorAll('tr').forEach(tr => {
-                        const cells: string[] = [];
-                        tr.querySelectorAll('th, td').forEach(cell => {
-                            cells.push(cell.textContent?.trim() || '');
-                        });
-                        rows.push(cells);
-                    });
-                }
-                // Process tbody
-                const tbody = el.querySelector('tbody') || el;
-                tbody.querySelectorAll('tr').forEach(tr => {
-                    // Skip rows already added from thead
-                    if (thead && tr.closest('thead')) return;
-                    const cells: string[] = [];
-                    tr.querySelectorAll('th, td').forEach(cell => {
-                        cells.push(cell.textContent?.trim() || '');
-                    });
-                    if (cells.length > 0) rows.push(cells);
-                });
-                if (rows.length > 0) {
-                    elements.push({ type: 'table', text: '', rows, hasHeader });
-                }
-                break;
+        iframe.onload = () => {
+            const win = iframe.contentWindow;
+            if (!win) {
+                iframe.remove();
+                finish();
+                return;
             }
-            case 'ul':
-                let ulIndex = 0;
-                el.childNodes.forEach(child => {
-                    if ((child as HTMLElement).tagName?.toLowerCase() === 'li') {
-                        ulIndex++;
-                        processNode(child, listIndent + 1, false, ulIndex);
-                    }
-                });
-                break;
-            case 'ol':
-                let olIndex = 0;
-                el.childNodes.forEach(child => {
-                    if ((child as HTMLElement).tagName?.toLowerCase() === 'li') {
-                        olIndex++;
-                        processNode(child, listIndent + 1, true, olIndex);
-                    }
-                });
-                break;
-            case 'li':
-                elements.push({
-                    type: 'li',
-                    text: el.textContent || '',
-                    indent: listIndent,
-                    ordered: orderedList,
-                    index: listIndex
-                });
-                // Check for nested lists
-                el.childNodes.forEach(child => {
-                    const childTag = (child as HTMLElement).tagName?.toLowerCase();
-                    if (childTag === 'ul' || childTag === 'ol') {
-                        processNode(child, listIndent, childTag === 'ol', 0);
-                    }
-                });
-                break;
-            default:
-                // Process children for other elements (div, article, etc.)
-                el.childNodes.forEach(child => processNode(child, listIndent, orderedList, listIndex));
-        }
-    }
 
-    if (container) {
-        container.childNodes.forEach(child => processNode(child));
-    }
+            let fallbackTimer: ReturnType<typeof setTimeout>;
+            const cleanup = () => {
+                win.removeEventListener('afterprint', cleanup);
+                clearTimeout(fallbackTimer);
+                // Defer removal a tick — some engines read the document
+                // asynchronously after print() returns.
+                setTimeout(() => iframe.remove(), 300);
+                finish();
+            };
+            // Fires when the dialog closes, whether the user saved or cancelled.
+            win.addEventListener('afterprint', cleanup);
+            // Safety net for webviews that don't emit afterprint.
+            fallbackTimer = setTimeout(cleanup, 120000);
 
-    return elements;
+            Promise.all([
+                win.document.fonts?.ready?.catch(() => undefined),
+                waitForImages(win.document),
+            ]).then(() => {
+                try {
+                    win.focus();
+                    win.print();
+                } catch {
+                    cleanup();
+                }
+            });
+        };
+
+        document.body.appendChild(iframe);
+        iframe.srcdoc = html;
+    });
 }
 
-// Helper to parse hex color to RGB tuple
-function hexToRgb(hex: string): [number, number, number] {
-    const clean = hex.replace('#', '');
-    return [
-        parseInt(clean.substring(0, 2), 16),
-        parseInt(clean.substring(2, 4), 16),
-        parseInt(clean.substring(4, 6), 16),
-    ];
-}
-
-// Export to PDF with real selectable text using jsPDF
+// Export to PDF via the webview's print engine (see the block comment above).
+// The theme argument is intentionally ignored: a shared/printed PDF must be
+// legible on white paper, so we always render the light theme. The on-screen
+// HTML export still honours the chosen theme.
 export async function exportToPDF(
     htmlContent: string,
     fileName: string,
-    theme: Theme,
-    _font: FontFamily,
+    _theme: Theme,
+    font: FontFamily,
     fontSize: FontSize
 ): Promise<void> {
-    const title = fileName.replace(/\.(md|markdown)$/i, '');
-
     if (!htmlContent || htmlContent.trim() === '') {
         console.error('No HTML content to export!');
         return;
     }
 
-    // Same cleanup as HTML export — without it the "Copy" button labels and
-    // heading icon ligatures end up as literal text in the PDF.
+    const title = fileName.replace(/\.(md|markdown)$/i, '');
+
+    // Same cleanup as HTML export — strips UI chrome (copy buttons, heading
+    // anchor icons) and inlines blob: images as data: URIs.
     const cleaned = await prepareExportHtml(htmlContent);
+    const fullHTML = generateHTML(cleaned, title, 'light', font, fontSize, true);
 
-    // Parse HTML into structured elements
-    const elements = parseHTMLForPDF(cleaned);
-    const sizes = pdfFontSizes[fontSize];
-    const colors = themeColors[theme];
-
-    // Derive RGB values from theme
-    const textRgb = hexToRgb(colors.textPrimary);
-    const textSecondaryRgb = hexToRgb(colors.textSecondary);
-    const borderRgb = hexToRgb(colors.border);
-    const h1Rgb = hexToRgb(colors.syntaxH1);
-    const h2Rgb = hexToRgb(colors.syntaxH2);
-    const h3Rgb = hexToRgb(colors.syntaxH3);
-
-    // Create PDF document (A4 size)
-    const pdf = new jsPDF({
-        orientation: 'portrait',
-        unit: 'mm',
-        format: 'a4',
-    });
-
-    const pageWidth = pdf.internal.pageSize.getWidth();
-    const pageHeight = pdf.internal.pageSize.getHeight();
-    const margin = 20;
-    const footerHeight = 15;
-    const maxWidth = pageWidth - margin * 2;
-    let y = margin;
-
-    // Helper to add new page if needed (reserves space for footer)
-    const checkPageBreak = (height: number) => {
-        if (y + height > pageHeight - margin - footerHeight) {
-            pdf.addPage();
-            y = margin;
-            return true;
-        }
-        return false;
-    };
-
-    // Helper to wrap text and return lines
-    const wrapText = (text: string, maxW: number, fontSizePt: number): string[] => {
-        pdf.setFontSize(fontSizePt);
-        return pdf.splitTextToSize(text, maxW);
-    };
-
-    // Set default text color
-    pdf.setTextColor(...textRgb);
-
-    // Render each element
-    for (const element of elements) {
-        switch (element.type) {
-            case 'h1': {
-                checkPageBreak(15);
-                y += 8;
-                pdf.setFontSize(sizes.h1);
-                pdf.setFont('helvetica', 'bold');
-                pdf.setTextColor(...h1Rgb);
-                const lines = wrapText(element.text, maxWidth, sizes.h1);
-                pdf.text(lines, margin, y);
-                y += lines.length * (sizes.h1 * 0.4) + 3;
-                pdf.setDrawColor(...borderRgb);
-                pdf.setLineWidth(0.5);
-                pdf.line(margin, y, pageWidth - margin, y);
-                y += 5;
-                pdf.setTextColor(...textRgb);
-                break;
-            }
-
-            case 'h2': {
-                checkPageBreak(12);
-                y += 6;
-                pdf.setFontSize(sizes.h2);
-                pdf.setFont('helvetica', 'bold');
-                pdf.setTextColor(...h2Rgb);
-                const lines = wrapText(element.text, maxWidth, sizes.h2);
-                pdf.text(lines, margin, y);
-                y += lines.length * (sizes.h2 * 0.4) + 2;
-                pdf.setDrawColor(...borderRgb);
-                pdf.setLineWidth(0.3);
-                pdf.line(margin, y, pageWidth - margin, y);
-                y += 4;
-                pdf.setTextColor(...textRgb);
-                break;
-            }
-
-            case 'h3': {
-                checkPageBreak(10);
-                y += 4;
-                pdf.setFontSize(sizes.h3);
-                pdf.setFont('helvetica', 'bold');
-                pdf.setTextColor(...h3Rgb);
-                const lines = wrapText(element.text, maxWidth, sizes.h3);
-                pdf.text(lines, margin, y);
-                y += lines.length * (sizes.h3 * 0.4) + 3;
-                pdf.setTextColor(...textRgb);
-                break;
-            }
-
-            case 'p': {
-                const lineH = sizes.base * 0.4 * sizes.lineHeight;
-                pdf.setFontSize(sizes.base);
-                pdf.setFont('helvetica', 'normal');
-                pdf.setTextColor(...textRgb);
-                const lines = wrapText(element.text, maxWidth, sizes.base);
-                // Check page break for each chunk of lines to prevent overflow
-                for (const line of lines) {
-                    checkPageBreak(lineH);
-                    pdf.text(line, margin, y);
-                    y += lineH;
-                }
-                y += 3;
-                break;
-            }
-
-            case 'li': {
-                const indent = (element.indent || 1) * 5;
-                const bullet = element.ordered ? `${element.index}.` : '\u2022';
-                const lineH = sizes.base * 0.4 * sizes.lineHeight;
-                pdf.setFontSize(sizes.base);
-                pdf.setFont('helvetica', 'normal');
-                pdf.setTextColor(...textRgb);
-
-                const cleanText = element.text.trim();
-                const lines = wrapText(cleanText, maxWidth - indent - 5, sizes.base);
-                checkPageBreak(lines.length * lineH);
-
-                pdf.text(bullet, margin + indent - 4, y);
-                pdf.text(lines, margin + indent + 2, y);
-                y += lines.length * lineH + 1;
-                break;
-            }
-
-            case 'pre': {
-                const codeLines = element.text.split('\n');
-                const lineH = sizes.code * 0.4;
-                const blockHeight = codeLines.length * lineH + 6;
-
-                // Split code blocks across pages if they're too tall
-                if (blockHeight > pageHeight - margin * 2 - footerHeight) {
-                    // Render line by line with page breaks
-                    pdf.setFontSize(sizes.code);
-                    pdf.setFont('courier', 'normal');
-                    pdf.setTextColor(60, 60, 60);
-                    for (const line of codeLines) {
-                        checkPageBreak(lineH + 4);
-                        pdf.setFillColor(245, 245, 245);
-                        pdf.rect(margin, y - 2, maxWidth, lineH + 2, 'F');
-                        const wrapped = wrapText(line || ' ', maxWidth - 6, sizes.code);
-                        pdf.text(wrapped, margin + 3, y);
-                        y += wrapped.length * lineH;
-                    }
-                    pdf.setTextColor(...textRgb);
-                    y += 3;
-                } else {
-                    checkPageBreak(blockHeight);
-                    pdf.setFillColor(245, 245, 245);
-                    pdf.roundedRect(margin, y - 2, maxWidth, blockHeight, 2, 2, 'F');
-                    pdf.setFontSize(sizes.code);
-                    pdf.setFont('courier', 'normal');
-                    pdf.setTextColor(60, 60, 60);
-                    let codeY = y + 2;
-                    for (const line of codeLines) {
-                        const wrapped = wrapText(line || ' ', maxWidth - 6, sizes.code);
-                        pdf.text(wrapped, margin + 3, codeY);
-                        codeY += wrapped.length * lineH;
-                    }
-                    pdf.setTextColor(...textRgb);
-                    y += blockHeight + 3;
-                }
-                break;
-            }
-
-            case 'blockquote': {
-                const lineH = sizes.base * 0.4 * sizes.lineHeight;
-                pdf.setFontSize(sizes.base);
-                pdf.setFont('helvetica', 'italic');
-                const lines = wrapText(element.text, maxWidth - 10, sizes.base);
-                const blockHeight = lines.length * lineH + 4;
-                checkPageBreak(blockHeight);
-
-                pdf.setFillColor(100, 100, 100);
-                pdf.rect(margin, y - 2, 2, blockHeight, 'F');
-                pdf.setFillColor(250, 250, 250);
-                pdf.rect(margin + 3, y - 2, maxWidth - 3, blockHeight, 'F');
-
-                pdf.setTextColor(...textSecondaryRgb);
-                pdf.text(lines, margin + 6, y + 2);
-                pdf.setTextColor(...textRgb);
-                pdf.setFont('helvetica', 'normal');
-                y += blockHeight + 3;
-                break;
-            }
-
-            case 'table': {
-                if (!element.rows || element.rows.length === 0) break;
-
-                const rows = element.rows;
-                const colCount = Math.max(...rows.map(r => r.length));
-                const cellPadding = 2;
-                const colWidth = (maxWidth - cellPadding * 2) / colCount;
-                const cellLineH = sizes.base * 0.4 * sizes.lineHeight;
-
-                pdf.setFontSize(sizes.base);
-                pdf.setDrawColor(...borderRgb);
-                pdf.setLineWidth(0.3);
-
-                for (let rowIdx = 0; rowIdx < rows.length; rowIdx++) {
-                    const row = rows[rowIdx];
-                    const isHeader = element.hasHeader && rowIdx === 0;
-
-                    // Wrap every cell first; the row grows to fit its tallest
-                    // cell so long content renders fully instead of being
-                    // silently truncated to the first wrapped line (EXPORT-02).
-                    const wrappedCells: string[][] = [];
-                    let maxLines = 1;
-                    for (let colIdx = 0; colIdx < colCount; colIdx++) {
-                        const wrapped = wrapText(row[colIdx] || '', colWidth - cellPadding * 2, sizes.base);
-                        wrappedCells.push(wrapped.length ? wrapped : ['']);
-                        if (wrapped.length > maxLines) maxLines = wrapped.length;
-                    }
-                    const rowHeight = maxLines * cellLineH + cellPadding * 2;
-
-                    checkPageBreak(rowHeight);
-
-                    // Draw header background
-                    if (isHeader) {
-                        pdf.setFillColor(245, 245, 245);
-                        pdf.rect(margin, y - cellPadding, maxWidth, rowHeight, 'F');
-                    }
-
-                    // Draw cells
-                    for (let colIdx = 0; colIdx < colCount; colIdx++) {
-                        const cellX = margin + colIdx * colWidth;
-
-                        // Cell border
-                        pdf.rect(cellX, y - cellPadding, colWidth, rowHeight, 'S');
-
-                        // Cell text — every wrapped line, not just the first
-                        pdf.setFont('helvetica', isHeader ? 'bold' : 'normal');
-                        pdf.setTextColor(...textRgb);
-                        const wrapped = wrappedCells[colIdx];
-                        for (let li = 0; li < wrapped.length; li++) {
-                            pdf.text(wrapped[li], cellX + cellPadding, y + cellPadding + li * cellLineH);
-                        }
-                    }
-
-                    y += rowHeight;
-                }
-                y += 3;
-                break;
-            }
-
-            case 'hr': {
-                checkPageBreak(10);
-                y += 5;
-                pdf.setDrawColor(...borderRgb);
-                pdf.setLineWidth(0.5);
-                pdf.line(margin, y, pageWidth - margin, y);
-                y += 5;
-                break;
-            }
-        }
-    }
-
-    // Add footer
-    const pageCount = pdf.getNumberOfPages();
-    const date = new Date().toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric'
-    });
-
-    for (let i = 1; i <= pageCount; i++) {
-        pdf.setPage(i);
-        pdf.setFontSize(8);
-        pdf.setFont('helvetica', 'normal');
-        pdf.setTextColor(150, 150, 150);
-        pdf.text(`Exported from Paperling on ${date}`, margin, pageHeight - 10);
-        pdf.text(`Page ${i} of ${pageCount}`, pageWidth - margin - 20, pageHeight - 10);
-    }
-
-    // Get PDF as array buffer
-    const pdfBuffer = pdf.output('arraybuffer');
-
-    // Use Tauri save dialog
-    const filePath = await save({
-        defaultPath: `${title}.pdf`,
-        filters: [{ name: 'PDF', extensions: ['pdf'] }],
-    });
-
-    if (filePath) {
-        await writeFile(filePath, new Uint8Array(pdfBuffer));
-    }
+    await printHtmlDocument(fullHTML);
 }


### PR DESCRIPTION
## What & why

Two fixes plus one latent-bug fix discovered along the way.

### 1. PDF export was garbling text (emoji, smart quotes, em dashes)
The old path drew text with jsPDF's **standard fonts**, which only support single-byte WinAnsi (Latin-1). Anything outside that range was emitted as raw bytes and rendered as garbage (the `&`-interleaved text and mangled `Ø=ßâ&` headings users saw). It also hand-rebuilt layout from parsed HTML, so the PDF never matched the preview.

**Now:** we render the same standalone HTML we already produce for HTML export inside an isolated off-screen iframe and drive the **webview's own print pipeline** ("Save as PDF" / "Microsoft Print to PDF"). The result matches the preview exactly — real Unicode + color emoji, selectable/searchable text, working links — at **zero added bundle weight**. PDF always renders the light theme so it stays legible on white paper.

- Removes the `jspdf` dependency and all dead jsPDF layout code (`parseHTMLForPDF`, `pdfFontSizes`, `hexToRgb`, `PDFElement`) — net −500+ lines.
- Hardens the print path: waits for fonts + inlined images, cleans up the iframe on `afterprint` with a fallback timer.
- Better `@media print` CSS: `@page` margins, `print-color-adjust` for code/table/blockquote fills, sensible page-break rules.

> Trade-off: PDF export now opens the OS print dialog (pick "Save as PDF") instead of a direct save dialog. This is the standard high-fidelity approach (Obsidian/Typora-style) and the only way to get correct emoji/Unicode + a layout that matches the preview.

### 2. Inline HTML in markdown (GitHub-style)
Adds `rehype-raw` + `rehype-sanitize` so raw HTML embedded in markdown renders like it does on GitHub, while stripping XSS vectors. Plugin order is `raw → sanitize → katex → highlight → source-line` so sanitize runs right after the only unsafe step and never strips KaTeX/highlight output. Sanitize schema = GitHub's `defaultSchema` plus two narrow allowances (math marker classes; the internal `wikilink:` protocol).

### 3. Latent bug: wikilinks never fired
react-markdown's default `urlTransform` stripped `wikilink:` hrefs to `""`, so the wikilink click handler could never run. A custom `urlTransform` now passes that scheme through (everything else still defaults, so `javascript:` etc. stay blocked).

## Verification
- Full markdown pipeline tested end-to-end through react-markdown: raw HTML (`details`/`summary`/`kbd`/`sub`/`sup`/`div`) renders, wikilinks/task lists/math/syntax highlighting/mermaid all preserved, and `script`/`onerror`/`javascript:`/`iframe`/`onclick` all stripped.
- `tsc --noEmit` clean; all 122 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)