### PR TITLE
feat: F11 fullscreen + cleaner "What's new" update dialog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     outputs:
       should_release: ${{ steps.bump.outputs.should_release }}
       version: ${{ steps.bump.outputs.version }}
+      notes: ${{ steps.notes.outputs.notes }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -73,6 +74,35 @@ jobs:
             echo "should_release=true" >> $GITHUB_OUTPUT
             echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           fi
+
+      # Build the release body from the top CHANGELOG section so the updater's
+      # "What's new" popup shows the actual changes (the in-app dialog strips
+      # the Installation block; the GitHub release page keeps it). Falls back to
+      # the generic blurb if the section comes out empty.
+      - name: Extract release notes from CHANGELOG
+        id: notes
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          # Print the lines of the first "## [...]" section, excluding the two
+          # heading lines that bound it.
+          CHANGES=$(awk '/^## \[/{c++; next} c==1' CHANGELOG.md)
+          if [ -z "$(echo "$CHANGES" | tr -d '[:space:]')" ]; then
+            CHANGES="A new version of Paperling is available."
+          fi
+          {
+            echo "notes<<__PAPERLING_NOTES__"
+            echo "## What's new in v$VERSION"
+            echo ""
+            printf '%s\n' "$CHANGES"
+            echo ""
+            echo "### Installation"
+            echo "- **Windows:** \`.msi\` (recommended) or \`.exe\` (NSIS installer)"
+            echo "- **Linux:** \`.deb\` or \`.AppImage\`"
+            echo "- **macOS:** \`.dmg\`"
+            echo ""
+            echo "See the [CHANGELOG](https://github.com/Razee4315/Paperling/blob/main/CHANGELOG.md) for the full history."
+            echo "__PAPERLING_NOTES__"
+          } >> "$GITHUB_OUTPUT"
 
   # ─── Job 2: Build + Release ────────────────────────────────
   release:
@@ -137,17 +167,7 @@ jobs:
           tauriScript: bun run tauri
           tagName: v__VERSION__
           releaseName: 'Paperling v__VERSION__'
-          releaseBody: |
-            ## Paperling v__VERSION__
-
-            A minimal, distraction-free markdown editor.
-
-            ### Installation
-            - **Windows:** `.msi` (recommended) or `.exe` (NSIS installer)
-            - **Linux:** `.deb` or `.AppImage`
-            - **macOS:** `.dmg`
-
-            See the [CHANGELOG](https://github.com/Razee4315/Paperling/blob/main/CHANGELOG.md) for details.
+          releaseBody: ${{ needs.check-and-bump.outputs.notes }}
           args: ${{ matrix.args }}
           releaseDraft: false
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Fullscreen mode (F11).** Press F11 to toggle distraction-free fullscreen on
+  Windows, Linux, and macOS. The title bar stays visible so there's always an
+  obvious way back, and a one-time hint reminds you to press F11 to exit. Also
+  available from the command palette.
 - **Auto-updater.** Paperling now checks GitHub Releases on launch and shows a
   popup when a newer version is available, with "Update now" (download with
   progress, install, restart), "Skip this version" (remembered per version),
@@ -27,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Cleaner "What's new" in the update popup.** The updater now shows the
+  release's actual changes as a tidy, scrollable list instead of a block of raw
+  text. Release notes are sourced automatically from this changelog at build
+  time, and links open in your browser rather than inside the app.
 - **Relicensed to Apache 2.0.** MarkLite moved from the previous custom
   non-commercial terms to the Apache License 2.0: free for both personal and
   commercial use, with an explicit patent grant. See `LICENSE` and `NOTICE`.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:window:allow-minimize",
     "core:window:allow-maximize",
     "core:window:allow-toggle-maximize",
+    "core:window:allow-set-fullscreen",
     "core:window:allow-close",
     "core:window:allow-destroy",
     "core:window:allow-start-dragging",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -853,6 +853,21 @@ function AppContent() {
   // Toggle the right-side AI assistant panel.
   const handleToggleAI = useCallback(() => setShowAIPanel((v) => !v), []);
 
+  // Toggle OS fullscreen (F11). The custom title bar deliberately stays
+  // visible so there's always an obvious way back (the same controls, plus
+  // F11 again); a one-time hint reinforces it for non-technical users. One
+  // Tauri call covers Windows, Linux, and macOS. FULLSCREEN-01.
+  const toggleFullscreen = useCallback(async () => {
+    try {
+      const w = Window.getCurrent();
+      const isFs = await w.isFullscreen();
+      await w.setFullscreen(!isFs);
+      if (!isFs) showToast("Fullscreen on — press F11 to exit", "info");
+    } catch {
+      /* browser dev mode — no Tauri window */
+    }
+  }, [showToast]);
+
   // Agent proposed an edited document → show it as a diff to accept/reject.
   // Ensure the editor (where the diff renders) is visible.
   const handleProposeEdit = useCallback((doc: string) => {
@@ -939,6 +954,7 @@ function AppContent() {
   useGlobalShortcuts({
     handleOpenFile, handleSaveFile, handleSaveAs, handleNewFile,
     handleToggleMode, handleToggleSplit, handleToggleFileExplorer, handleToggleTOC,
+    toggleFullscreen,
     openCheatsheet: () => setShowCheatsheet(true),
     openPalette: () => setShowPalette(true),
     openSettings: () => setShowSettings(true),
@@ -1079,6 +1095,18 @@ function AppContent() {
       });
     }
 
+    // Fullscreen works anywhere (including the welcome screen), so unlike the
+    // other View entries it isn't gated on a file being open.
+    items.push({
+      id: "view.fullscreen",
+      label: "Toggle fullscreen",
+      hint: "F11",
+      section: "View",
+      icon: "fullscreen",
+      keywords: "full screen distraction free f11 immersive",
+      run: toggleFullscreen,
+    });
+
     // === AI === only when a buffer exists and AI is enabled in Settings.
     // The command palette is the always-reachable entry point for AI assist
     // (the toolbar AI button is hidden when the toolbar is off). Dispatches a
@@ -1167,7 +1195,7 @@ function AppContent() {
     // (post-debounce) for no reason. Headings are computed below in a
     // separate hook that's gated on the palette actually being open.
     handleNewFile, handleOpenFile, handleSaveFile, handleSaveAs,
-    handleToggleSplit, handleToggleFileExplorer, handleToggleTOC,
+    handleToggleSplit, handleToggleFileExplorer, handleToggleTOC, toggleFullscreen,
     loadFile, filePath, hasFile, showToast,
     typewriterModeEnabled, toolbarVisible, aiEnabled,
   ]);

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -40,6 +40,7 @@ const groups: ShortcutGroup[] = [
         items: [
             { keys: `${cmd}+E`, description: "Toggle Reader / Code" },
             { keys: `${cmd}+\\`, description: "Toggle split view" },
+            { keys: "F11", description: "Toggle fullscreen" },
             { keys: `${cmd}+Shift+E`, description: "Toggle file explorer" },
             { keys: `${cmd}+Shift+O`, description: "Toggle outline" },
             { keys: `${cmd}+P`, description: "Command palette" },

--- a/src/components/UpdateDialog.tsx
+++ b/src/components/UpdateDialog.tsx
@@ -1,10 +1,64 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
+import Markdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { getSkippedUpdateVersion, setSkippedUpdateVersion } from "../utils/persistence";
 import { attachFocusTrap } from "../utils/focusTrap";
 
 type Phase = "available" | "downloading" | "installed" | "error";
+
+/**
+ * The GitHub release body is what `update.body` carries. Older releases shipped
+ * a generic install blurb ("A minimal… markdown editor" + an Installation list
+ * + a CHANGELOG link); newer ones inject the actual changelog section. This
+ * strips the boilerplate either way so the dialog only ever shows real changes,
+ * degrading gracefully on old releases instead of dumping raw text at the user.
+ */
+function cleanReleaseNotes(raw: string): string {
+    let s = raw.replace(/\r\n/g, "\n").trim();
+    // Cut the generic install instructions (and everything after) if present.
+    const inst = s.search(/^#{1,6}\s+Installation\b/im);
+    if (inst >= 0) s = s.slice(0, inst).trim();
+    // The dialog header already names the version, so drop a redundant leading
+    // "## What's new…" / "## Paperling vX" title line.
+    s = s.replace(/^#{1,6}\s+(What's new|Paperling)\b.*\n+/i, "");
+    // Drop the marketing tagline and the "see the changelog" footer line.
+    s = s.replace(/^A minimal,? distraction-free markdown editor\.?\s*$/im, "");
+    s = s.replace(/^See the \[CHANGELOG\].*$/im, "");
+    return s.trim();
+}
+
+// Compact, theme-aware renderers for the release notes. No rehype-raw, so any
+// HTML in the notes is inert — and links open in the OS browser, not the
+// webview. Headings collapse to small section labels; list items get an accent
+// dot. Kept module-level for a stable component identity.
+const NOTES_COMPONENTS: Components = {
+    h1: ({ children }) => <p className="mt-3 mb-1 first:mt-0 text-[11px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">{children}</p>,
+    h2: ({ children }) => <p className="mt-3 mb-1 first:mt-0 text-[11px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">{children}</p>,
+    h3: ({ children }) => <p className="mt-3 mb-1 first:mt-0 text-[11px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">{children}</p>,
+    h4: ({ children }) => <p className="mt-3 mb-1 first:mt-0 text-[11px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">{children}</p>,
+    p: ({ children }) => <p className="my-1 text-[12px] leading-relaxed text-[var(--text-secondary)]">{children}</p>,
+    ul: ({ children }) => <ul className="my-1 space-y-1">{children}</ul>,
+    ol: ({ children }) => <ol className="my-1 space-y-1 list-decimal pl-5 text-[12px] text-[var(--text-secondary)]">{children}</ol>,
+    li: ({ children }) => (
+        <li className="relative pl-4 text-[12px] leading-relaxed text-[var(--text-secondary)] before:absolute before:left-0 before:top-[8px] before:h-1 before:w-1 before:rounded-full before:bg-[var(--accent)]">
+            {children}
+        </li>
+    ),
+    strong: ({ children }) => <strong className="font-semibold text-[var(--text-primary)]">{children}</strong>,
+    code: ({ children }) => <code className="rounded bg-[var(--bg-hover)] px-1 py-0.5 font-mono text-[11px] text-[var(--text-primary)]">{children}</code>,
+    a: ({ children, href }) => (
+        <button
+            type="button"
+            onClick={() => { if (href) openUrl(href).catch(() => {/* opener unavailable */}); }}
+            className="text-[var(--accent)] hover:underline"
+        >
+            {children}
+        </button>
+    ),
+};
 
 /**
  * Checks GitHub Releases (latest.json) once on startup and, if a newer signed
@@ -22,6 +76,11 @@ export function UpdateDialog() {
     const dialogRef = useRef<HTMLDivElement>(null);
 
     const busy = phase === "downloading" || phase === "installed";
+
+    // Boilerplate-stripped release notes. Empty when the body is only the
+    // generic install blurb (old releases) — the dialog then just shows the
+    // version line, never a wall of raw markdown.
+    const notes = useMemo(() => (update?.body ? cleanReleaseNotes(update.body) : ""), [update]);
 
     // Escape dismisses like "Later", and Tab stays inside the dialog — the
     // same keyboard contract as the Settings modal. Disabled while busy: a
@@ -110,9 +169,17 @@ export function UpdateDialog() {
                         </div>
                     </div>
 
-                    {update.body && phase === "available" && (
-                        <div className="mt-3 max-h-36 overflow-y-auto px-3 py-2 text-[12px] leading-relaxed text-[var(--text-secondary)] whitespace-pre-wrap bg-[var(--bg-secondary)] border border-[var(--border-subtle)] rounded-[var(--radius-md)]">
-                            {update.body}
+                    {notes && phase === "available" && (
+                        <div className="mt-4">
+                            <div className="flex items-center gap-1.5 mb-1.5 text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+                                <span className="material-symbols-outlined text-[14px] text-[var(--accent)]">auto_awesome</span>
+                                What's new
+                            </div>
+                            <div className="max-h-52 overflow-y-auto pr-1 -mr-1">
+                                <Markdown remarkPlugins={[remarkGfm]} components={NOTES_COMPONENTS}>
+                                    {notes}
+                                </Markdown>
+                            </div>
                         </div>
                     )}
 

--- a/src/hooks/useGlobalShortcuts.test.tsx
+++ b/src/hooks/useGlobalShortcuts.test.tsx
@@ -14,6 +14,7 @@ function makeHandlers(over: Partial<ShortcutHandlers> = {}): ShortcutHandlers {
         handleNewFile: vi.fn(),
         handleToggleMode: vi.fn(),
         handleToggleSplit: vi.fn(),
+        toggleFullscreen: vi.fn(),
         handleToggleFileExplorer: vi.fn(),
         handleToggleTOC: vi.fn(),
         openCheatsheet: vi.fn(),
@@ -77,6 +78,11 @@ describe("useGlobalShortcuts", () => {
         press({ key: ",", ctrlKey: true });
         expect(h.openPalette).toHaveBeenCalledTimes(1);
         expect(h.openSettings).toHaveBeenCalledTimes(1);
+    });
+
+    it("F11 toggles fullscreen", () => {
+        press({ key: "F11" });
+        expect(h.toggleFullscreen).toHaveBeenCalledTimes(1);
     });
 
     it("Alt+J dispatches the AI-assist event", () => {

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -9,6 +9,8 @@ export interface ShortcutHandlers {
     handleNewFile: () => void;
     handleToggleMode: () => void;
     handleToggleSplit: () => void;
+    /** Toggle OS fullscreen (F11). Cross-platform via the Tauri window API. */
+    toggleFullscreen: () => void;
     handleToggleFileExplorer: () => void;
     handleToggleTOC: () => void;
     openCheatsheet: () => void;
@@ -35,6 +37,16 @@ export function useGlobalShortcuts(handlers: ShortcutHandlers) {
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             const s = ref.current;
+            // F11 - Toggle fullscreen. The universal fullscreen key on Windows
+            // and Linux. macOS reserves F11 for Show Desktop, where users
+            // fullscreen via the green title-bar button; the underlying Tauri
+            // setFullscreen drives the same window state either way. No file
+            // needed — works on the welcome screen too. FULLSCREEN-01.
+            if (e.key === "F11") {
+                e.preventDefault();
+                s.toggleFullscreen();
+                return;
+            }
             // Ctrl+Shift+E - Toggle file explorer (check before Ctrl+E)
             if (e.ctrlKey && e.shiftKey && e.key === "E") {
                 e.preventDefault();


### PR DESCRIPTION
## What

Two features:

### 1. Fullscreen (F11)
Cross-platform fullscreen toggle via the Tauri window API (`setFullscreen`/`isFullscreen`) — one code path for Windows, Linux, and macOS. The custom title bar stays visible so there's always an obvious way back, plus a one-time "press F11 to exit" toast. Available from the keyboard (F11), the command palette, and listed in the cheatsheet.

### 2. Cleaner "What's new" update dialog
The updater popup previously dumped a generic install blurb as raw text — users never saw the actual changes. Now:
- `release.yml` injects the top `CHANGELOG.md` section into the release body, so the updater shows real release notes.
- `UpdateDialog` renders them as a clean, scrollable "What's new" list via `react-markdown` (a sanitizer strips install boilerplate, so old releases degrade gracefully). Links open in the OS browser, not the webview.

## Notes
- The richer dialog fully applies from the **next** release (it ships the new body format). Older releases' bodies strip to empty, so the dialog shows just the version line.
- Since the popup now feeds from `## [Unreleased]`, keep that section trimmed to current highlights.

## Testing
- `tsc --noEmit` clean
- Full vitest suite: 123 passed (added an F11 test)
