### PR TITLE
feat(nav): [[ autocomplete and create-missing notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`[[` autocomplete.** Typing `[[` in the editor now suggests the other
+  markdown files in the folder, so linking is a couple of keystrokes.
+- **Create missing notes.** Clicking a `[[link]]` or relative link to a file
+  that doesn't exist yet offers to create it and opens the new note.
+
 ## [1.0.40] - 2026-06-28
 
 ### Added

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo, lazy, Suspense } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { open, save } from "@tauri-apps/plugin-dialog";
+import { open, save, ask } from "@tauri-apps/plugin-dialog";
 import { listen, TauriEvent } from "@tauri-apps/api/event";
 import { Window } from "@tauri-apps/api/window";
 
@@ -664,6 +664,23 @@ function AppContent() {
     };
   }, [loadFile]);
 
+  // Offer to create a note that a link points at but doesn't exist yet, then
+  // open it. Used by both wikilinks and relative links. NAV-07.
+  const offerCreateNote = useCallback(async (path: string, displayName: string) => {
+    const confirmed = await ask(`"${displayName}" doesn't exist yet. Create it?`, {
+      title: "Create note",
+      kind: "info",
+    });
+    if (!confirmed) return;
+    try {
+      await invoke<number>("save_file", { path, content: "" });
+      await loadFile(path);
+    } catch (err) {
+      const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
+      showToast(msg || "Could not create note", "error");
+    }
+  }, [loadFile, showToast]);
+
   // Wikilink click: resolve target relative to the current file's folder.
   // Tries `<target>.md` first, then `<target>` literal. Silently fails if neither exists.
   // SECURITY: rejects path-traversal and absolute paths so a crafted document
@@ -700,18 +717,29 @@ function AppContent() {
         return;
       } catch {/* try next */}
     }
-    showToast(`Could not resolve [[${target}]]`, "error");
-  }, [filePath, loadFile, showToast]);
+    // Nothing matched — offer to create the note next to the current file, the
+    // way Obsidian turns a dangling [[link]] into a new file. NAV-07.
+    offerCreateNote(`${dir}${sep}${cleaned}.md`, `${cleaned}.md`);
+  }, [filePath, loadFile, showToast, offerCreateNote]);
 
   // Standard relative markdown links — `[text](note.md)`, `[x](sub/note.md)`,
   // `[y](../other.md)` — open in-app like wikilinks (the preview only routes
   // local .md/.markdown hrefs here). Resolve against the current file's folder,
   // normalising `.`/`..` segments. A missing file surfaces via loadFile. NAV-05.
