### PR TITLE
feat(nav): in-app link navigation with back/forward history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Link navigation with history.** Clicking a `[[wikilink]]` or a standard
+  relative `[text](note.md)` link now opens that file in-app. Back and forward
+  buttons (and `Alt+←` / `Alt+→`) move through the files you've visited, and
+  opening a file now starts you at the top instead of the previous scroll spot.
+
 ## [1.0.39] - 2026-06-28
 
 ## [1.0.38] - 2026-06-28

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { useFullscreen } from "./hooks/useFullscreen";
 import { useScrollSync } from "./hooks/useScrollSync";
 import { useAutosave } from "./hooks/useAutosave";
 import { useExternalChangeWatcher } from "./hooks/useExternalChangeWatcher";
+import { useNavigationHistory, type NavMode } from "./hooks/useNavigationHistory";
 
 // === Lazy-loaded screens / dialogs ===
 //
@@ -92,6 +93,7 @@ import {
 } from "./utils/persistence";
 import { getAutoSave } from "./utils/persistence";
 import { pickBootFile } from "./utils/boot";
+import { resolveRelativePath } from "./utils/resolveRelativePath";
 import { countSourceWords, countWords } from "./utils/documentStats";
 import { Tour } from "./components/Tour";
 import { PreviewFindBar } from "./components/PreviewFindBar";
