### PR TITLE
refactor(app): extract & test autosave + external-change watcher

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,8 @@ import { useDebouncedValue } from "./hooks/useDebouncedValue";
 import { usePersistedState } from "./hooks/usePersistedState";
 import { useFullscreen } from "./hooks/useFullscreen";
 import { useScrollSync } from "./hooks/useScrollSync";
+import { useAutosave } from "./hooks/useAutosave";
+import { useExternalChangeWatcher } from "./hooks/useExternalChangeWatcher";
 
 // === Lazy-loaded screens / dialogs ===
 //
@@ -428,10 +430,11 @@ function AppContent() {
   originalContentRef.current = originalContent;
   const filePathRef = useRef(filePath);
   filePathRef.current = filePath;
-  // Mirror of proposedDoc for the focus-time external-change listener (registered
-  // once, so it can't read the state directly). AI-01.
-  const proposedDocRef = useRef(proposedDoc);
-  proposedDocRef.current = proposedDoc;
+  // Whether an AI review is pending, mirrored into a ref for the focus-time
+  // external-change watcher (registered once, so it can't read state directly).
+  // AI-01.
+  const reviewActiveRef = useRef(false);
+  reviewActiveRef.current = proposedDoc != null;
 
   // Intercept EVERY window-close path (Alt+F4, taskbar close, the title bar X,
   // OS shutdown) and route dirty buffers through the unsaved-changes dialog.
@@ -500,66 +503,42 @@ function AppContent() {
     forceCloseWindow();
   }, [forceCloseWindow]);
 
-  // External-change detection: when the window regains focus, stat the open
-  // file. If it changed on disk and the buffer is clean, reload silently; if
-  // the buffer is dirty, warn that saving will overwrite. EXT-01.
-  useEffect(() => {
-    let checking = false;
-    const checkExternalChange = async () => {
-      const path = filePathRef.current;
-      if (!path || checking) return;
-      checking = true;
-      // Don't reload over an in-progress AI review — the editor is showing a
-      // proposed document the user hasn't accepted/rejected yet. AI-01.
-      if (proposedDocRef.current != null) return;
-      try {
-        const info = await invoke<{ modified: number }>("get_file_info", { path });
-        const known = knownMtimeRef.current;
-        if (known > 0 && info.modified > known) {
-          // Update first so a failed/declined reload doesn't re-toast forever.
-          knownMtimeRef.current = info.modified;
-          if (contentRef.current === originalContentRef.current) {
-            await loadFileDirect(path);
-            showToast("File changed on disk, reloaded the latest version", "info");
-          } else {
-            showToast("This file changed on disk. Saving will overwrite those changes.", "error");
-          }
-        }
-      } catch {/* file gone or stat failed — the save path will surface it */}
-      finally { checking = false; }
-    };
-    window.addEventListener("focus", checkExternalChange);
-    return () => window.removeEventListener("focus", checkExternalChange);
-  }, [loadFileDirect, showToast]);
+  // External-change detection: on window focus, stat the open file and reload
+  // (clean buffer) or warn (dirty buffer). EXT-01. Callbacks are memoised so the
+  // focus listener stays registered across renders.
+  const handleExternalReloaded = useCallback(
+    () => showToast("File changed on disk, reloaded the latest version", "info"),
+    [showToast]
+  );
+  const handleExternalConflict = useCallback(
+    () => showToast("This file changed on disk. Saving will overwrite those changes.", "error"),
+    [showToast]
+  );
+  useExternalChangeWatcher({
+    filePathRef, contentRef, originalContentRef, knownMtimeRef,
+    isReviewActiveRef: reviewActiveRef,
+    reload: loadFileDirect,
+    onReloaded: handleExternalReloaded,
+    onConflict: handleExternalConflict,
+  });
 
