### PR TITLE
feat(tabs): remember each tab's place on switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Tabs remember your place.** Switching back to a tab returns you to the line
+  you were on instead of jumping to the top.
+
 ## [1.0.44] - 2026-06-28
 
 ## [1.0.43] - 2026-06-28

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -286,6 +286,10 @@ function AppContent() {
   activeTabIdRef.current = activeTabId;
   const liveRef = useRef({ filePath, fileName, content, originalContent, fileSize });
   liveRef.current = { filePath, fileName, content, originalContent, fileSize };
+  // The line we'd return to when this file is re-activated: the caret line while
+  // editing, or the top-visible line in reader mode. TABS-02.
+  const currentLineRef = useRef(1);
+  currentLineRef.current = mode === "preview" ? previewLine : cursorPosition.line;
 
   const commitTabs = useCallback((next: TabState[]) => {
     tabsRef.current = next;
@@ -310,6 +314,7 @@ function AppContent() {
       originalContent: live.originalContent,
       fileSize: live.fileSize,
       knownMtime: knownMtimeRef.current,
+      cursorLine: currentLineRef.current,
     } : t)));
   }, [commitTabs]);
 
@@ -323,7 +328,13 @@ function AppContent() {
     setFileSize(tab.fileSize);
     knownMtimeRef.current = tab.knownMtime;
     if (tab.filePath) setLastFile(tab.filePath);
-    requestAnimationFrame(() => window.dispatchEvent(new CustomEvent("paperling:scroll-top")));
+    // Restore where you were in this tab — jump to the remembered line, or fall
+    // back to the top for a never-focused / line-1 tab. TABS-02.
+    const line = tab.cursorLine ?? 1;
+    requestAnimationFrame(() => {
+      if (line > 1) window.dispatchEvent(new CustomEvent("paperling:goto-line", { detail: { line } }));
+      else window.dispatchEvent(new CustomEvent("paperling:scroll-top"));
+    });
   }, []);
 
   // Switch to an already-open tab, snapshotting the current one first.

--- a/src/utils/tabsModel.ts
+++ b/src/utils/tabsModel.ts
@@ -15,6 +15,9 @@ export interface TabState {
   fileSize: number;
   /** Last-known on-disk mtime (ms), for external-change detection. */
   knownMtime: number;
+  /** 1-based caret/top-visible line when last active, to restore your place on
+   *  switch-back. Undefined for a never-yet-focused tab. */
+  cursorLine?: number;
 }
 
 /** A tab is dirty when its buffer differs from what's on disk. */


### PR DESCRIPTION
Completes the tabs feature by closing the documented v1 gap: **switching back to a tab returns you to where you were** instead of jumping to the top.

- `TabState` gains an optional `cursorLine`. `snapshotActiveTab` records the live line on switch-away (the caret line while editing, or the top-visible line in reader mode); `applyTabToLive` jumps back to it via the existing `goto-line` event (which works in code, split, and reader modes alike). Falls back to scroll-to-top for a line-1 or never-focused tab.

`tsc --noEmit` clean · `vite build` OK · **211 tests pass**.