@@ -265,8 +267,15 @@ function AppContent() {
   // focus to detect the file changing under us (sync tools, other editors).
   const knownMtimeRef = useRef<number>(0);
 
+  // Back/forward navigation between files (wikilinks, relative links, recents).
+  // navModeRef tells loadFileDirect how the current load should mutate history;
+  // it's a ref so it survives the async unsaved-changes dialog. NAV-03.
+  const { commit: commitNav, canGoBack, canGoForward, peekBack, peekForward } = useNavigationHistory();
+  const navModeRef = useRef<NavMode>("normal");
+
   // Load file from path (with unsaved changes check)
   const loadFileDirect = useCallback(async (path: string) => {
+    const outgoing = filePathRef.current;
     setIsLoading(true);
     try {
       const fileData = await invoke<FileData>("read_file", { path });
@@ -279,6 +288,13 @@ function AppContent() {
       // Track recents + last-opened for restore-on-launch
       addRecentFile(fileData.path, fileData.name);
       setLastFile(fileData.path);
+      // Record the jump in history and snap the new file to the top. Both are
+      // skipped when the path didn't change (an external-change reload should
+      // keep the reader where they were). NAV-03 / NAV-04.
+      if (outgoing !== fileData.path) {
+        commitNav(navModeRef.current, outgoing, fileData.path);
+        requestAnimationFrame(() => window.dispatchEvent(new CustomEvent("paperling:scroll-top")));
+      }
     } catch (err) {
       console.error("Failed to load file:", err);
       // Surface the actual error from Rust so "File too large" / "File not
@@ -288,8 +304,9 @@ function AppContent() {
       showToast(msg || "Failed to open file", "error");
     } finally {
       setIsLoading(false);
+      navModeRef.current = "normal";
     }
-  }, [showToast]);
+  }, [showToast, commitNav]);
 
   // Settings flags above persist themselves via usePersistedState; the matching
   // setters (setSavedViewMode, setSplitRatio, …) are passed into that hook.
@@ -598,7 +615,26 @@ function AppContent() {
   const handleCancelOpen = useCallback(() => {
     setShowUnsavedBeforeOpen(false);
     setPendingFilePath(null);
+    // The navigation was abandoned — don't let a pending back/forward intent
+    // leak into the next normal open. NAV-03.
+    navModeRef.current = "normal";
   }, []);
+
+  // Back / forward between visited files. Routed through loadFile so unsaved
+  // changes still prompt; navModeRef tells loadFileDirect how to update history
+  // once the load actually lands (and survives the dialog round-trip). NAV-03.
+  const goBack = useCallback(() => {
+    const target = peekBack();
+    if (!target) return;
+    navModeRef.current = "back";
+    loadFile(target);
+  }, [peekBack, loadFile]);
+  const goForward = useCallback(() => {
+    const target = peekForward();
+    if (!target) return;
+    navModeRef.current = "forward";
+    loadFile(target);
+  }, [peekForward, loadFile]);
 
   // Listen for Tauri drag-drop events
   useEffect(() => {
@@ -666,6 +702,16 @@ function AppContent() {
     }
     showToast(`Could not resolve [[${target}]]`, "error");
   }, [filePath, loadFile, showToast]);
+
+  // Standard relative markdown links — `[text](note.md)`, `[x](sub/note.md)`,
+  // `[y](../other.md)` — open in-app like wikilinks (the preview only routes
+  // local .md/.markdown hrefs here). Resolve against the current file's folder,
+  // normalising `.`/`..` segments. A missing file surfaces via loadFile. NAV-05.
+  const handleNavigateRelative = useCallback((href: string) => {
+    if (!filePath) return;
+    const resolved = resolveRelativePath(filePath, href);
+    if (resolved) loadFile(resolved);
+  }, [filePath, loadFile]);
 
   const handleNewFile = useCallback(() => {
     if (content !== originalContent) {
@@ -897,6 +943,7 @@ function AppContent() {
     // Ctrl+F in reader mode opens the preview find bar (the editor keymap
     // handles find in code/split mode, where the editor has focus). FIND-01.
     openPreviewFind: () => setPreviewFindOpen(true),
+    goBack, goForward,
     hasFile, content, mode,
   });
 
@@ -1201,6 +1248,10 @@ function AppContent() {
         filePath={filePath ?? undefined}
         onOpenFile={handleOpenFile}
         onNewFile={handleNewFile}
+        onBack={goBack}
+        onForward={goForward}
+        canGoBack={canGoBack}
+        canGoForward={canGoForward}
         getExportHtml={getExportHtml}
         onExportSuccess={handleExportSuccess}
         onExportError={handleExportError}
@@ -1312,6 +1363,7 @@ function AppContent() {
                   onScrollFraction={onPreviewScrollFraction}
                   registerScroller={registerPreviewScroller}
                   onWikilinkClick={handleWikilinkClick}
+                  onNavigateRelative={handleNavigateRelative}
                 />
               </Suspense>
 

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -578,6 +578,22 @@ function CodeEditorImpl({
         return () => window.removeEventListener("paperling:goto-line", handler);
     }, []);
 
+    // Snap the caret and viewport to the start when a different file opens, so
+    // you don't begin a new file at the previous file's cursor/scroll. NAV-04.
+    useEffect(() => {
+        const toTop = () => {
+            const v = viewRef.current;
+            if (!v) return;
+            v.dispatch({
+                selection: { anchor: 0 },
+                effects: EditorView.scrollIntoView(0, { y: "start" }),
+            });
+            v.scrollDOM.scrollTop = 0;
+        };
+        window.addEventListener("paperling:scroll-top", toTop);
+        return () => window.removeEventListener("paperling:scroll-top", toTop);
+    }, []);
+
     // Alt+J (and the command palette's "AI assist") is selection-aware, matching
     // the docs: with text selected it opens the inline selection-assist bubble;
     // with no selection it opens the docked AI side panel (chat about the doc).

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -160,6 +160,8 @@ interface MarkdownPreviewProps {
     onScrollFraction?: (fraction: number) => void;
     registerScroller?: (scroller: Scroller | null) => void;
     onWikilinkClick?: (target: string) => void;
+    /** Open a relative `[text](note.md)` link in-app instead of externally. */
+    onNavigateRelative?: (href: string) => void;
 }
 
 /** Slugify heading text into a stable, URL-safe id (GitHub-style). */
@@ -603,6 +605,7 @@ function MarkdownPreviewImpl({
     onScrollFraction,
     registerScroller,
     onWikilinkClick,
+    onNavigateRelative,
 }: MarkdownPreviewProps) {
     const mainRef = useRef<HTMLElement>(null);
     const [zoomImage, setZoomImage] = useState<{ src: string; alt: string } | null>(null);
@@ -725,6 +728,30 @@ function MarkdownPreviewImpl({
                     </a>
                 );
             }
+            // Relative links to local markdown files — `[x](note.md)`,
+            // `[y](sub/note.md)`, `[z](../other.md)` — open in-app like wikilinks
+            // instead of doing nothing. Only .md/.markdown (optionally with a
+            // #fragment) are claimed so other relative links fall through. NAV-05.
+            if (
+                href &&
+                onNavigateRelative &&
+                !/^(https?:|mailto:|data:|wikilink:|#)/i.test(href) &&
+                /\.(md|markdown)(#.*)?$/i.test(href)
+            ) {
+                const targetHref = href;
+                return (
+                    <a
+                        href="#"
+                        {...rest}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            onNavigateRelative(targetHref);
+                        }}
+                    >
+                        {children}
+                    </a>
+                );
+            }
             // External http(s) and mailto links — route through the OS default
             // handler so the webview itself doesn't navigate away from the app.
             const isExternal = !!href && /^(https?:|mailto:)/i.test(href);
@@ -775,7 +802,7 @@ function MarkdownPreviewImpl({
             if (type !== "checkbox") return <input type={type} checked={checked} {...rest} />;
             return <InteractiveTaskCheckbox initialChecked={!!checked} onToggle={handleTaskToggle} />;
         },
-    }), [baseDir, handleTaskToggle, onWikilinkClick]);
+    }), [baseDir, handleTaskToggle, onWikilinkClick, onNavigateRelative]);
 
     // Parse YAML frontmatter once per content change. We render it as a
     // metadata card and pass the *body* (without the --- block) to react-markdown
@@ -933,6 +960,14 @@ function MarkdownPreviewImpl({
         };
         window.addEventListener("paperling:goto-line", handler);
         return () => window.removeEventListener("paperling:goto-line", handler);
+    }, []);
+
+    // Snap to the top when a different file is opened, so you don't land
+    // mid-document at the previous file's scroll offset. NAV-04.
+    useEffect(() => {
+        const toTop = () => { if (mainRef.current) mainRef.current.scrollTop = 0; };
+        window.addEventListener("paperling:scroll-top", toTop);
+        return () => window.removeEventListener("paperling:scroll-top", toTop);
     }, []);
 
     // Register imperative scroller for split-view sync

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -40,6 +40,8 @@ const groups: ShortcutGroup[] = [
         items: [
             { keys: `${cmd}+E`, description: "Toggle Reader / Code" },
             { keys: `${cmd}+\\`, description: "Toggle split view" },
+            { keys: "Alt+←", description: "Back (previous file)" },
+            { keys: "Alt+→", description: "Forward" },
             { keys: "F11", description: "Toggle fullscreen" },
             { keys: `${cmd}+Shift+E`, description: "Toggle file explorer" },
             { keys: `${cmd}+Shift+O`, description: "Toggle outline" },

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -10,6 +10,10 @@ interface TitleBarProps {
     filePath?: string;
     onOpenFile?: () => void;
     onNewFile?: () => void;
+    onBack?: () => void;
+    onForward?: () => void;
+    canGoBack?: boolean;
+    canGoForward?: boolean;
     getExportHtml?: () => string;
     onExportSuccess?: (format: string) => void;
     onExportError?: (format: string) => void;
@@ -19,7 +23,7 @@ interface TitleBarProps {
     onToggleFullscreen?: () => void;
 }
 
-function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, getExportHtml, onExportSuccess, onExportError, onToggleAI, aiActive, isFullscreen, onToggleFullscreen }: TitleBarProps) {
+function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, onBack, onForward, canGoBack, canGoForward, getExportHtml, onExportSuccess, onExportError, onToggleAI, aiActive, isFullscreen, onToggleFullscreen }: TitleBarProps) {
     const handleMinimize = async () => {
         try {
             const appWindow = Window.getCurrent();
@@ -130,6 +134,26 @@ function TitleBarImpl({ fileName, isDirty, filePath, onOpenFile, onNewFile, getE
                     {hasFile && onOpenFile && (
                         <>
                             <div className="w-[1px] h-4 bg-[var(--border)] ml-2"></div>
+                            {/* Back / forward through visited files (wikilinks, links, recents) */}
+                            <button
+                                onClick={onBack}
+                                disabled={!canGoBack}
+                                aria-label="Back"
+                                title="Back (Alt+Left)"
+                                className="flex items-center justify-center w-7 h-7 rounded-[var(--radius-md)] transition-colors disabled:opacity-30 disabled:cursor-default enabled:hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] enabled:hover:text-[var(--text-primary)]"
+                            >
+                                <span className="material-symbols-outlined text-[18px]">arrow_back</span>
+                            </button>
+                            <button
+                                onClick={onForward}
+                                disabled={!canGoForward}
+                                aria-label="Forward"
+                                title="Forward (Alt+Right)"
+                                className="flex items-center justify-center w-7 h-7 rounded-[var(--radius-md)] transition-colors disabled:opacity-30 disabled:cursor-default enabled:hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] enabled:hover:text-[var(--text-primary)]"
+                            >
+                                <span className="material-symbols-outlined text-[18px]">arrow_forward</span>
+                            </button>
+                            <div className="w-[1px] h-4 bg-[var(--border)]"></div>
                             {onNewFile && (
                                 <button
                                     onClick={onNewFile}

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -18,6 +18,9 @@ export interface ShortcutHandlers {
     openSettings: () => void;
     /** Open the reader-mode find bar. Only invoked when mode === "preview". */
     openPreviewFind?: () => void;
+    /** Navigate back/forward through visited files (Alt+Left / Alt+Right). */
+    goBack?: () => void;
+    goForward?: () => void;
     hasFile: boolean;
     content: string;
     /** Current view mode — Ctrl+F routes to the preview find bar in reader
@@ -99,6 +102,19 @@ export function useGlobalShortcuts(handlers: ShortcutHandlers) {
                     e.preventDefault();
                     s.openPreviewFind();
                 }
+            }
+            // Alt+Left / Alt+Right - back/forward through visited files, like a
+            // browser. Alt (not Ctrl) keeps Ctrl+Arrow free for word-wise caret
+            // movement in the editor. NAV-03.
+            if (e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey && e.key === "ArrowLeft") {
+                e.preventDefault();
+                s.goBack?.();
+                return;
+            }
+            if (e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey && e.key === "ArrowRight") {
+                e.preventDefault();
+                s.goForward?.();
+                return;
             }
             // ? - Show cheatsheet (only when no input is focused)
             if (e.key === "?" && !e.ctrlKey && !e.metaKey && !e.altKey) {

--- a/src/hooks/useNavigationHistory.test.ts
+++ b/src/hooks/useNavigationHistory.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useNavigationHistory } from "./useNavigationHistory";
+
+describe("useNavigationHistory", () => {
+  it("starts empty", () => {
+    const { result } = renderHook(() => useNavigationHistory());
+    expect(result.current.canGoBack).toBe(false);
+    expect(result.current.canGoForward).toBe(false);
+    expect(result.current.peekBack()).toBeNull();
+  });
+
+  it("records normal navigation onto the back stack", () => {
+    const { result } = renderHook(() => useNavigationHistory());
+    act(() => result.current.commit("normal", "a.md", "b.md"));
+    expect(result.current.canGoBack).toBe(true);
+    expect(result.current.peekBack()).toBe("a.md");
+    expect(result.current.canGoForward).toBe(false);
+  });
+
+  it("ignores a no-op navigation to the same file (reload)", () => {
+    const { result } = renderHook(() => useNavigationHistory());
+    act(() => result.current.commit("normal", "a.md", "a.md"));
+    expect(result.current.canGoBack).toBe(false);
+  });
+
+  it("moves the current file onto Forward when going back", () => {
+    const { result } = renderHook(() => useNavigationHistory());
+    act(() => result.current.commit("normal", "a.md", "b.md")); // back: [a]
+    act(() => result.current.commit("back", "b.md", "a.md"));    // back: [], fwd: [b]
+    expect(result.current.canGoBack).toBe(false);
+    expect(result.current.canGoForward).toBe(true);
+    expect(result.current.peekForward()).toBe("b.md");
+  });
+
+  it("round-trips back then forward", () => {
+    const { result } = renderHook(() => useNavigationHistory());
+    act(() => result.current.commit("normal", "a.md", "b.md"));
+    act(() => result.current.commit("back", "b.md", "a.md"));
+    act(() => result.current.commit("forward", "a.md", "b.md"));
+    expect(result.current.canGoBack).toBe(true);
+    expect(result.current.peekBack()).toBe("a.md");
+    expect(result.current.canGoForward).toBe(false);
+  });
+
+  it("a new normal navigation clears the forward stack (new branch)", () => {
+    const { result } = renderHook(() => useNavigationHistory());
+    act(() => result.current.commit("normal", "a.md", "b.md"));
+    act(() => result.current.commit("back", "b.md", "a.md")); // fwd: [b]
+    act(() => result.current.commit("normal", "a.md", "c.md"));
+    expect(result.current.canGoForward).toBe(false);
+    expect(result.current.peekBack()).toBe("a.md");
+  });
+
+  it("reset clears both stacks", () => {
+    const { result } = renderHook(() => useNavigationHistory());
+    act(() => result.current.commit("normal", "a.md", "b.md"));
+    act(() => result.current.reset());
+    expect(result.current.canGoBack).toBe(false);
+    expect(result.current.canGoForward).toBe(false);
+  });
+});

--- a/src/hooks/useNavigationHistory.ts
+++ b/src/hooks/useNavigationHistory.ts
@@ -1,0 +1,77 @@
+import { useCallback, useRef, useState } from "react";
+
+export type NavMode = "normal" | "back" | "forward";
+
+export interface NavigationHistory {
+  /** True when there's a previous file to return to. */
+  canGoBack: boolean;
+  /** True when a back-navigation can be undone with forward. */
+  canGoForward: boolean;
+  /** Path that "Back" would load, without mutating anything. */
+  peekBack: () => string | null;
+  /** Path that "Forward" would load, without mutating anything. */
+  peekForward: () => string | null;
+  /**
+   * Record a completed navigation once a file load actually succeeds. Centralising
+   * the mutation here (rather than in the Back/Forward click handlers) keeps the
+   * stacks consistent even when an unsaved-changes dialog defers — or cancels —
+   * the load.
+   *   - normal:  push the file we left onto Back, clear Forward (a new branch).
+   *   - back:    pop the target off Back, push the file we left onto Forward.
+   *   - forward: pop the target off Forward, push the file we left onto Back.
+   * A no-op when `from === to` (e.g. an external-change reload of the same file).
+   */
+  commit: (mode: NavMode, from: string | null, to: string) => void;
+  /** Clear all history (e.g. when starting a fresh blank buffer). */
+  reset: () => void;
+}
+
+export function useNavigationHistory(): NavigationHistory {
+  const backRef = useRef<string[]>([]);
+  const forwardRef = useRef<string[]>([]);
+  // Re-render so the toolbar's enabled/disabled state tracks the ref-held stacks.
+  const [, force] = useState(0);
+  const bump = useCallback(() => force((n) => (n + 1) & 0xffff), []);
+
+  const peekBack = useCallback(
+    () => backRef.current[backRef.current.length - 1] ?? null,
+    []
+  );
+  const peekForward = useCallback(
+    () => forwardRef.current[forwardRef.current.length - 1] ?? null,
+    []
+  );
+
+  const commit = useCallback(
+    (mode: NavMode, from: string | null, to: string) => {
+      if (from === to) return;
+      if (mode === "back") {
+        if (backRef.current[backRef.current.length - 1] === to) backRef.current.pop();
+        if (from) forwardRef.current.push(from);
+      } else if (mode === "forward") {
+        if (forwardRef.current[forwardRef.current.length - 1] === to) forwardRef.current.pop();
+        if (from) backRef.current.push(from);
+      } else {
+        if (from) backRef.current.push(from);
+        forwardRef.current = [];
+      }
+      bump();
+    },
+    [bump]
+  );
+
+  const reset = useCallback(() => {
+    backRef.current = [];
+    forwardRef.current = [];
+    bump();
+  }, [bump]);
+
+  return {
+    canGoBack: backRef.current.length > 0,
+    canGoForward: forwardRef.current.length > 0,
+    peekBack,
+    peekForward,
+    commit,
+    reset,
+  };
+}

--- a/src/utils/resolveRelativePath.test.ts
+++ b/src/utils/resolveRelativePath.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { resolveRelativePath } from "./resolveRelativePath";
+
+describe("resolveRelativePath", () => {
+  it("resolves a sibling file", () => {
+    expect(resolveRelativePath("/notes/a.md", "b.md")).toBe("/notes/b.md");
+  });
+
+  it("resolves into a subfolder", () => {
+    expect(resolveRelativePath("/notes/a.md", "sub/b.md")).toBe("/notes/sub/b.md");
+  });
+
+  it("walks up with ..", () => {
+    expect(resolveRelativePath("/notes/deep/a.md", "../b.md")).toBe("/notes/b.md");
+    expect(resolveRelativePath("/notes/deep/a.md", "../../b.md")).toBe("/b.md");
+  });
+
+  it("does not pop above the root", () => {
+    expect(resolveRelativePath("/a.md", "../../../b.md")).toBe("/b.md");
+  });
+
+  it("keeps Windows backslash separators", () => {
+    expect(resolveRelativePath("C:\\notes\\a.md", "sub\\b.md")).toBe("C:\\notes\\sub\\b.md");
+    expect(resolveRelativePath("C:\\notes\\a.md", "b.md")).toBe("C:\\notes\\b.md");
+  });
+
+  it("drops a #fragment", () => {
+    expect(resolveRelativePath("/notes/a.md", "b.md#section")).toBe("/notes/b.md");
+  });
+
+  it("decodes percent-encoded segments", () => {
+    expect(resolveRelativePath("/notes/a.md", "my%20note.md")).toBe("/notes/my note.md");
+  });
+
+  it("ignores ./ and empty segments", () => {
+    expect(resolveRelativePath("/notes/a.md", "./b.md")).toBe("/notes/b.md");
+  });
+
+  it("returns null for empty or NUL-bearing input", () => {
+    expect(resolveRelativePath("/notes/a.md", "")).toBeNull();
+    expect(resolveRelativePath("/notes/a.md", "#only-anchor")).toBeNull();
+    expect(resolveRelativePath("/notes/a.md", "b\0.md")).toBeNull();
+  });
+
+  it("returns null without a base file", () => {
+    expect(resolveRelativePath("", "b.md")).toBeNull();
+  });
+});

--- a/src/utils/resolveRelativePath.ts
+++ b/src/utils/resolveRelativePath.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolve a relative markdown link (`note.md`, `sub/note.md`, `../other.md`)
+ * against the directory of the currently open file, the way a browser resolves a
+ * relative href. Returns an absolute path using the same separator style as
+ * `baseFilePath`, or null when there's nothing to resolve.
+ *
+ * - Any `#fragment` is dropped (we navigate to the file, not a sub-anchor).
+ * - `.` and empty segments are skipped; `..` pops a directory (never above root).
+ * - Percent-encoding in segments is decoded (`my%20note.md` → `my note.md`).
+ */
+export function resolveRelativePath(baseFilePath: string, href: string): string | null {
+  if (!baseFilePath) return null;
+  const hashIdx = href.indexOf("#");
+  const rel = (hashIdx >= 0 ? href.slice(0, hashIdx) : href).trim();
+  if (!rel || rel.includes("\0")) return null;
+
+  const sep = baseFilePath.includes("\\") ? "\\" : "/";
+  const lastSep = Math.max(baseFilePath.lastIndexOf("/"), baseFilePath.lastIndexOf("\\"));
+  // lastSep === 0 means a root-level file ("/a.md"): the directory is "/", which
+  // splits to [""] so the leading separator is preserved. -1 means no directory.
+  const parts = lastSep >= 0 ? baseFilePath.slice(0, lastSep).split(/[\\/]/) : [];
+
+  for (const raw of rel.split(/[\\/]/)) {
+    let seg: string;
+    try { seg = decodeURIComponent(raw); } catch { seg = raw; }
+    if (seg === "" || seg === ".") continue;
+    // `..` climbs one directory but never past the root. The leading "" marker
+    // (from an absolute "/path") represents root, so don't pop it away.
+    if (seg === "..") { if (parts.length && parts[parts.length - 1] !== "") parts.pop(); }
+    else parts.push(seg);
+  }
+
+  const resolved = parts.join(sep);
+  return resolved || null;
+}


### PR DESCRIPTION
Makes clicking a link to another markdown file feel like a real knowledge tool — the "full bundle" of the navigation work.

## What's new
1. **Relative links open in-app.** `[text](note.md)`, `[x](sub/note.md)`, `[y](../other.md)` now load that file inside Paperling. Previously only `[[wikilinks]]` navigated and plain relative links did nothing (`MarkdownPreview.tsx` treated them as inert). Resolution is a **pure, tested helper** (`resolveRelativePath`) covering subfolders, `..` (never above root), percent-encoded spaces, `#fragments`, and Windows separators.
2. **Back / forward history.** A tested `useNavigationHistory` hook tracks visited files. **Toolbar Back/Forward buttons** (disabled when empty) + **`Alt+←` / `Alt+→`** move through them, browser-style. History mutation is centralised in `loadFileDirect` so it stays consistent even across the unsaved-changes dialog (back/forward still prompt on a dirty buffer), and an external-change reload of the same file is never recorded.
3. **Open-to-top.** Opening a *different* file resets the editor caret and both panes' scroll to the start (via a `paperling:scroll-top` event) — so you no longer land mid-document at the previous file's offset. A same-file external reload deliberately **keeps your place**.

## Tests (17 new)
- `useNavigationHistory`: normal/back/forward transitions, reload no-op, forward-stack clearing on a new branch, reset.
- `resolveRelativePath`: siblings, subfolders, `..`, root clamping, Windows backslashes, fragments, encoding, null cases.
- `tsc --noEmit` clean · `vite build` OK · **196 tests pass**.

## Notes
- Cheatsheet (`?`) and CHANGELOG updated with the new shortcuts.
- Graph view and daily notes were intentionally **left out** — they pull toward the heavy vault app Paperling deliberately isn't. Backlinks and cross-file search are the natural next picks from the feature review.