-  // Autosave: once enabled, persist 1.5s after the last edit. Silent on success
-  // (the status dot already flips to Saved). Failures surface a toast, throttled
-  // to at most once per 30s so a broken disk keeps reminding the user without
-  // spamming on every 1.5s tick. The unsaved dot stays lit the whole time as
-  // the always-on signal. A successful save clears the throttle.
-  const lastAutosaveErrorRef = useRef(0);
-  useEffect(() => {
-    if (!autoSaveEnabled || !filePath || content === originalContent) return;
-    // Never autosave while an AI review is pending: `content` then reflects only
-    // the chunks accepted so far, and a later "Reject all" would leave disk
-    // holding edits the user explicitly rejected. AI-01.
-    if (proposedDoc != null) return;
-    const id = window.setTimeout(async () => {
-      try {
-        knownMtimeRef.current = await invoke<number>("save_file", { path: filePath, content });
-        setOriginalContent(content);
-        lastAutosaveErrorRef.current = 0;
-      } catch (err) {
-        const now = Date.now();
-        if (now - lastAutosaveErrorRef.current > 30000) {
-          lastAutosaveErrorRef.current = now;
-          const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
-          showToast(msg || "Autosave failed", "error");
-        }
-      }
-    }, 1500);
-    return () => window.clearTimeout(id);
-  }, [autoSaveEnabled, content, originalContent, filePath, proposedDoc, showToast]);
+  // Autosave 1.5s after the last edit. See useAutosave for the throttling and
+  // the AI-review guard (AI-01). Callbacks are memoised so the debounce timer
+  // isn't reset on every unrelated re-render.
+  const handleAutosaved = useCallback((mtime: number, saved: string) => {
+    knownMtimeRef.current = mtime;
+    setOriginalContent(saved);
+  }, []);
+  const handleAutosaveError = useCallback((msg: string) => showToast(msg, "error"), [showToast]);
+  useAutosave({
+    enabled: autoSaveEnabled,
+    filePath,
+    content,
+    originalContent,
+    isReviewActive: proposedDoc != null,
+    onSaved: handleAutosaved,
+    onError: handleAutosaveError,
+  });
 
   // Load file with unsaved changes protection
   const loadFile = useCallback(async (path: string) => {

--- a/src/hooks/useAutosave.test.ts
+++ b/src/hooks/useAutosave.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { invoke } from "@tauri-apps/api/core";
+import { useAutosave, type UseAutosaveOptions } from "./useAutosave";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+const base = (over: Partial<UseAutosaveOptions> = {}): UseAutosaveOptions => ({
+  enabled: true,
+  filePath: "C:/doc.md",
+  content: "new",
+  originalContent: "old",
+  isReviewActive: false,
+  onSaved: vi.fn(),
+  onError: vi.fn(),
+  ...over,
+});
+
+describe("useAutosave", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (invoke as Mock).mockReset().mockResolvedValue(1700000000000);
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("does not save when disabled", async () => {
+    renderHook((p: UseAutosaveOptions) => useAutosave(p), { initialProps: base({ enabled: false }) });
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("does not save an Untitled buffer (no path)", async () => {
+    renderHook((p: UseAutosaveOptions) => useAutosave(p), { initialProps: base({ filePath: null }) });
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("does not save when the buffer is clean", async () => {
+    renderHook((p: UseAutosaveOptions) => useAutosave(p), { initialProps: base({ content: "x", originalContent: "x" }) });
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("does NOT save while an AI review is pending, even when dirty (AI-01)", async () => {
+    const onSaved = vi.fn();
+    renderHook((p: UseAutosaveOptions) => useAutosave(p), {
+      initialProps: base({ isReviewActive: true, onSaved }),
+    });
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(invoke).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("saves after the debounce and reports the new mtime + saved content", async () => {
+    const onSaved = vi.fn();
+    renderHook((p: UseAutosaveOptions) => useAutosave(p), { initialProps: base({ onSaved }) });
+
+    // Nothing before the debounce elapses.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(invoke).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(600);
+    expect(invoke).toHaveBeenCalledWith("save_file", { path: "C:/doc.md", content: "new" });
+    expect(onSaved).toHaveBeenCalledWith(1700000000000, "new");
+  });
+
+  it("coalesces rapid edits — only the latest content is written", async () => {
+    const onSaved = vi.fn();
+    const { rerender } = renderHook((p: UseAutosaveOptions) => useAutosave(p), {
+      initialProps: base({ content: "a", onSaved }),
+    });
+    await vi.advanceTimersByTimeAsync(1000); // not yet
+    rerender(base({ content: "ab", onSaved }));
+    await vi.advanceTimersByTimeAsync(1000); // resets, still not yet
+    rerender(base({ content: "abc", onSaved }));
+    await vi.advanceTimersByTimeAsync(1600);
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith("save_file", { path: "C:/doc.md", content: "abc" });
+  });
+
+  it("throttles repeated failures to onError", async () => {
+    (invoke as Mock).mockRejectedValue("Disk full");
+    const onError = vi.fn();
+    const { rerender } = renderHook((p: UseAutosaveOptions) => useAutosave(p), {
+      initialProps: base({ content: "a", onError }),
+    });
+    await vi.advanceTimersByTimeAsync(1600);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith("Disk full");
+
+    // A second failure shortly after stays silent (30s throttle window).
+    rerender(base({ content: "b", onError }));
+    await vi.advanceTimersByTimeAsync(1600);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useAutosave.ts
+++ b/src/hooks/useAutosave.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export interface UseAutosaveOptions {
+  /** Master toggle (Settings → Editor). */
+  enabled: boolean;
+  /** Path of the open file, or null for an unsaved Untitled buffer. */
+  filePath: string | null;
+  /** Live editor content. */
+  content: string;
+  /** Last-persisted content; autosave is a no-op while it equals `content`. */
+  originalContent: string;
+  /**
+   * True while an AI review is pending. `content` then reflects only the chunks
+   * accepted so far, and a later "Reject all" would otherwise leave disk holding
+   * edits the user explicitly rejected, so autosave must stay parked. AI-01.
+   */
+  isReviewActive: boolean;
+  /** Called after a successful write with the new mtime and the saved content. */
+  onSaved: (mtime: number, content: string) => void;
+  /** Called when a write fails (already throttled to at most once per 30s). */
+  onError: (message: string) => void;
+}
+
+/** Debounce before persisting after the last edit. */
+const AUTOSAVE_DELAY_MS = 1500;
+/** Don't surface autosave failures more than once per this window. */
+const ERROR_THROTTLE_MS = 30_000;
+
+/**
+ * Autosave: once enabled, persist the buffer a moment after the user stops
+ * typing. Silent on success (the status dot already flips to "Saved"); failures
+ * surface through `onError`, throttled so a broken disk keeps reminding the user
+ * without spamming on every debounce tick. A successful save clears the throttle.
+ *
+ * `onSaved`/`onError` must be stable (wrap in useCallback) — they're effect deps,
+ * so a fresh identity each render would reset the debounce timer continuously and
+ * autosave would never fire.
+ */
+export function useAutosave({
+  enabled,
+  filePath,
+  content,
+  originalContent,
+  isReviewActive,
+  onSaved,
+  onError,
+}: UseAutosaveOptions): void {
+  const lastErrorRef = useRef(0);
+
+  useEffect(() => {
+    if (!enabled || !filePath || content === originalContent || isReviewActive) return;
+    const id = window.setTimeout(async () => {
+      try {
+        const mtime = await invoke<number>("save_file", { path: filePath, content });
+        onSaved(mtime, content);
+        lastErrorRef.current = 0;
+      } catch (err) {
+        const now = Date.now();
+        if (now - lastErrorRef.current > ERROR_THROTTLE_MS) {
+          lastErrorRef.current = now;
+          const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
+          onError(msg || "Autosave failed");
+        }
+      }
+    }, AUTOSAVE_DELAY_MS);
+    return () => window.clearTimeout(id);
+  }, [enabled, filePath, content, originalContent, isReviewActive, onSaved, onError]);
+}

--- a/src/hooks/useExternalChangeWatcher.test.ts
+++ b/src/hooks/useExternalChangeWatcher.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock, type RefObject } from "vitest";
+import { renderHook, cleanup } from "@testing-library/react";
+import { invoke } from "@tauri-apps/api/core";
+import { useExternalChangeWatcher, type UseExternalChangeWatcherOptions } from "./useExternalChangeWatcher";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+// Vitest globals are off, so testing-library's auto-cleanup isn't registered.
+// Unmount each hook manually so its window "focus" listener doesn't leak into
+// the next test (which would fire stale listeners and double-count invoke).
+afterEach(cleanup);
+
+const ref = <T,>(value: T): RefObject<T> => ({ current: value });
+
+function setup(over: Partial<UseExternalChangeWatcherOptions> = {}) {
+  const opts: UseExternalChangeWatcherOptions = {
+    filePathRef: ref<string | null>("C:/doc.md"),
+    contentRef: ref("same"),
+    originalContentRef: ref("same"),
+    knownMtimeRef: ref(100),
+    isReviewActiveRef: ref(false),
+    reload: vi.fn().mockResolvedValue(undefined),
+    onReloaded: vi.fn(),
+    onConflict: vi.fn(),
+    ...over,
+  };
+  renderHook(() => useExternalChangeWatcher(opts));
+  return opts;
+}
+
+// Dispatch a window focus and let the async handler settle.
+async function focus() {
+  window.dispatchEvent(new Event("focus"));
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe("useExternalChangeWatcher", () => {
+  beforeEach(() => (invoke as Mock).mockReset());
+
+  it("reloads silently when the file changed on disk and the buffer is clean", async () => {
+    (invoke as Mock).mockResolvedValue({ modified: 200 });
+    const o = setup();
+    await focus();
+    expect(o.reload).toHaveBeenCalledWith("C:/doc.md");
+    expect(o.onReloaded).toHaveBeenCalled();
+    expect(o.onConflict).not.toHaveBeenCalled();
+    expect(o.knownMtimeRef.current).toBe(200); // advanced so it won't re-fire
+  });
+
+  it("warns instead of reloading when the buffer is dirty", async () => {
+    (invoke as Mock).mockResolvedValue({ modified: 200 });
+    const o = setup({ contentRef: ref("edited"), originalContentRef: ref("same") });
+    await focus();
+    expect(o.onConflict).toHaveBeenCalled();
+    expect(o.reload).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the on-disk mtime is not newer", async () => {
+    (invoke as Mock).mockResolvedValue({ modified: 100 });
+    const o = setup({ knownMtimeRef: ref(100) });
+    await focus();
+    expect(o.reload).not.toHaveBeenCalled();
+    expect(o.onConflict).not.toHaveBeenCalled();
+  });
+
+  it("does not stat while an AI review is pending", async () => {
+    const o = setup({ isReviewActiveRef: ref(true) });
+    await focus();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(o.reload).not.toHaveBeenCalled();
+  });
+
+  it("keeps working after a review-time focus (no stranded in-flight flag)", async () => {
+    // Regression guard: an early return must not leave the `checking` latch set,
+    // which would silently kill detection for the rest of the session.
+    const isReviewActiveRef = ref(true);
+    (invoke as Mock).mockResolvedValue({ modified: 200 });
+    const o = setup({ isReviewActiveRef });
+
+    await focus(); // review active → skipped
+    expect(invoke).not.toHaveBeenCalled();
+
+    isReviewActiveRef.current = false; // review ended
+    await focus(); // must run now
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(o.reload).toHaveBeenCalledWith("C:/doc.md");
+  });
+
+  it("ignores focus when no file is open", async () => {
+    const o = setup({ filePathRef: ref<string | null>(null) });
+    await focus();
+    expect(invoke).not.toHaveBeenCalled();
+    expect(o.reload).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useExternalChangeWatcher.ts
+++ b/src/hooks/useExternalChangeWatcher.ts
@@ -1,0 +1,72 @@
+import { useEffect, type RefObject } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export interface UseExternalChangeWatcherOptions {
+  /** Path of the open file, or null. Read live via ref (listener mounts once). */
+  filePathRef: RefObject<string | null>;
+  /** Live editor content. */
+  contentRef: RefObject<string>;
+  /** Last-persisted content. */
+  originalContentRef: RefObject<string>;
+  /** Known on-disk mtime (ms). Updated in place when a newer mtime is seen. */
+  knownMtimeRef: RefObject<number>;
+  /** True while an AI review is pending — don't reload over a proposed diff. */
+  isReviewActiveRef: RefObject<boolean>;
+  /** Reload the file from disk (used when the buffer is clean). */
+  reload: (path: string) => Promise<void>;
+  /** Called after a silent reload of a clean buffer. */
+  onReloaded: () => void;
+  /** Called when the file changed on disk but the buffer is dirty. */
+  onConflict: () => void;
+}
+
+/**
+ * Detect the open file changing underneath us (sync tools, another editor). On
+ * window focus, stat the file: if it's newer than what we last wrote and the
+ * buffer is clean, reload silently; if the buffer is dirty, warn that saving will
+ * overwrite. EXT-01.
+ *
+ * `reload`/`onReloaded`/`onConflict` should be stable (useCallback); everything
+ * else is read through refs so the focus listener mounts once.
+ */
+export function useExternalChangeWatcher({
+  filePathRef,
+  contentRef,
+  originalContentRef,
+  knownMtimeRef,
+  isReviewActiveRef,
+  reload,
+  onReloaded,
+  onConflict,
+}: UseExternalChangeWatcherOptions): void {
+  useEffect(() => {
+    let checking = false;
+    const checkExternalChange = async () => {
+      const path = filePathRef.current;
+      // Bail before claiming the `checking` slot so an early return can never
+      // strand it set (that would silently kill detection for the session).
+      if (!path || checking || isReviewActiveRef.current) return;
+      checking = true;
+      try {
+        const info = await invoke<{ modified: number }>("get_file_info", { path });
+        const known = knownMtimeRef.current ?? 0;
+        if (known > 0 && info.modified > known) {
+          // Update first so a failed/declined reload doesn't re-toast forever.
+          knownMtimeRef.current = info.modified;
+          if (contentRef.current === originalContentRef.current) {
+            await reload(path);
+            onReloaded();
+          } else {
+            onConflict();
+          }
+        }
+      } catch {
+        /* file gone or stat failed — the save path will surface it */
+      } finally {
+        checking = false;
+      }
+    };
+    window.addEventListener("focus", checkExternalChange);
+    return () => window.removeEventListener("focus", checkExternalChange);
+  }, [filePathRef, contentRef, originalContentRef, knownMtimeRef, isReviewActiveRef, reload, onReloaded, onConflict]);
+}


### PR DESCRIPTION
Moves the two **highest-risk file-session effects** out of the `AppContent` god component into focused, independently-testable hooks — and adds the integration coverage the audit flagged as the top test gap (there was no test around autosave + AI review, where the recent data-loss bug lived). Behaviour-preserving: the inline effects became hook calls with memoised callbacks so timers/listeners aren't reset on unrelated re-renders.

## Hooks (`src/hooks/`)
- **`useAutosave`** — debounced save-after-edit, error throttling, and the AI-review guard (AI-01). Tested: disabled / no-path / clean / **review-active** no-ops, the debounce window, rapid-edit coalescing, and failure throttling.
- **`useExternalChangeWatcher`** — focus-time stat → reload (clean buffer) or warn (dirty), skipped during a review. Tested: reload, conflict, no-op when not newer, review skip, no-file.

## Bug fixed along the way
The inline watcher (as written by my own AI-01 fix) returned on the review guard **after** claiming its in-flight `checking` latch *without releasing it* — so a single window-focus during an AI review silently disabled external-change detection for the rest of the session. The guard now returns **before** the latch is set, and a regression test (`keeps working after a review-time focus`) locks it.

## Impact
- `App.tsx`: 1511 to 1490 lines; the two trickiest effects are now unit-tested.
- `tsc --noEmit` clean and 179 tests pass (13 new).

## Deferred
The broader file-state extraction (`useFileSession` owning `filePath`/`content`/`save`/`load`/dialogs) is a sensible next step — now **de-risked** by this coverage. Kept out of this PR to keep the diff focused and reviewable.