-  const handleNavigateRelative = useCallback((href: string) => {
+  const handleNavigateRelative = useCallback(async (href: string) => {
     if (!filePath) return;
     const resolved = resolveRelativePath(filePath, href);
-    if (resolved) loadFile(resolved);
-  }, [filePath, loadFile]);
+    if (!resolved) return;
+    try {
+      // Probe first so a link to a not-yet-created note offers creation rather
+      // than flashing a "failed to open" error. NAV-07.
+      await invoke("get_file_info", { path: resolved });
+      loadFile(resolved);
+    } catch {
+      const name = resolved.replace(/\\/g, "/").split("/").pop() || resolved;
+      offerCreateNote(resolved, name);
+    }
+  }, [filePath, loadFile, offerCreateNote]);
 
   const handleNewFile = useCallback(() => {
     if (content !== originalContent) {

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -13,7 +13,7 @@ import {
 import { history, defaultKeymap, historyKeymap } from "@codemirror/commands";
 import { markdown } from "@codemirror/lang-markdown";
 import { syntaxHighlighting, HighlightStyle } from "@codemirror/language";
-import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
+import { autocompletion, closeBrackets, closeBracketsKeymap, type CompletionContext, type CompletionResult, type Completion } from "@codemirror/autocomplete";
 import { unifiedMergeView, getChunks, getOriginalDoc } from "@codemirror/merge";
 import { tags as t } from "@lezer/highlight";
 import { getImageFromClipboard, saveImageToFile, createMarkdownImage } from "../utils/imageUtils";
@@ -32,6 +32,8 @@ import { AIBubble } from "./AIBubble";
 import { TableToolbar } from "./TableToolbar";
 import { pasteUrlOnSelection, pasteUrlAutolink, pasteTsvAsTable, htmlToMarkdown } from "../utils/smartPaste";
 import { getAIEnabled } from "../utils/persistence";
+import { invoke } from "@tauri-apps/api/core";
+import { matchWikilinkPrefix, rankFileNames, toWikiName } from "../utils/wikilinkComplete";
 import { applyTableOp, findTableAt, locateCell, type Align } from "../utils/tableModel";
 import type { Scroller } from "../utils/scrollSync";
 
@@ -178,6 +180,9 @@ function CodeEditorImpl({
     const onErrorRef = useRef(onError); onErrorRef.current = onError;
     const onNoticeRef = useRef(onNotice); onNoticeRef.current = onNotice;
     const filePathRef = useRef(filePath); filePathRef.current = filePath;
+    // Base names (without .md) of the sibling files, for `[[` autocomplete. Kept
+    // in a ref so the once-created completion source always sees the latest list.
+    const wikiNamesRef = useRef<string[]>([]);
     const aiConfigRef = useRef(aiConfig); aiConfigRef.current = aiConfig;
     const typewriterRef = useRef(typewriterMode); typewriterRef.current = typewriterMode;
     const slashStateRef = useRef(slashState); slashStateRef.current = slashState;
@@ -195,6 +200,60 @@ function CodeEditorImpl({
     const reviewingRef = useRef(false);
     const reviewOriginalRef = useRef("");
     const lastReviewRef = useRef<string | null>(null);
+
+    // `[[` autocomplete: when the caret is inside an open wikilink target, offer
+    // the folder's other markdown files. Reads wikiNamesRef (refreshed below) so
+    // the once-created editor always sees the current list. NAV-06.
+    const wikiCompletionSource = useCallback((context: CompletionContext): CompletionResult | null => {
+        const line = context.state.doc.lineAt(context.pos);
+        const textBefore = line.text.slice(0, context.pos - line.from);
+        const m = matchWikilinkPrefix(textBefore);
+        if (!m) return null;
+        const names = rankFileNames(wikiNamesRef.current, m.query);
+        if (names.length === 0) return null;
+        const from = line.from + m.from;
+        // closeBrackets usually inserts `]]` already; only add it if it's missing.
+        const hasClose = context.state.doc.sliceString(context.pos, context.pos + 2) === "]]";
+        const options: Completion[] = names.map((name) => ({
+            label: name,
+            type: "text",
+            apply: (view: EditorView, _c: Completion, fromPos: number, toPos: number) => {
+                const insert = hasClose ? name : `${name}]]`;
+                view.dispatch({
+                    changes: { from: fromPos, to: toPos, insert },
+                    // Land the caret just past the closing `]]`.
+                    selection: { anchor: fromPos + name.length + 2 },
+                });
+            },
+        }));
+        return { from, options, validFor: /^[^\]\n|]*$/ };
+    }, []);
+
+    // Refresh the sibling-file list for `[[` autocomplete when the open file (and
+    // thus its folder) changes, and when the window regains focus (files may have
+    // been added/removed elsewhere). Excludes the open file itself.
+    useEffect(() => {
+        let cancelled = false;
+        const fp = filePath;
+        const norm = fp ? fp.replace(/\\/g, "/") : "";
+        const lastSlash = norm.lastIndexOf("/");
+        const dir = fp && lastSlash > 0 ? fp.slice(0, lastSlash) : null;
+        if (!dir) { wikiNamesRef.current = []; return; }
+        const load = () => {
+            invoke<{ name: string; path: string }[]>("list_directory_files", { directory: dir })
+                .then((entries) => {
+                    if (cancelled) return;
+                    wikiNamesRef.current = entries
+                        .filter((e) => e.path !== fp)
+                        .map((e) => toWikiName(e.name))
+                        .filter(Boolean);
+                })
+                .catch(() => { if (!cancelled) wikiNamesRef.current = []; });
+        };
+        load();
+        window.addEventListener("focus", load);
+        return () => { cancelled = true; window.removeEventListener("focus", load); };
+    }, [filePath]);
 
     const openAIBubble = useCallback(() => {
         const view = viewRef.current;
@@ -302,6 +361,7 @@ function CodeEditorImpl({
                     drawSelection(),
                     dropCursor(),
                     closeBrackets(),
+                    autocompletion({ override: [wikiCompletionSource], icons: false, aboveCursor: false }),
                     markdown(),
                     syntaxHighlighting(markdownHighlight),
                     editorTheme,

--- a/src/utils/wikilinkComplete.test.ts
+++ b/src/utils/wikilinkComplete.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { matchWikilinkPrefix, rankFileNames, toWikiName } from "./wikilinkComplete";
+
+describe("matchWikilinkPrefix", () => {
+  it("matches an open [[ with the typed query", () => {
+    expect(matchWikilinkPrefix("see [[Foo")).toEqual({ from: 6, query: "Foo" });
+  });
+
+  it("matches an empty target right after [[", () => {
+    expect(matchWikilinkPrefix("text [[")).toEqual({ from: 7, query: "" });
+  });
+
+  it("returns null when there is no open [[", () => {
+    expect(matchWikilinkPrefix("just some text")).toBeNull();
+    expect(matchWikilinkPrefix("a [ single bracket")).toBeNull();
+  });
+
+  it("returns null once the link is closed", () => {
+    expect(matchWikilinkPrefix("[[Foo]] and more")).toBeNull();
+  });
+
+  it("does not match across a ] or newline", () => {
+    expect(matchWikilinkPrefix("[[Foo] bar")).toBeNull();
+  });
+
+  it("stops completing once an alias pipe is typed", () => {
+    expect(matchWikilinkPrefix("[[Foo|al")).toBeNull();
+  });
+
+  it("uses the last open [[ on the line", () => {
+    expect(matchWikilinkPrefix("[[Done]] then [[Bar")).toEqual({ from: 16, query: "Bar" });
+  });
+});
+
+describe("rankFileNames", () => {
+  const names = ["Index", "Inbox", "Project Ideas", "ideas-archive", "Notes"];
+
+  it("returns everything for an empty query", () => {
+    expect(rankFileNames(names, "")).toHaveLength(5);
+  });
+
+  it("filters case-insensitively by substring", () => {
+    expect(rankFileNames(names, "idea")).toEqual(["ideas-archive", "Project Ideas"]);
+  });
+
+  it("ranks prefix matches above mid-string matches", () => {
+    const r = rankFileNames(["my-inbox", "Inbox"], "inbox");
+    expect(r[0]).toBe("Inbox"); // prefix beats mid-string
+  });
+
+  it("respects the limit", () => {
+    const many = Array.from({ length: 100 }, (_, i) => `note-${i}`);
+    expect(rankFileNames(many, "note", 10)).toHaveLength(10);
+  });
+
+  it("returns nothing when nothing matches", () => {
+    expect(rankFileNames(names, "zzz")).toEqual([]);
+  });
+});
+
+describe("toWikiName", () => {
+  it("strips .md and .markdown", () => {
+    expect(toWikiName("Foo.md")).toBe("Foo");
+    expect(toWikiName("Bar.markdown")).toBe("Bar");
+    expect(toWikiName("no-ext")).toBe("no-ext");
+  });
+});

--- a/src/utils/wikilinkComplete.ts
+++ b/src/utils/wikilinkComplete.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure helpers for `[[wikilink]]` autocomplete. Kept out of the editor so the
+ * matching and ranking can be unit-tested without a CodeMirror instance.
+ */
+
+/**
+ * Detect an open `[[` immediately before the cursor on the current line.
+ * Returns the offset (within `textBefore`) where the link target starts and the
+ * text typed so far, or null when the cursor isn't inside a wikilink target.
+ *
+ * Returns null once a `|` is typed (that's the alias, not a file to complete)
+ * and never matches across a `]` or newline.
+ */
+export function matchWikilinkPrefix(textBefore: string): { from: number; query: string } | null {
+  const m = /\[\[([^\]\n]*)$/.exec(textBefore);
+  if (!m) return null;
+  const query = m[1];
+  if (query.includes("|")) return null; // completing the alias, not the target
+  return { from: m.index + 2, query };
+}
+
+/**
+ * Filter and rank candidate file names against a query. Prefix matches rank
+ * above mid-string matches; ties break by match position, then length, then
+ * alphabetically. An empty query returns everything (capped), so just typing
+ * `[[` lists the folder.
+ */
+export function rankFileNames(names: string[], query: string, limit = 50): string[] {
+  const q = query.toLowerCase();
+  const scored: { name: string; rank: number; idx: number; len: number }[] = [];
+  for (const name of names) {
+    const idx = name.toLowerCase().indexOf(q);
+    if (q && idx === -1) continue;
+    scored.push({ name, rank: q === "" || idx === 0 ? 0 : 1, idx: idx < 0 ? 0 : idx, len: name.length });
+  }
+  scored.sort(
+    (a, b) => a.rank - b.rank || a.idx - b.idx || a.len - b.len || a.name.localeCompare(b.name)
+  );
+  return scored.slice(0, limit).map((s) => s.name);
+}
+
+/** Strip a trailing .md / .markdown extension for display as a wikilink target. */
+export function toWikiName(fileName: string): string {
+  return fileName.replace(/\.(md|markdown)$/i, "");
+}


### PR DESCRIPTION
Two delighters that build directly on the in-app link navigation shipped in #81.

## `[[` autocomplete
Typing `[[` in the editor now pops a dropdown of the **other markdown files in the folder**. Selecting one inserts `[[name]]` and lands the caret past the closing brackets. Implemented as a CodeMirror completion source over the existing `list_directory_files` command; the list refreshes on file-change and window-focus and excludes the open file. The match-prefix + rank logic lives in a pure, tested helper (`wikilinkComplete.ts`).

## Create-missing notes
Clicking a `[[link]]` — or a relative `[text](note.md)` — whose target **doesn't exist yet** now asks whether to create it (Tauri confirm dialog), writes an empty file, and opens it. Previously this was a dead-end "could not resolve" toast. This is the Obsidian behavior where a dangling link becomes a new note.

## Tests
- `wikilinkComplete`: prefix matching (open `[[`, closed link, `]`/newline boundaries, alias pipe, last-on-line) and ranking (empty query, substring filter, prefix-beats-midstring, limit, no-match).
- `tsc --noEmit` clean · `vite build` OK · **209 tests pass** (13 new).

First of three: cross-file search and multiple tabs follow in their own PRs.