### PR TITLE
feat(search): search across all files in the folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Search across files** (`Ctrl+Shift+F`). Search the text of every markdown
+  file in the current folder, grouped by file with line numbers; pick a result
+  to jump straight to that line. Also in the command palette.
 - **`[[` autocomplete.** Typing `[[` in the editor now suggests the other
   markdown files in the folder, so linking is a couple of keystrokes.
 - **Create missing notes.** Clicking a `[[link]]` or relative link to a file

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "paperling"
-version = "1.0.24"
+version = "1.0.40"
 dependencies = [
  "keyring",
  "serde",
@@ -2930,6 +2930,8 @@ dependencies = [
  "tauri-plugin-updater",
  "thiserror 2.0.18",
  "tokio",
+ "webview2-com",
+ "windows",
 ]
 
 [[package]]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -238,8 +238,159 @@ pub async fn list_directory_files(directory: String) -> Result<Vec<FileEntry>, C
     
     // Sort alphabetically, case-insensitively.
     entries.sort_by_key(|a| a.name.to_lowercase());
-    
+
     Ok(entries)
+}
+
+/// A single matching line within a file.
+#[derive(Debug, Serialize)]
+pub struct SearchMatch {
+    /// 1-based line number.
+    pub line: u32,
+    /// The trimmed (and possibly truncated) line text.
+    pub text: String,
+}
+
+/// All matches for one file.
+#[derive(Debug, Serialize)]
+pub struct FileSearchResult {
+    pub path: String,
+    pub name: String,
+    pub matches: Vec<SearchMatch>,
+}
+
+// Bounds so a search over a huge or pathological folder stays responsive and
+// can't balloon webview memory. Hit caps degrade gracefully (partial results).
+const SEARCH_MAX_FILES: usize = 5000; // markdown files scanned
+const SEARCH_MAX_RESULTS: usize = 300; // files returned with at least one match
+const SEARCH_MAX_MATCHES_PER_FILE: usize = 50;
+const SEARCH_MAX_FILE_BYTES: u64 = 5 * 1024 * 1024; // skip very large files
+const SEARCH_SNIPPET_CHARS: usize = 240; // truncate long matching lines
+
+/// Search the text of every markdown file under `directory` (recursively) for
+/// `query`. Case-insensitive unless `case_sensitive`. Returns per-file matches
+/// with 1-based line numbers so the UI can jump straight to a hit. Skips hidden
+/// directories plus `node_modules` / `target`, and is bounded by the caps above.
+#[tauri::command]
+pub async fn search_files(
+    directory: String,
+    query: String,
+    case_sensitive: bool,
+) -> Result<Vec<FileSearchResult>, CommandError> {
+    let q = query.trim().to_string();
+    if q.is_empty() {
+        return Ok(Vec::new());
+    }
+    let root = PathBuf::from(&directory);
+    if !root.is_dir() {
+        return Err(CommandError::FileNotFound(directory));
+    }
+
+    // The walk is blocking I/O; keep it off the async runtime's worker threads.
+    tokio::task::spawn_blocking(move || Ok(search_markdown_tree(root, &q, case_sensitive)))
+        .await
+        .map_err(|e| CommandError::ReadError(e.to_string()))?
+}
+
+/// Synchronous, bounded recursive search used by `search_files`. Pulled out so
+/// it can be unit-tested without a Tauri/async harness. `query` is assumed
+/// non-empty and already trimmed.
+fn search_markdown_tree(root: PathBuf, query: &str, case_sensitive: bool) -> Vec<FileSearchResult> {
+    let needle = if case_sensitive { query.to_string() } else { query.to_lowercase() };
+    let mut results: Vec<FileSearchResult> = Vec::new();
+    let mut files_scanned = 0usize;
+    let mut stack = vec![root];
+
+    while let Some(dir) = stack.pop() {
+        if results.len() >= SEARCH_MAX_RESULTS || files_scanned >= SEARCH_MAX_FILES {
+            break;
+        }
+        let read_dir = match std::fs::read_dir(&dir) {
+            Ok(r) => r,
+            Err(_) => continue, // unreadable dir — skip, don't fail the whole search
+        };
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            if file_type.is_dir() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if name.starts_with('.') || name == "node_modules" || name == "target" {
+                        continue;
+                    }
+                }
+                stack.push(path);
+                continue;
+            }
+            let is_md = path
+                .extension()
+                .map(|e| e == "md" || e == "markdown")
+                .unwrap_or(false);
+            if !is_md {
+                continue;
+            }
+            files_scanned += 1;
+            if files_scanned > SEARCH_MAX_FILES {
+                break;
+            }
+            if let Ok(meta) = entry.metadata() {
+                if meta.len() > SEARCH_MAX_FILE_BYTES {
+                    continue;
+                }
+            }
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(_) => continue, // binary / non-UTF8 — skip
+            };
+            let mut matches = Vec::new();
+            for (i, line) in content.lines().enumerate() {
+                let haystack = if case_sensitive {
+                    line.to_string()
+                } else {
+                    line.to_lowercase()
+                };
+                if haystack.contains(&needle) {
+                    let trimmed = line.trim();
+                    // Char-boundary-safe truncation (byte slicing could panic on
+                    // multibyte UTF-8).
+                    let text = if trimmed.chars().count() > SEARCH_SNIPPET_CHARS {
+                        let mut s: String = trimmed.chars().take(SEARCH_SNIPPET_CHARS).collect();
+                        s.push('…');
+                        s
+                    } else {
+                        trimmed.to_string()
+                    };
+                    matches.push(SearchMatch {
+                        line: (i + 1) as u32,
+                        text,
+                    });
+                    if matches.len() >= SEARCH_MAX_MATCHES_PER_FILE {
+                        break;
+                    }
+                }
+            }
+            if !matches.is_empty() {
+                let name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or_default()
+                    .to_string();
+                results.push(FileSearchResult {
+                    path: path.to_string_lossy().to_string(),
+                    name,
+                    matches,
+                });
+                if results.len() >= SEARCH_MAX_RESULTS {
+                    break;
+                }
+            }
+        }
+    }
+
+    results.sort_by_key(|r| r.name.to_lowercase());
+    results
 }
 
 /// Strip any path components from a filename so it can't traverse outside the
