### PR TITLE
feat(tabs): open multiple files in tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multiple tabs.** Open several files at once. Opening a file (or following a
+  link) opens it in a new tab instead of replacing what you're reading; a tab bar
+  appears once a second file is open. `Ctrl+N` opens a new tab, `Ctrl+W` closes
+  one, middle-click closes too, and unsaved tabs prompt before closing.
+
 ## [1.0.41] - 2026-06-28
 
 ### Added

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,6 +97,8 @@ import {
 import { getAutoSave } from "./utils/persistence";
 import { pickBootFile } from "./utils/boot";
 import { resolveRelativePath } from "./utils/resolveRelativePath";
+import { TabBar, type TabBarItem } from "./components/TabBar";
+import { findTabByPath, nextActiveAfterClose, type TabState } from "./utils/tabsModel";
 import { countSourceWords, countWords } from "./utils/documentStats";
 import { Tour } from "./components/Tour";
 import { PreviewFindBar } from "./components/PreviewFindBar";
@@ -152,6 +154,10 @@ function AppContent() {
   const [showTour, setShowTour] = useState(false);
   const [showStats, setShowStats] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
+  // Open-file tabs. The live state above is always the ACTIVE tab; `tabs` holds
+  // the snapshots of every open file (incl. the active one). TABS-01.
+  const [tabs, setTabs] = useState<TabState[]>([]);
+  const [activeTabId, setActiveTabId] = useState<string | null>(null);
   const [splitRatio, setSplitRatioState] = usePersistedState<number>(getSplitRatio, setSplitRatio);
   const [aiConfig, setAiConfigState] = useState(() => getAIConfig());
   const [aiEnabled, setAiEnabledState] = usePersistedState<boolean>(getAIEnabled, setAIEnabled);
@@ -171,9 +177,6 @@ function AppContent() {
   const [selectionRange, setSelectionRange] = useState<{ start: number; end: number }>({ start: 0, end: 0 });
   const [isLoading, setIsLoading] = useState(false);
 
-  // Pending file to open after unsaved changes dialog
-  const [pendingFilePath, setPendingFilePath] = useState<string | null>(null);
-  const [showUnsavedBeforeOpen, setShowUnsavedBeforeOpen] = useState(false);
   // Unsaved-changes dialog for window close (Alt+F4, taskbar close, the title
   // bar X). The Tauri close-requested handler below intercepts ALL of them.
   const [showUnsavedBeforeClose, setShowUnsavedBeforeClose] = useState(false);
@@ -271,15 +274,84 @@ function AppContent() {
   // focus to detect the file changing under us (sync tools, other editors).
   const knownMtimeRef = useRef<number>(0);
 
-  // Back/forward navigation between files (wikilinks, relative links, recents).
-  // navModeRef tells loadFileDirect how the current load should mutate history;
-  // it's a ref so it survives the async unsaved-changes dialog. NAV-03.
-  const { commit: commitNav, canGoBack, canGoForward, peekBack, peekForward } = useNavigationHistory();
+  // === Tabs (snapshot-swap) ===
+  // The live state (filePath/content/…) IS the active tab. `tabsRef`/`liveRef`
+  // mirror state synchronously so the open/switch/close helpers can read and
+  // commit without waiting for a re-render. We snapshot the active tab before
+  // leaving it and restore the target's snapshot into the live state — so every
+  // single-file system (autosave, AI review, external-change) is untouched. TABS-01.
+  const tabSeqRef = useRef(0);
+  // How the next file load should update back/forward history (set by goBack/
+  // goForward; reset after each load and on a plain tab switch). NAV-03.
   const navModeRef = useRef<NavMode>("normal");
+  const tabsRef = useRef<TabState[]>([]);
+  tabsRef.current = tabs;
+  const activeTabIdRef = useRef<string | null>(null);
+  activeTabIdRef.current = activeTabId;
+  const liveRef = useRef({ filePath, fileName, content, originalContent, fileSize });
+  liveRef.current = { filePath, fileName, content, originalContent, fileSize };
+
+  const commitTabs = useCallback((next: TabState[]) => {
+    tabsRef.current = next;
+    setTabs(next);
+  }, []);
+  const setActiveTab = useCallback((id: string | null) => {
+    activeTabIdRef.current = id;
+    setActiveTabId(id);
+  }, []);
+  const newTabId = useCallback(() => `tab-${++tabSeqRef.current}`, []);
+
+  // Write the live editor state back into the active tab's entry.
+  const snapshotActiveTab = useCallback(() => {
+    const id = activeTabIdRef.current;
+    if (!id) return;
+    const live = liveRef.current;
+    commitTabs(tabsRef.current.map((t) => (t.id === id ? {
+      ...t,
+      filePath: live.filePath,
+      fileName: live.fileName ?? "Untitled.md",
+      content: live.content,
+      originalContent: live.originalContent,
+      fileSize: live.fileSize,
+      knownMtime: knownMtimeRef.current,
+    } : t)));
+  }, [commitTabs]);
+
+  // Load a tab's stored snapshot into the live editor state.
+  const applyTabToLive = useCallback((tab: TabState) => {
+    setProposedDoc(null); // an AI review belongs to the file we're leaving
+    setFilePath(tab.filePath);
+    setFileName(tab.fileName);
+    setContent(tab.content);
+    setOriginalContent(tab.originalContent);
+    setFileSize(tab.fileSize);
+    knownMtimeRef.current = tab.knownMtime;
+    if (tab.filePath) setLastFile(tab.filePath);
+    requestAnimationFrame(() => window.dispatchEvent(new CustomEvent("paperling:scroll-top")));
+  }, []);
+
+  // Switch to an already-open tab, snapshotting the current one first. A plain
+  // switch isn't a history navigation, so clear any pending back/forward intent.
+  const activateTab = useCallback((id: string) => {
+    navModeRef.current = "normal";
+    if (id === activeTabIdRef.current) return;
+    snapshotActiveTab();
+    const target = tabsRef.current.find((t) => t.id === id);
+    if (!target) return;
+    setActiveTab(id);
+    applyTabToLive(target);
+  }, [snapshotActiveTab, setActiveTab, applyTabToLive]);
+
+  // Back/forward navigation between files (wikilinks, relative links, recents).
+  // navModeRef (declared above) tells loadFileDirect how each load should mutate
+  // history, and survives the async open path. NAV-03.
+  const { commit: commitNav, canGoBack, canGoForward, peekBack, peekForward } = useNavigationHistory();
 
   // Load file from path (with unsaved changes check)
   const loadFileDirect = useCallback(async (path: string) => {
     const outgoing = filePathRef.current;
+    // Preserve the file we're leaving in its tab before overwriting live state.
+    snapshotActiveTab();
     setIsLoading(true);
     try {
       const fileData = await invoke<FileData>("read_file", { path });
@@ -292,6 +364,22 @@ function AppContent() {
       // Track recents + last-opened for restore-on-launch
       addRecentFile(fileData.path, fileData.name);
       setLastFile(fileData.path);
+      // Upsert the tab: reuse an existing tab for this path (e.g. a reload),
+      // otherwise open a new one. Either way it becomes active. TABS-01.
+      const loaded = {
+        filePath: fileData.path, fileName: fileData.name,
+        content: fileData.content, originalContent: fileData.content,
+        fileSize: fileData.size, knownMtime: fileData.modified ?? 0,
+      };
+      const existing = findTabByPath(tabsRef.current, fileData.path);
+      if (existing) {
+        commitTabs(tabsRef.current.map((t) => (t.id === existing.id ? { ...t, ...loaded } : t)));
+        setActiveTab(existing.id);
+      } else {
+        const id = newTabId();
+        commitTabs([...tabsRef.current, { id, ...loaded }]);
+        setActiveTab(id);
+      }
       // Record the jump in history and snap the new file to the top. Both are
       // skipped when the path didn't change (an external-change reload should
       // keep the reader where they were). NAV-03 / NAV-04.
@@ -310,7 +398,7 @@ function AppContent() {
       setIsLoading(false);
       navModeRef.current = "normal";
     }
-  }, [showToast, commitNav]);
+  }, [showToast, commitNav, snapshotActiveTab, commitTabs, setActiveTab, newTabId]);
 
   // Settings flags above persist themselves via usePersistedState; the matching
   // setters (setSavedViewMode, setSplitRatio, …) are passed into that hook.
@@ -416,6 +504,14 @@ function AppContent() {
         // launch restores what the user actually had open.
         addRecentFile(fileData.path, fileData.name);
         setLastFile(fileData.path);
+        // Seed the first tab for the restored file. TABS-01.
+        const id = newTabId();
+        commitTabs([{
+          id, filePath: fileData.path, fileName: fileData.name,
+          content: fileData.content, originalContent: fileData.content,
+          fileSize: fileData.size, knownMtime: fileData.modified ?? 0,
+        }]);
+        setActiveTab(id);
       } catch (err) {
         const msg = typeof err === "string" ? err : (err as { message?: string })?.message || "";
         if (target.source === "cli") {
@@ -561,68 +657,52 @@ function AppContent() {
     onError: handleAutosaveError,
   });
 
-  // Load file with unsaved changes protection
+  // Open a file: if it's already in a tab, just switch to it (preserving any
+  // unsaved edits there); otherwise load it into a new tab. With tabs there's no
+  // need to prompt before opening — the current file stays open in its own tab.
   const loadFile = useCallback(async (path: string) => {
-    if (contentRef.current !== originalContentRef.current) {
-      // Has unsaved changes — ask user first
-      setPendingFilePath(path);
-      setShowUnsavedBeforeOpen(true);
+    const existing = findTabByPath(tabsRef.current, path);
+    if (existing) { activateTab(existing.id); return; }
+    await loadFileDirect(path);
+  }, [activateTab, loadFileDirect]);
+
+  // Close a tab. Prompts before discarding unsaved changes; when the active tab
+  // closes, focus the neighbour (or fall back to the welcome screen). TABS-01.
+  const closeTab = useCallback(async (id: string) => {
+    const tab = tabsRef.current.find((t) => t.id === id);
+    if (!tab) return;
+    const isActive = id === activeTabIdRef.current;
+    const dirty = isActive
+      ? liveRef.current.content !== liveRef.current.originalContent
+      : tab.content !== tab.originalContent;
+    if (dirty) {
+      const discard = await ask(`Discard unsaved changes to "${tab.fileName}"?`, {
+        title: "Close tab",
+        kind: "warning",
+      });
+      if (!discard) return;
+    }
+    const nextId = nextActiveAfterClose(tabsRef.current, id);
+    const remaining = tabsRef.current.filter((t) => t.id !== id);
+    commitTabs(remaining);
+    if (!isActive) return;
+    const target = nextId ? remaining.find((t) => t.id === nextId) : undefined;
+    if (target) {
+      setActiveTab(target.id);
+      applyTabToLive(target);
     } else {
-      await loadFileDirect(path);
+      // Last tab closed — return to the clean welcome state.
+      setActiveTab(null);
+      setProposedDoc(null);
+      setFilePath(null);
+      setFileName(null);
+      setContent("");
+      setOriginalContent("");
+      setFileSize(0);
+      knownMtimeRef.current = 0;
+      setLastFile(null);
     }
-  }, [loadFileDirect]);
-
-  // New file: clears buffer. Used by handleNewFile and the dialog handlers.
-  const startBlankFile = useCallback(() => {
-    setFilePath(null);
-    setFileName("Untitled.md");
-    setContent("");
-    setOriginalContent("");
-    setFileSize(0);
-    setLastFile(null);
-    setMode("code");
-  }, []);
-
-  // Handlers for unsaved-before-open dialog. Supports a "__NEW__" sentinel
-  // so the New File action routes through the same confirmation flow.
-  const handleSaveAndOpen = useCallback(async () => {
-    setShowUnsavedBeforeOpen(false);
-    if (filePath) {
-      try {
-        knownMtimeRef.current = await invoke<number>("save_file", { path: filePath, content });
-        setOriginalContent(content);
-      } catch (err) {
-        console.error("Failed to save file:", err);
-        const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
-        showToast(msg || "Failed to save file", "error");
-        return;
-      }
-    }
-    if (pendingFilePath === "__NEW__") {
-      startBlankFile();
-    } else if (pendingFilePath) {
-      await loadFileDirect(pendingFilePath);
-    }
-    setPendingFilePath(null);
-  }, [filePath, content, pendingFilePath, loadFileDirect, showToast, startBlankFile]);
-
-  const handleDiscardAndOpen = useCallback(async () => {
-    setShowUnsavedBeforeOpen(false);
-    if (pendingFilePath === "__NEW__") {
-      startBlankFile();
-    } else if (pendingFilePath) {
-      await loadFileDirect(pendingFilePath);
-    }
-    setPendingFilePath(null);
-  }, [pendingFilePath, loadFileDirect, startBlankFile]);
-
-  const handleCancelOpen = useCallback(() => {
-    setShowUnsavedBeforeOpen(false);
-    setPendingFilePath(null);
-    // The navigation was abandoned — don't let a pending back/forward intent
-    // leak into the next normal open. NAV-03.
-    navModeRef.current = "normal";
-  }, []);
+  }, [commitTabs, setActiveTab, applyTabToLive]);
 
   // Back / forward between visited files. Routed through loadFile so unsaved
   // changes still prompt; navModeRef tells loadFileDirect how to update history
@@ -765,14 +845,26 @@ function AppContent() {
     return lastSep > 0 ? filePath.slice(0, lastSep) : null;
   }, [filePath]);
 
+  // New file: opens a fresh Untitled buffer in its own tab (the current file
+  // stays open in its tab, so nothing is discarded). TABS-01.
   const handleNewFile = useCallback(() => {
-    if (content !== originalContent) {
-      setPendingFilePath("__NEW__");
-      setShowUnsavedBeforeOpen(true);
-    } else {
-      startBlankFile();
-    }
-  }, [content, originalContent, startBlankFile]);
+    snapshotActiveTab();
+    const id = newTabId();
+    commitTabs([...tabsRef.current, {
+      id, filePath: null, fileName: "Untitled.md",
+      content: "", originalContent: "", fileSize: 0, knownMtime: 0,
+    }]);
+    setActiveTab(id);
+    setProposedDoc(null);
+    setFilePath(null);
+    setFileName("Untitled.md");
+    setContent("");
+    setOriginalContent("");
+    setFileSize(0);
+    knownMtimeRef.current = 0;
+    setLastFile(null);
+    setMode("code");
+  }, [snapshotActiveTab, commitTabs, setActiveTab, newTabId]);
 
   // "Replay the welcome tour" from Settings → About. The tour spotlights
   // editor chrome, so make sure a buffer exists before showing it.
@@ -821,13 +913,22 @@ function AppContent() {
       setOriginalContent(content);
       addRecentFile(selected, name);
       setLastFile(selected);
+      // Keep the active tab's entry in step with the new path/name so reopening
+      // the just-saved file switches to this tab instead of duplicating it. TABS-01.
+      const activeId = activeTabIdRef.current;
+      if (activeId) {
+        commitTabs(tabsRef.current.map((t) => (t.id === activeId ? {
+          ...t, filePath: selected, fileName: name, content, originalContent: content,
+          knownMtime: knownMtimeRef.current,
+        } : t)));
+      }
       showToast("File saved", "success");
     } catch (err) {
       console.error("Failed to save file:", err);
       const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
       showToast(msg || "Failed to save file", "error");
     }
-  }, [content, fileName, showToast]);
+  }, [content, fileName, showToast, commitTabs]);
 
   // Save file (Save As if no path yet)
   const handleSaveFile = useCallback(async () => {
@@ -996,6 +1097,7 @@ function AppContent() {
     // handles find in code/split mode, where the editor has focus). FIND-01.
     openPreviewFind: () => setPreviewFindOpen(true),
     openSearch: () => setShowSearch(true),
+    closeActiveTab: () => { if (activeTabIdRef.current) closeTab(activeTabIdRef.current); },
     goBack, goForward,
     hasFile, content, mode,
   });
@@ -1302,6 +1404,22 @@ function AppContent() {
     [paletteItems, headingPaletteItems]
   );
 
+  // Tab-bar items. The active tab's name/dirty come from live state (its stored
+  // snapshot lags until the next switch); inactive tabs read their snapshot.
+  // Keyed on `isDirty` (a boolean) so typing within an already-dirty file
+  // doesn't churn this list. TABS-01.
+  const tabBarItems = useMemo<TabBarItem[]>(
+    () => tabs.map((t) => {
+      const active = t.id === activeTabId;
+      return {
+        id: t.id,
+        name: active ? (fileName ?? "Untitled.md") : t.fileName,
+        dirty: active ? isDirty : t.content !== t.originalContent,
+      };
+    }),
+    [tabs, activeTabId, fileName, isDirty]
+  );
+
   return (
     <div className="h-screen flex flex-col bg-[var(--bg-primary)] overflow-hidden transition-colors">
       <TitleBar
@@ -1322,6 +1440,17 @@ function AppContent() {
         isFullscreen={isFullscreen}
         onToggleFullscreen={toggleFullscreen}
       />
+
+      {/* Tab bar — only once a second file is open, so the single-file view stays
+          as clean as before. TABS-01. */}
+      {tabBarItems.length >= 2 && (
+        <TabBar
+          tabs={tabBarItems}
+          activeId={activeTabId}
+          onSelect={activateTab}
+          onClose={closeTab}
+        />
+      )}
 
       {/* Startup update check; invisible unless an update is actually available. */}
       <Suspense fallback={null}>
@@ -1497,19 +1626,6 @@ function AppContent() {
             selectionWordCount={selectionWordCount}
           />
         </>
-      )}
-
-      {/* Unsaved-changes dialog: only mounts when needed. Most app sessions
-          never trigger it, so eagerly loading the module was pure waste. */}
-      {showUnsavedBeforeOpen && (
-        <Suspense fallback={null}>
-          <UnsavedChangesDialog
-            isOpen={showUnsavedBeforeOpen}
-            onClose={handleCancelOpen}
-            onDiscard={handleDiscardAndOpen}
-            onSave={handleSaveAndOpen}
-          />
-        </Suspense>
       )}
 
       {/* Unsaved-changes dialog for window close — fed by the Tauri

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -30,7 +30,8 @@ const groups: ShortcutGroup[] = [
         title: "File",
         items: [
             { keys: `${cmd}+O`, description: "Open file" },
-            { keys: `${cmd}+N`, description: "New file" },
+            { keys: `${cmd}+N`, description: "New file (new tab)" },
+            { keys: `${cmd}+W`, description: "Close tab" },
             { keys: `${cmd}+S`, description: "Save" },
             { keys: `${cmd}+Shift+S`, description: "Save As…" },
         ],

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,0 +1,70 @@
+import { memo } from "react";
+
+export interface TabBarItem {
+    id: string;
+    name: string;
+    dirty: boolean;
+}
+
+interface TabBarProps {
+    tabs: TabBarItem[];
+    activeId: string | null;
+    onSelect: (id: string) => void;
+    onClose: (id: string) => void;
+}
+
+function TabBarImpl({ tabs, activeId, onSelect, onClose }: TabBarProps) {
+    return (
+        <div
+            role="tablist"
+            aria-label="Open files"
+            className="h-9 shrink-0 flex items-stretch overflow-x-auto bg-[var(--bg-titlebar)] border-b border-[var(--border)] no-select"
+        >
+            {tabs.map((tab) => {
+                const isActive = tab.id === activeId;
+                return (
+                    <div
+                        key={tab.id}
+                        role="tab"
+                        aria-selected={isActive}
+                        title={tab.name}
+                        onMouseDown={(e) => {
+                            // Middle-click closes, like a browser.
+                            if (e.button === 1) { e.preventDefault(); onClose(tab.id); }
+                            else if (e.button === 0) onSelect(tab.id);
+                        }}
+                        className={`group/tab relative flex items-center gap-2 pl-3 pr-2 max-w-[200px] cursor-pointer border-r border-[var(--border)] transition-colors ${
+                            isActive
+                                ? "bg-[var(--bg-primary)] text-[var(--text-primary)]"
+                                : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"
+                        }`}
+                    >
+                        {/* Active-tab top accent */}
+                        {isActive && <span className="absolute left-0 top-0 h-[2px] w-full bg-[var(--accent)]" aria-hidden="true" />}
+                        <span className="material-symbols-outlined text-[14px] shrink-0 opacity-70">description</span>
+                        <span className="truncate text-xs">{tab.name}</span>
+                        {/* Dirty dot doubles as the close target on hover. */}
+                        <button
+                            onMouseDown={(e) => { e.stopPropagation(); }}
+                            onClick={(e) => { e.stopPropagation(); onClose(tab.id); }}
+                            aria-label={`Close ${tab.name}`}
+                            title="Close"
+                            className="shrink-0 w-4 h-4 flex items-center justify-center rounded hover:bg-[var(--bg-hover)] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                        >
+                            {tab.dirty ? (
+                                <>
+                                    <span className="material-symbols-outlined text-[14px] group-hover/tab:hidden" aria-hidden="true">circle</span>
+                                    <span className="material-symbols-outlined text-[14px] hidden group-hover/tab:inline" aria-hidden="true">close</span>
+                                </>
+                            ) : (
+                                <span className="material-symbols-outlined text-[14px] opacity-0 group-hover/tab:opacity-100" aria-hidden="true">close</span>
+                            )}
+                        </button>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+export const TabBar = memo(TabBarImpl);

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -20,6 +20,8 @@ export interface ShortcutHandlers {
     openPreviewFind?: () => void;
     /** Open cross-file search (Ctrl+Shift+F). */
     openSearch?: () => void;
+    /** Close the active tab (Ctrl+W). */
+    closeActiveTab?: () => void;
     /** Navigate back/forward through visited files (Alt+Left / Alt+Right). */
     goBack?: () => void;
     goForward?: () => void;
@@ -96,6 +98,13 @@ export function useGlobalShortcuts(handlers: ShortcutHandlers) {
             if (e.ctrlKey && !e.shiftKey && e.key === "\\") {
                 e.preventDefault();
                 if (s.hasFile) s.handleToggleSplit();
+            }
+            // Ctrl+W - close the active tab (falls back to the welcome screen
+            // when it's the last one). The webview doesn't reserve Ctrl+W.
+            if (e.ctrlKey && !e.shiftKey && (e.key === "w" || e.key === "W")) {
+                e.preventDefault();
+                if (s.hasFile) s.closeActiveTab?.();
+                return;
             }
             // Ctrl+Shift+F - search across all files in the folder (checked
             // before the unshifted Ctrl+F find-in-document below).

--- a/src/utils/tabsModel.test.ts
+++ b/src/utils/tabsModel.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { findTabByPath, isTabDirty, nextActiveAfterClose, type TabState } from "./tabsModel";
+
+const tab = (id: string, filePath: string | null, content = "x", originalContent = "x"): TabState => ({
+  id, filePath, fileName: filePath?.split("/").pop() ?? "Untitled.md",
+  content, originalContent, fileSize: 0, knownMtime: 0,
+});
+
+describe("isTabDirty", () => {
+  it("is dirty only when content diverges from the saved original", () => {
+    expect(isTabDirty({ content: "a", originalContent: "a" })).toBe(false);
+    expect(isTabDirty({ content: "a", originalContent: "b" })).toBe(true);
+  });
+});
+
+describe("findTabByPath", () => {
+  const tabs = [tab("1", "/a.md"), tab("2", "/b.md"), tab("3", null)];
+  it("finds by path", () => {
+    expect(findTabByPath(tabs, "/b.md")?.id).toBe("2");
+  });
+  it("never matches a null path (multiple Untitled buffers are distinct)", () => {
+    expect(findTabByPath(tabs, null)).toBeUndefined();
+  });
+  it("returns undefined when not open", () => {
+    expect(findTabByPath(tabs, "/missing.md")).toBeUndefined();
+  });
+});
+
+describe("nextActiveAfterClose", () => {
+  const tabs = [tab("1", "/a.md"), tab("2", "/b.md"), tab("3", "/c.md")];
+
+  it("focuses the tab to the right of the closed one", () => {
+    expect(nextActiveAfterClose(tabs, "2")).toBe("3");
+  });
+  it("focuses the left neighbour when closing the last tab", () => {
+    expect(nextActiveAfterClose(tabs, "3")).toBe("2");
+  });
+  it("focuses the new first tab when closing the first", () => {
+    expect(nextActiveAfterClose(tabs, "1")).toBe("2");
+  });
+  it("returns null when closing the only tab", () => {
+    expect(nextActiveAfterClose([tab("1", "/a.md")], "1")).toBeNull();
+  });
+  it("returns null for an unknown id", () => {
+    expect(nextActiveAfterClose(tabs, "nope")).toBeNull();
+  });
+});

--- a/src/utils/tabsModel.ts
+++ b/src/utils/tabsModel.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure data model for the open-file tabs. The heavy state lives in App (the
+ * "active" tab is the live editor); these helpers just manage the list so the
+ * tricky bits (which tab to focus after a close) are unit-testable.
+ */
+
+export interface TabState {
+  /** Stable id for the lifetime of the tab (unrelated to the file path). */
+  id: string;
+  /** null for an unsaved "Untitled" buffer. */
+  filePath: string | null;
+  fileName: string;
+  content: string;
+  originalContent: string;
+  fileSize: number;
+  /** Last-known on-disk mtime (ms), for external-change detection. */
+  knownMtime: number;
+}
+
+/** A tab is dirty when its buffer differs from what's on disk. */
+export function isTabDirty(tab: Pick<TabState, "content" | "originalContent">): boolean {
+  return tab.content !== tab.originalContent;
+}
+
+/** Find an open tab by file path (null paths never match). */
+export function findTabByPath(tabs: TabState[], path: string | null): TabState | undefined {
+  if (path == null) return undefined;
+  return tabs.find((t) => t.filePath === path);
+}
+
+/**
+ * Which tab should become active after `closingId` is closed: the tab to the
+ * right (the one that slides into the closed slot), else the tab to the left,
+ * else null when nothing remains. Mirrors common editor behaviour.
+ */
+export function nextActiveAfterClose(tabs: TabState[], closingId: string): string | null {
+  const idx = tabs.findIndex((t) => t.id === closingId);
+  if (idx === -1) return null;
+  const remaining = tabs.filter((t) => t.id !== closingId);
+  if (remaining.length === 0) return null;
+  return (remaining[idx] ?? remaining[idx - 1] ?? remaining[remaining.length - 1]).id;
+}


### PR DESCRIPTION
Adds a tab bar so several files can be open at once — the largest "daily driver" gap from the feature review, and the third of the three features requested.

## Architecture — snapshot-swap
The existing single-file state stays the **live active document**; a `tabs` array holds a snapshot of every open file. Switching tabs snapshots the active one and restores the target's snapshot into live state. This means autosave, AI review, and external-change detection all keep operating on the active file **unchanged** — no rewrite of the core state model, which keeps the blast radius small.

## Behaviour
- Opening a file (Ctrl+O, file explorer, `[[wikilink]]`/relative link, a search result, drag-drop, recents) now opens it in a **new tab** instead of replacing the current one. Opening an **already-open** file just switches to its tab — no reload, no lost edits. Since opening never discards, the old unsaved-before-open dialog is removed.
- **Ctrl+N** → new Untitled tab · **Ctrl+W** / middle-click → close · dirty tabs prompt before closing.
- Closing the active tab focuses a neighbour; closing the last returns to the welcome screen.
- The tab bar only appears with **2+ tabs**, so the single-file view stays exactly as clean as before.
- Active-tab name/dirty come from live state; the dot updates instantly. Save As keeps the tab's path in sync so the saved file doesn't reopen as a duplicate.

## Tests
- `tabsModel`: find-by-path (incl. null paths never matching), next-active-after-close (right/left/first/only/unknown), dirty. **9 new**.
- `tsc --noEmit` clean · `vite build` OK · **218 JS tests pass**.

## Known v1 limitations (intentional, follow-up material)
- Per-tab cursor/scroll position isn't preserved across switches (opening/switching lands at the top).
- Autosave runs for the **active** tab only (an edited background tab autosaves when re-activated).
- The window-close prompt still checks only the active file's unsaved state, not every tab.

> Note: this is a large stateful feature and there's no full App-level integration harness, so a manual smoke-test of open/switch/close/dirty flows is worth doing before release. The pure list logic is unit-tested and the wiring is type-checked + build-verified.