@@ -446,7 +597,52 @@ pub fn set_ai_key(key: String) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{sanitize_image_name, save_file, validate_rel_path};
+    use super::{sanitize_image_name, save_file, search_markdown_tree, validate_rel_path};
+
+    #[test]
+    fn search_finds_matches_recursively_and_case_insensitively() {
+        let dir = std::env::temp_dir().join(format!("paperling-search-{}", std::process::id()));
+        let sub = dir.join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(dir.join("a.md"), "Hello World\nsecond line").unwrap();
+        std::fs::write(sub.join("b.md"), "nothing here\nanother WORLD ref").unwrap();
+        std::fs::write(dir.join("c.txt"), "world but not markdown").unwrap();
+
+        let results = search_markdown_tree(dir.clone(), "world", false);
+
+        // Two markdown files match; the .txt is ignored.
+        assert_eq!(results.len(), 2);
+        let a = results.iter().find(|r| r.name == "a.md").unwrap();
+        assert_eq!(a.matches.len(), 1);
+        assert_eq!(a.matches[0].line, 1);
+        assert_eq!(a.matches[0].text, "Hello World");
+        let b = results.iter().find(|r| r.name == "b.md").unwrap();
+        assert_eq!(b.matches[0].line, 2);
+
+        // Case-sensitive search misses the lowercase/uppercase variants.
+        let cs = search_markdown_tree(dir.clone(), "world", true);
+        assert!(cs.is_empty());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn search_skips_hidden_and_ignored_dirs() {
+        let dir = std::env::temp_dir().join(format!("paperling-search-skip-{}", std::process::id()));
+        let hidden = dir.join(".git");
+        let modules = dir.join("node_modules");
+        std::fs::create_dir_all(&hidden).unwrap();
+        std::fs::create_dir_all(&modules).unwrap();
+        std::fs::write(dir.join("keep.md"), "needle").unwrap();
+        std::fs::write(hidden.join("x.md"), "needle").unwrap();
+        std::fs::write(modules.join("y.md"), "needle").unwrap();
+
+        let results = search_markdown_tree(dir.clone(), "needle", false);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "keep.md");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 
     #[test]
     fn save_file_writes_atomically_and_returns_mtime() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 mod commands;
 mod pdf;
 
-use commands::{read_file, save_file, get_file_info, list_directory_files, save_image, read_image_file, get_ai_key, set_ai_key};
+use commands::{read_file, save_file, get_file_info, list_directory_files, search_files, save_image, read_image_file, get_ai_key, set_ai_key};
 use tauri::{Manager, Emitter};
 use std::sync::Mutex;
 
@@ -78,6 +78,7 @@ pub fn run() {
             save_file,
             get_file_info,
             list_directory_files,
+            search_files,
             save_image,
             read_image_file,
             get_ai_key,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,9 @@ const StatsDialog = lazy(() =>
 const CommandPalette = lazy(() =>
     import("./components/CommandPalette").then((m) => ({ default: m.CommandPalette }))
 );
+const GlobalSearch = lazy(() =>
+    import("./components/GlobalSearch").then((m) => ({ default: m.GlobalSearch }))
+);
 const ShortcutCheatsheet = lazy(() =>
     import("./components/ShortcutCheatsheet").then((m) => ({ default: m.ShortcutCheatsheet }))
 );
@@ -148,6 +151,7 @@ function AppContent() {
   const [showSettings, setShowSettings] = useState(false);
   const [showTour, setShowTour] = useState(false);
   const [showStats, setShowStats] = useState(false);
+  const [showSearch, setShowSearch] = useState(false);
   const [splitRatio, setSplitRatioState] = usePersistedState<number>(getSplitRatio, setSplitRatio);
   const [aiConfig, setAiConfigState] = useState(() => getAIConfig());
   const [aiEnabled, setAiEnabledState] = usePersistedState<boolean>(getAIEnabled, setAIEnabled);
@@ -741,6 +745,26 @@ function AppContent() {
     }
   }, [filePath, loadFile, offerCreateNote]);
 
+  // Open a cross-file search result: load the file (if not already open) and
+  // jump to the matching line once it has rendered. The goto-line event is the
+  // same one the TOC/palette use, so it lands correctly in any view mode. SEARCH-01.
+  const handleOpenSearchResult = useCallback((path: string, line: number) => {
+    const jump = () => window.setTimeout(
+      () => window.dispatchEvent(new CustomEvent("paperling:goto-line", { detail: { line } })),
+      120
+    );
+    if (path === filePathRef.current) { jump(); return; }
+    loadFile(path);
+    jump();
+  }, [loadFile]);
+
+  // Folder the cross-file search runs in: the open file's directory.
+  const currentDirectory = useMemo(() => {
+    if (!filePath) return null;
+    const lastSep = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+    return lastSep > 0 ? filePath.slice(0, lastSep) : null;
+  }, [filePath]);
+
   const handleNewFile = useCallback(() => {
     if (content !== originalContent) {
       setPendingFilePath("__NEW__");
@@ -971,6 +995,7 @@ function AppContent() {
     // Ctrl+F in reader mode opens the preview find bar (the editor keymap
     // handles find in code/split mode, where the editor has focus). FIND-01.
     openPreviewFind: () => setPreviewFindOpen(true),
+    openSearch: () => setShowSearch(true),
     goBack, goForward,
     hasFile, content, mode,
   });
@@ -1095,6 +1120,15 @@ function AppContent() {
         section: "View",
         icon: "folder",
         run: handleToggleFileExplorer,
+      });
+      items.push({
+        id: "search.files",
+        label: "Search in files…",
+        hint: "Ctrl+Shift+F",
+        section: "View",
+        icon: "search",
+        keywords: "find across folder grep global content",
+        run: () => setShowSearch(true),
       });
       items.push({
         id: "view.toc",
@@ -1533,6 +1567,16 @@ function AppContent() {
       {showPalette && (
         <Suspense fallback={null}>
           <CommandPalette isOpen={showPalette} items={fullPaletteItems} onClose={() => setShowPalette(false)} />
+        </Suspense>
+      )}
+      {showSearch && (
+        <Suspense fallback={null}>
+          <GlobalSearch
+            isOpen={showSearch}
+            directory={currentDirectory}
+            onClose={() => setShowSearch(false)}
+            onOpenResult={handleOpenSearchResult}
+          />
         </Suspense>
       )}
       {showSettings && (

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { attachFocusTrap } from "../utils/focusTrap";
+
+interface SearchMatch {
+    line: number;
+    text: string;
+}
+interface FileResult {
+    path: string;
+    name: string;
+    matches: SearchMatch[];
+}
+
+interface GlobalSearchProps {
+    isOpen: boolean;
+    /** Folder to search (the current file's directory), or null when no file is open. */
+    directory: string | null;
+    onClose: () => void;
+    onOpenResult: (path: string, line: number) => void;
+}
+
+/** Flattened, keyboard-navigable view of one match. */
+interface FlatItem {
+    path: string;
+    line: number;
+}
+
+export function GlobalSearch({ isOpen, directory, onClose, onOpenResult }: GlobalSearchProps) {
+    const [query, setQuery] = useState("");
+    const [caseSensitive, setCaseSensitive] = useState(false);
+    const [results, setResults] = useState<FileResult[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [active, setActive] = useState(0);
+
+    const panelRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const reqIdRef = useRef(0);
+
+    // Flat list of every match, in render order, for arrow-key navigation.
+    const flat = useMemo<FlatItem[]>(
+        () => results.flatMap((r) => r.matches.map((m) => ({ path: r.path, line: m.line }))),
+        [results]
+    );
+    const totalMatches = flat.length;
+
+    // Reset transient state each time the panel opens; focus the input.
+    useEffect(() => {
+        if (!isOpen) return;
+        setActive(0);
+        const t = window.setTimeout(() => inputRef.current?.focus(), 0);
+        const detachTrap = attachFocusTrap(panelRef.current);
+        return () => { window.clearTimeout(t); detachTrap(); };
+    }, [isOpen]);
+
+    // Debounced search. A monotonic request id guards against out-of-order
+    // responses (a slow early query resolving after a faster later one).
+    useEffect(() => {
+        if (!isOpen) return;
+        const q = query.trim();
+        if (!q || !directory) {
+            setResults([]);
+            setLoading(false);
+            setError(null);
+            return;
+        }
+        const id = ++reqIdRef.current;
+        setLoading(true);
+        const handle = window.setTimeout(() => {
+            invoke<FileResult[]>("search_files", { directory, query: q, caseSensitive })
+                .then((res) => {
+                    if (reqIdRef.current !== id) return;
+                    setResults(res);
+                    setError(null);
+                    setActive(0);
+                })
+                .catch((err) => {
+                    if (reqIdRef.current !== id) return;
+                    setResults([]);
+                    setError(typeof err === "string" ? err : "Search failed");
+                })
+                .finally(() => {
+                    if (reqIdRef.current === id) setLoading(false);
+                });
+        }, 200);
+        return () => window.clearTimeout(handle);
+    }, [isOpen, query, caseSensitive, directory]);
+
+    const openItem = (item: FlatItem | undefined) => {
+        if (!item) return;
+        onOpenResult(item.path, item.line);
+        onClose();
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === "Escape") { e.preventDefault(); onClose(); return; }
+        if (e.key === "ArrowDown") { e.preventDefault(); setActive((i) => Math.min(i + 1, Math.max(0, totalMatches - 1))); }
+        else if (e.key === "ArrowUp") { e.preventDefault(); setActive((i) => Math.max(i - 1, 0)); }
+        else if (e.key === "Enter") { e.preventDefault(); openItem(flat[active]); }
+    };
+
+    if (!isOpen) return null;
+
+    // Running index so each match knows its position in the flat list.
+    let flatIndex = -1;
+
+    return (
+        <div
+            className="fixed inset-0 z-[80] flex items-start justify-center pt-[10vh] bg-black/40 animate-fade-in"
+            onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}
+        >
+            <div
+                ref={panelRef}
+                role="dialog"
+                aria-label="Search in files"
+                onKeyDown={handleKeyDown}
+                className="w-[min(680px,92vw)] max-h-[70vh] flex flex-col bg-[var(--bg-secondary)] border border-[var(--border)] rounded-xl shadow-2xl overflow-hidden"
+            >
+                {/* Search input row */}
+                <div className="flex items-center gap-2 px-4 h-12 border-b border-[var(--border)]">
+                    <span className="material-symbols-outlined text-[20px] text-[var(--text-muted)]">search</span>
+                    <input
+                        ref={inputRef}
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        placeholder={directory ? "Search across files in this folder…" : "Open a file first to search its folder"}
+                        disabled={!directory}
+                        className="flex-1 bg-transparent outline-none text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
+                    />
+                    <button
+                        onClick={() => setCaseSensitive((v) => !v)}
+                        aria-pressed={caseSensitive}
+                        title="Match case"
+                        className={`flex items-center justify-center w-7 h-7 rounded-md text-xs font-semibold transition-colors ${caseSensitive ? "bg-[var(--accent)] text-[var(--accent-text)]" : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"}`}
+                    >
+                        Aa
+                    </button>
+                    <button onClick={onClose} aria-label="Close search" className="flex items-center justify-center w-7 h-7 rounded-md hover:bg-[var(--bg-hover)] text-[var(--text-secondary)]">
+                        <span className="material-symbols-outlined text-[18px]">close</span>
+                    </button>
+                </div>
+
+                {/* Results */}
+                <div className="flex-1 min-h-0 overflow-y-auto">
+                    {error ? (
+                        <div className="p-6 text-sm text-[var(--danger)]" role="alert">{error}</div>
+                    ) : !query.trim() ? (
+                        <div className="p-6 text-sm text-[var(--text-muted)]">Type to search every markdown file in the current folder.</div>
+                    ) : loading && results.length === 0 ? (
+                        <div className="p-6 text-sm text-[var(--text-secondary)]">Searching…</div>
+                    ) : totalMatches === 0 ? (
+                        <div className="p-6 text-sm text-[var(--text-secondary)]">No matches.</div>
+                    ) : (
+                        <div className="py-2">
+                            <div className="px-4 pb-2 text-xs text-[var(--text-muted)]">
+                                {totalMatches} match{totalMatches === 1 ? "" : "es"} in {results.length} file{results.length === 1 ? "" : "s"}
+                            </div>
+                            {results.map((file) => (
+                                <div key={file.path} className="mb-1">
+                                    <div className="px-4 py-1 flex items-center gap-2 text-xs font-semibold text-[var(--text-secondary)]">
+                                        <span className="material-symbols-outlined text-[14px]">description</span>
+                                        <span className="truncate">{file.name}</span>
+                                    </div>
+                                    <ul>
+                                        {file.matches.map((m) => {
+                                            flatIndex += 1;
+                                            const isActive = flatIndex === active;
+                                            return (
+                                                <li key={`${file.path}:${m.line}`}>
+                                                    <button
+                                                        onClick={() => { onOpenResult(file.path, m.line); onClose(); }}
+                                                        className={`w-full text-left pl-10 pr-4 py-1 flex items-baseline gap-3 text-sm transition-colors ${isActive ? "bg-[var(--accent)] text-[var(--accent-text)]" : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"}`}
+                                                    >
+                                                        <span className={`shrink-0 tabular-nums text-xs ${isActive ? "" : "text-[var(--text-muted)]"}`}>{m.line}</span>
+                                                        <span className="truncate font-mono text-[13px]">{m.text}</span>
+                                                    </button>
+                                                </li>
+                                            );
+                                        })}
+                                    </ul>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -44,6 +44,7 @@ const groups: ShortcutGroup[] = [
             { keys: "Alt+→", description: "Forward" },
             { keys: "F11", description: "Toggle fullscreen" },
             { keys: `${cmd}+Shift+E`, description: "Toggle file explorer" },
+            { keys: `${cmd}+Shift+F`, description: "Search across files" },
             { keys: `${cmd}+Shift+O`, description: "Toggle outline" },
             { keys: `${cmd}+P`, description: "Command palette" },
             { keys: `${cmd}+,`, description: "Open settings" },

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -18,6 +18,8 @@ export interface ShortcutHandlers {
     openSettings: () => void;
     /** Open the reader-mode find bar. Only invoked when mode === "preview". */
     openPreviewFind?: () => void;
+    /** Open cross-file search (Ctrl+Shift+F). */
+    openSearch?: () => void;
     /** Navigate back/forward through visited files (Alt+Left / Alt+Right). */
     goBack?: () => void;
     goForward?: () => void;
@@ -94,6 +96,13 @@ export function useGlobalShortcuts(handlers: ShortcutHandlers) {
             if (e.ctrlKey && !e.shiftKey && e.key === "\\") {
                 e.preventDefault();
                 if (s.hasFile) s.handleToggleSplit();
+            }
+            // Ctrl+Shift+F - search across all files in the folder (checked
+            // before the unshifted Ctrl+F find-in-document below).
+            if (e.ctrlKey && e.shiftKey && (e.key === "f" || e.key === "F")) {
+                e.preventDefault();
+                if (s.hasFile) s.openSearch?.();
+                return;
             }
             // Ctrl+F in reader mode - find in preview. In code/split mode the
             // focused editor's own keymap handles Mod-f, so this never races it.


### PR DESCRIPTION
Project-wide content search — the biggest functional gap called out in the audit.

## Backend (`search_files`)
A bounded, **recursive** walk of the current folder's markdown files returning per-file matches with **1-based line numbers**. Skips hidden dirs, `node_modules`/`target`, very large files, and non-UTF8 content; caps files scanned / results / matches-per-file so it stays responsive on big trees. The walk is a pure sync helper (`search_markdown_tree`) run off-thread via `spawn_blocking`, with **Rust unit tests** for recursive + case-insensitive matching and directory skipping.

## Frontend (`GlobalSearch`)
A modal opened with **`Ctrl+Shift+F`** (and from the command palette):
- Debounced query with **out-of-order-response guarding** (a slow early request can't overwrite a newer one).
- Case-sensitive toggle.
- Results grouped by file, each match showing its line number and a snippet.
- Keyboard navigation (Up/Down/Enter) and click-to-open.
- Jumps to the matched line via the existing `goto-line` event, so it lands correctly in Reader, Code, or Split.

## Tests
- Rust: `search_finds_matches_recursively_and_case_insensitively`, `search_skips_hidden_and_ignored_dirs` (**12 Rust tests pass**).
- `tsc --noEmit` clean · `vite build` OK · **209 JS tests pass**.
- Also reconciles pre-existing `Cargo.lock` drift (version + already-declared webview2 deps).

Second of three. Multiple tabs is the last and largest, coming in its own PR.