### PR TITLE
Tabs robustness: fix data-loss bugs + finish the tab feature

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "paperling"
-version = "1.0.40"
+version = "1.0.44"
 dependencies = [
  "keyring",
  "serde",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -55,6 +55,50 @@ pub struct FileData {
     pub modified: u64,
 }
 
+/// Line-ending convention of a file.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Eol {
+    Lf,
+    Crlf,
+}
+
+/// Detect a file's dominant line ending by reading just its first chunk and
+/// inspecting the first newline. `\r\n` → Crlf, a bare `\n` → Lf, and a file with
+/// no newline at all (or that can't be read) falls back to Lf. Cheap: we never
+/// read more than the first 64 KB regardless of file size. EOL-01.
+async fn detect_file_eol(path: &str) -> Eol {
+    use tokio::io::AsyncReadExt;
+    let mut file = match tokio::fs::File::open(path).await {
+        Ok(f) => f,
+        Err(_) => return Eol::Lf,
+    };
+    let mut buf = vec![0u8; 64 * 1024];
+    let n = match file.read(&mut buf).await {
+        Ok(n) => n,
+        Err(_) => return Eol::Lf,
+    };
+    for i in 0..n {
+        if buf[i] == b'\n' {
+            return if i > 0 && buf[i - 1] == b'\r' { Eol::Crlf } else { Eol::Lf };
+        }
+    }
+    Eol::Lf
+}
+
+/// Re-apply a file's line ending to editor content (which CodeMirror always
+/// normalises to `\n`). We first collapse any stray `\r\n`/`\r` to `\n` so a
+/// CRLF target can't produce `\r\r\n`. EOL-01.
+fn apply_eol(content: &str, eol: Eol) -> String {
+    if eol == Eol::Lf && !content.contains('\r') {
+        return content.to_string();
+    }
+    let normalized = content.replace("\r\n", "\n").replace('\r', "\n");
+    match eol {
+        Eol::Lf => normalized,
+        Eol::Crlf => normalized.replace('\n', "\r\n"),
+    }
+}
+
 /// Last-modified time in ms since the Unix epoch (0 when unavailable).
 fn mtime_ms(metadata: &std::fs::Metadata) -> u64 {
     metadata
@@ -132,13 +176,41 @@ pub async fn save_file(path: String, content: String) -> Result<u64, CommandErro
         )));
     }
 
+    // Preserve the on-disk file's line ending. The editor hands us `\n`-only
+    // content; if the existing file uses CRLF we write CRLF back, so opening and
+    // saving a Windows file doesn't rewrite every line and produce a noisy diff.
+    // A brand-new file (save-as / new note) has no existing EOL, so we keep the
+    // editor's LF. EOL-01.
+    let file_exists = PathBuf::from(&path).exists();
+    let content = if file_exists {
+        apply_eol(&content, detect_file_eol(&path).await)
+    } else {
+        content
+    };
+
     // Same directory as the target so the rename never crosses a filesystem
     // boundary (cross-device renames aren't atomic and can fail outright).
     let tmp = format!("{}.{}.paperling-tmp", path, std::process::id());
 
-    tokio::fs::write(&tmp, &content)
-        .await
-        .map_err(|e| CommandError::WriteError(e.to_string()))?;
+    // Write, then fsync BEFORE the rename. Without the sync, a crash right after
+    // the rename can leave the (renamed) file present but empty/partial on disk,
+    // because the directory entry can reach disk before the data does. An editor
+    // whose whole job is not losing words should pay this cost. SAVE-02.
+    {
+        use tokio::io::AsyncWriteExt;
+        let mut f = match tokio::fs::File::create(&tmp).await {
+            Ok(f) => f,
+            Err(e) => return Err(CommandError::WriteError(e.to_string())),
+        };
+        if let Err(e) = f.write_all(content.as_bytes()).await {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(CommandError::WriteError(e.to_string()));
+        }
+        if let Err(e) = f.sync_all().await {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(CommandError::WriteError(e.to_string()));
+        }
+    }
 
     if let Err(e) = tokio::fs::rename(&tmp, &path).await {
         // Don't leave the temp file behind on failure.
@@ -597,7 +669,7 @@ pub fn set_ai_key(key: String) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{sanitize_image_name, save_file, search_markdown_tree, validate_rel_path};
+    use super::{apply_eol, sanitize_image_name, save_file, search_markdown_tree, validate_rel_path, Eol};
 
     #[test]
     fn search_finds_matches_recursively_and_case_insensitively() {
@@ -673,6 +745,43 @@ mod tests {
                 .filter(|e| e.file_name().to_string_lossy().contains("paperling-tmp"))
                 .collect();
             assert!(leftovers.is_empty());
+
+            std::fs::remove_dir_all(&dir).ok();
+        });
+    }
+
+    #[test]
+    fn apply_eol_converts_and_normalizes() {
+        // LF stays LF.
+        assert_eq!(apply_eol("a\nb\nc", Eol::Lf), "a\nb\nc");
+        // LF content → CRLF on save.
+        assert_eq!(apply_eol("a\nb\nc", Eol::Crlf), "a\r\nb\r\nc");
+        // Never doubles up if some \r slipped in.
+        assert_eq!(apply_eol("a\r\nb", Eol::Crlf), "a\r\nb");
+        assert_eq!(apply_eol("a\r\nb", Eol::Lf), "a\nb");
+    }
+
+    #[test]
+    fn save_file_preserves_crlf_line_endings() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let dir = std::env::temp_dir().join(format!("paperling-eol-{}", std::process::id()));
+            std::fs::create_dir_all(&dir).unwrap();
+            let path = dir.join("crlf.md").to_string_lossy().to_string();
+
+            // Seed a CRLF file, then "edit" it with LF-only content (as the editor
+            // would hand us) and confirm the CRLF convention survives the save.
+            std::fs::write(&path, "one\r\ntwo\r\n").unwrap();
+            save_file(path.clone(), "one\ntwo\nthree".into()).await.unwrap();
+            assert_eq!(std::fs::read_to_string(&path).unwrap(), "one\r\ntwo\r\nthree");
+
+            // A brand-new file keeps the editor's LF.
+            let lf_path = dir.join("new.md").to_string_lossy().to_string();
+            save_file(lf_path.clone(), "a\nb".into()).await.unwrap();
+            assert_eq!(std::fs::read_to_string(&lf_path).unwrap(), "a\nb");
 
             std::fs::remove_dir_all(&dir).ok();
         });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,7 +98,15 @@ import {
 import { getAutoSave } from "./utils/persistence";
 import { resolveRelativePath } from "./utils/resolveRelativePath";
 import { TabBar, type TabBarItem } from "./components/TabBar";
-import { findTabByPath, nextActiveAfterClose, type TabState } from "./utils/tabsModel";
+import {
+  findTabByPath,
+  nextActiveAfterClose,
+  nextUntitledName,
+  findReusableUntitledTab,
+  computeTabLabels,
+  moveTab,
+  type TabState,
+} from "./utils/tabsModel";
 import { countSourceWords, countWords } from "./utils/documentStats";
 import { Tour } from "./components/Tour";
 import { PreviewFindBar } from "./components/PreviewFindBar";
@@ -924,13 +932,13 @@ function AppContent() {
     let unlisten: (() => void) | undefined;
 
     listen<{ paths: string[] }>(TauriEvent.DRAG_DROP, async (event) => {
-      const paths = event.payload.paths;
-      if (paths && paths.length > 0) {
-        const firstPath = paths[0];
-        // Only load markdown files
-        if (firstPath.endsWith('.md') || firstPath.endsWith('.markdown')) {
-          await loadFile(firstPath);
-        }
+      // Open EVERY dropped markdown file in its own tab (the last one wins focus),
+      // rather than only the first. TABS-11.
+      const paths = (event.payload.paths ?? []).filter(
+        (p) => p.endsWith(".md") || p.endsWith(".markdown")
+      );
+      for (const p of paths) {
+        await loadFile(p);
       }
     }).then((fn) => {
       if (mounted) {
@@ -1044,26 +1052,34 @@ function AppContent() {
   }, [filePath]);
 
   // New file: opens a fresh Untitled buffer in its own tab (the current file
-  // stays open in its tab, so nothing is discarded). TABS-01.
+  // stays open in its tab, so nothing is discarded). Reuses a pristine empty
+  // untitled tab if one exists, and numbers new ones Untitled-N.md. TABS-01/08.
   const handleNewFile = useCallback(() => {
+    const reusable = findReusableUntitledTab(tabsRef.current);
+    if (reusable) {
+      if (reusable.id !== activeTabIdRef.current) activateTab(reusable.id);
+      setMode("code");
+      return;
+    }
     snapshotActiveTab();
     bumpDocSwap(); // fresh Untitled buffer → editor resets undo history. TABS-03.
     const id = newTabId();
+    const name = nextUntitledName(tabsRef.current);
     commitTabs([...tabsRef.current, {
-      id, filePath: null, fileName: "Untitled.md",
+      id, filePath: null, fileName: name,
       content: "", originalContent: "", fileSize: 0, knownMtime: 0,
     }]);
     setActiveTab(id);
     setProposedDoc(null);
     setFilePath(null);
-    setFileName("Untitled.md");
+    setFileName(name);
     setContent("");
     setOriginalContent("");
     setFileSize(0);
     knownMtimeRef.current = 0;
     setLastFile(null);
     setMode("code");
-  }, [snapshotActiveTab, commitTabs, setActiveTab, newTabId, bumpDocSwap]);
+  }, [snapshotActiveTab, commitTabs, setActiveTab, newTabId, bumpDocSwap, activateTab]);
 
   // "Replay the welcome tour" from Settings → About. The tour spotlights
   // editor chrome, so make sure a buffer exists before showing it.
@@ -1606,19 +1622,32 @@ function AppContent() {
 
   // Tab-bar items. The active tab's name/dirty come from live state (its stored
   // snapshot lags until the next switch); inactive tabs read their snapshot.
-  // Keyed on `isDirty` (a boolean) so typing within an already-dirty file
-  // doesn't churn this list. TABS-01.
-  const tabBarItems = useMemo<TabBarItem[]>(
-    () => tabs.map((t) => {
+  // `label` disambiguates duplicate file names by folder (TABS-09); `name` is
+  // the bare file name (title/aria). Keyed on `isDirty` (a boolean) so typing
+  // within an already-dirty file doesn't churn this list. TABS-01.
+  const tabBarItems = useMemo<TabBarItem[]>(() => {
+    const resolved = tabs.map((t) => {
       const active = t.id === activeTabId;
       return {
         id: t.id,
-        name: active ? (fileName ?? "Untitled.md") : t.fileName,
+        fileName: active ? (fileName ?? "Untitled.md") : t.fileName,
+        filePath: active ? filePath : t.filePath,
         dirty: active ? isDirty : t.content !== t.originalContent,
       };
-    }),
-    [tabs, activeTabId, fileName, isDirty]
-  );
+    });
+    const labels = computeTabLabels(resolved);
+    return resolved.map((t) => ({
+      id: t.id,
+      name: t.fileName,
+      label: labels.get(t.id) ?? t.fileName,
+      dirty: t.dirty,
+    }));
+  }, [tabs, activeTabId, fileName, filePath, isDirty]);
+
+  // Drag-reorder: move a tab to a new index. TABS-10.
+  const handleReorderTab = useCallback((fromIndex: number, toIndex: number) => {
+    commitTabs(moveTab(tabsRef.current, fromIndex, toIndex));
+  }, [commitTabs]);
 
   return (
     <div className="h-screen flex flex-col bg-[var(--bg-primary)] overflow-hidden transition-colors">
@@ -1646,6 +1675,7 @@ function AppContent() {
           onSelect={activateTab}
           onClose={closeTab}
           onNewTab={handleNewFile}
+          onReorder={handleReorderTab}
         />
       )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,8 @@ import {
   initAIKey,
   getLastFile,
   getSavedViewMode,
+  getSession,
+  setSession,
   getSpellCheck,
   getSplitRatio,
   getToolbarEnabled,
@@ -94,7 +96,6 @@ import {
   setWordWrap,
 } from "./utils/persistence";
 import { getAutoSave } from "./utils/persistence";
-import { pickBootFile } from "./utils/boot";
 import { resolveRelativePath } from "./utils/resolveRelativePath";
 import { TabBar, type TabBarItem } from "./components/TabBar";
 import { findTabByPath, nextActiveAfterClose, type TabState } from "./utils/tabsModel";
@@ -524,51 +525,87 @@ function AppContent() {
         // Browser dev mode / older backend without the command — restore only.
       }
 
-      const target = pickBootFile(cliFile, getLastFile());
-      if (!target.path) {
+      // Assemble the ordered list of paths to reopen and which one is active.
+      // Prefer the full saved session (TABS-07); fall back to the single
+      // lastFile for sessions saved before multi-tab restore existed.
+      const session = getSession();
+      const cursorByPath = new Map<string, number | undefined>();
+      let paths: string[] = [];
+      let activePath: string | null = null;
+      if (session) {
+        paths = session.tabs.map((t) => t.path);
+        session.tabs.forEach((t) => cursorByPath.set(t.path, t.cursorLine));
+        activePath = session.tabs[session.activeIndex]?.path ?? paths[0] ?? null;
+      } else {
+        const last = getLastFile();
+        if (last) { paths = [last]; activePath = last; }
+      }
+      // A CLI / double-clicked file is always the active tab, appended if new.
+      if (cliFile) {
+        if (!paths.includes(cliFile)) paths.push(cliFile);
+        activePath = cliFile;
+      }
+
+      if (paths.length === 0) {
         setBooting(false);
         return;
       }
 
-      try {
-        const fileData = await invoke<FileData>("read_file", { path: target.path });
-        bumpDocSwap(); // restored document → editor starts with clean undo history
-        setFilePath(fileData.path);
-        setFileName(fileData.name);
-        setContent(fileData.content);
-        setOriginalContent(fileData.content);
-        setFileSize(fileData.size);
-        knownMtimeRef.current = fileData.modified ?? 0;
-        // Bump the recents entry's timestamp to "now" so it sorts as
-        // most-recent, and persist as the session file so the next plain
-        // launch restores what the user actually had open.
-        addRecentFile(fileData.path, fileData.name);
-        setLastFile(fileData.path);
-        // Seed the first tab for the restored file. TABS-01.
-        const id = newTabId();
-        commitTabs([{
-          id, filePath: fileData.path, fileName: fileData.name,
-          content: fileData.content, originalContent: fileData.content,
-          fileSize: fileData.size, knownMtime: fileData.modified ?? 0,
-        }]);
-        setActiveTab(id);
-      } catch (err) {
-        const msg = typeof err === "string" ? err : (err as { message?: string })?.message || "";
-        if (target.source === "cli") {
-          // The user explicitly asked for this file — always tell them why
-          // it didn't open (moved/deleted/too large).
-          showToast(`Could not open file: ${msg || target.path}`, "error");
-        } else {
-          // Stale session file (moved / deleted) — fail quietly like before,
-          // except the TooLarge case, which deserves an explanation.
-          setLastFile(null);
-          if (/too large/i.test(msg)) {
-            showToast(`Could not restore last file: ${msg}`, "error");
+      // Read each file, skipping any that have gone missing / too large. The CLI
+      // file's failure is always surfaced (the user explicitly asked for it).
+      const loaded: TabState[] = [];
+      let activeId: string | null = null;
+      for (const p of paths) {
+        try {
+          const fd = await invoke<FileData>("read_file", { path: p });
+          const id = newTabId();
+          loaded.push({
+            id, filePath: fd.path, fileName: fd.name,
+            content: fd.content, originalContent: fd.content,
+            fileSize: fd.size, knownMtime: fd.modified ?? 0,
+            cursorLine: cursorByPath.get(p),
+          });
+          if (p === activePath) activeId = id;
+        } catch (err) {
+          const msg = typeof err === "string" ? err : (err as { message?: string })?.message || "";
+          if (cliFile && p === cliFile) {
+            showToast(`Could not open file: ${msg || p}`, "error");
+          } else if (/too large/i.test(msg)) {
+            showToast(`Could not restore "${p}": ${msg}`, "error");
           }
+          // Otherwise a stale session entry — drop it quietly.
         }
-      } finally {
-        setBooting(false);
       }
+
+      if (loaded.length === 0) {
+        setSession(null);
+        setLastFile(null);
+        setBooting(false);
+        return;
+      }
+      if (!activeId) activeId = loaded[0].id;
+      const activeTabData = loaded.find((t) => t.id === activeId)!;
+
+      bumpDocSwap(); // restored document → editor starts with clean undo history
+      commitTabs(loaded);
+      setActiveTab(activeId);
+      setFilePath(activeTabData.filePath);
+      setFileName(activeTabData.fileName);
+      setContent(activeTabData.content);
+      setOriginalContent(activeTabData.content);
+      setFileSize(activeTabData.fileSize);
+      knownMtimeRef.current = activeTabData.knownMtime;
+      addRecentFile(activeTabData.filePath!, activeTabData.fileName);
+      setLastFile(activeTabData.filePath);
+      // Restore the active tab's caret line once the editor has mounted.
+      const line = activeTabData.cursorLine ?? 1;
+      if (line > 1) {
+        window.setTimeout(
+          () => window.dispatchEvent(new CustomEvent("paperling:goto-line", { detail: { line } })),
+          150
+        );
+      }
+      setBooting(false);
     })();
     // Run only once on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -761,6 +798,26 @@ function AppContent() {
     window.addEventListener("focus", onFocus);
     return () => window.removeEventListener("focus", onFocus);
   }, [commitTabs, showToast]);
+
+  // Persist the whole open-tab session (paths + which is active) so a relaunch
+  // reopens everything, not just one file. Runs whenever the tab list or the
+  // active tab changes. Untitled buffers have no path and are omitted. The
+  // active tab's caret line comes from the live currentLineRef (its snapshot
+  // lags until the next switch). TABS-07.
+  useEffect(() => {
+    const activeId = activeTabIdRef.current;
+    const persistable = tabs.filter((t) => t.filePath);
+    if (persistable.length === 0) {
+      setSession(null);
+      return;
+    }
+    const sessTabs = persistable.map((t) => ({
+      path: t.filePath!,
+      cursorLine: t.id === activeId ? currentLineRef.current : t.cursorLine,
+    }));
+    const activeIdx = persistable.findIndex((t) => t.id === activeId);
+    setSession({ tabs: sessTabs, activeIndex: activeIdx < 0 ? 0 : activeIdx });
+  }, [tabs, activeTabId]);
 
   // Open a file: if it's already in a tab, just switch to it (preserving any
   // unsaved edits there); otherwise load it into a new tab. With tabs there's no

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1071,14 +1071,15 @@ function AppContent() {
   // Open a cross-file search result: load the file (if not already open) and
   // jump to the matching line once it has rendered. The goto-line event is the
   // same one the TOC/palette use, so it lands correctly in any view mode. SEARCH-01.
-  const handleOpenSearchResult = useCallback((path: string, line: number) => {
-    const jump = () => window.setTimeout(
-      () => window.dispatchEvent(new CustomEvent("paperling:goto-line", { detail: { line } })),
-      120
+  const handleOpenSearchResult = useCallback(async (path: string, line: number) => {
+    // Wait for the file to actually load before jumping, instead of racing a
+    // fixed timeout that a large document could lose (landing at the top). SEARCH-01.
+    if (path !== filePathRef.current) {
+      await loadFile(path);
+    }
+    requestAnimationFrame(() =>
+      window.dispatchEvent(new CustomEvent("paperling:goto-line", { detail: { line } }))
     );
-    if (path === filePathRef.current) { jump(); return; }
-    loadFile(path);
-    jump();
   }, [loadFile]);
 
   // Folder the cross-file search runs in: the open file's directory.
@@ -1132,8 +1133,9 @@ function AppContent() {
   // Open file dialog
   const handleOpenFile = useCallback(async () => {
     try {
+      // Allow selecting several files at once — each opens in its own tab. TABS-11.
       const selected = await open({
-        multiple: false,
+        multiple: true,
         filters: [
           {
             name: "Markdown",
@@ -1142,8 +1144,10 @@ function AppContent() {
         ],
       });
 
-      if (selected && typeof selected === "string") {
+      if (typeof selected === "string") {
         await loadFile(selected);
+      } else if (Array.isArray(selected)) {
+        for (const p of selected) await loadFile(p);
       }
     } catch (err) {
       console.error("Failed to open file dialog:", err);
@@ -1443,6 +1447,15 @@ function AppContent() {
         keywords: "words count reading time",
         run: () => setShowStats(true),
       });
+      items.push({
+        id: "tab.close",
+        label: "Close tab",
+        hint: "Ctrl+W",
+        section: "File",
+        icon: "tab_close",
+        keywords: "close current tab",
+        run: () => { if (activeTabIdRef.current) closeTab(activeTabIdRef.current); },
+      });
     }
 
     // === View === only when a buffer exists
@@ -1612,7 +1625,7 @@ function AppContent() {
     // separate hook that's gated on the palette actually being open.
     handleNewFile, handleOpenFile, handleSaveFile, handleSaveAs,
     handleToggleSplit, handleToggleFileExplorer, handleToggleTOC, toggleFullscreen,
-    loadFile, filePath, hasFile, showToast,
+    loadFile, filePath, hasFile, showToast, closeTab,
     typewriterModeEnabled, toolbarVisible, aiEnabled,
     theme, setTheme,
   ]);
@@ -1651,12 +1664,32 @@ function AppContent() {
     return items;
   }, [showPalette, deferredContent]);
 
+  // "Open tabs" palette section — jump to any open tab by name (only worthwhile
+  // with more than one open). Uses the same folder disambiguation as the bar. TABS-11.
+  const tabPaletteItems = useMemo<PaletteCommand[]>(() => {
+    if (tabs.length < 2) return [];
+    const resolved = tabs.map((t) => ({
+      id: t.id,
+      fileName: t.id === activeTabId ? (fileName ?? "Untitled.md") : t.fileName,
+      filePath: t.id === activeTabId ? filePath : t.filePath,
+    }));
+    const labels = computeTabLabels(resolved);
+    return tabs.map((t) => ({
+      id: `opentab.${t.id}`,
+      label: `${labels.get(t.id) ?? t.fileName}${t.id === activeTabId ? " (current)" : ""}`,
+      section: "Open tabs",
+      icon: "tab",
+      keywords: "switch tab open file",
+      run: () => activateTab(t.id),
+    }));
+  }, [tabs, activeTabId, fileName, filePath, activateTab]);
+
   // Concatenated list passed to the palette. Same `paletteItems` shape as
   // before so the CommandPalette component sees no API change. Reference
-  // changes only when one of the two sources changes — typically rare.
+  // changes only when one of the sources changes — typically rare.
   const fullPaletteItems = useMemo<PaletteCommand[]>(
-    () => (headingPaletteItems.length ? [...paletteItems, ...headingPaletteItems] : paletteItems),
-    [paletteItems, headingPaletteItems]
+    () => [...paletteItems, ...tabPaletteItems, ...headingPaletteItems],
+    [paletteItems, tabPaletteItems, headingPaletteItems]
   );
 
   // Tab-bar items. The active tab's name/dirty come from live state (its stored

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -306,6 +306,29 @@ function AppContent() {
   }, []);
   const newTabId = useCallback(() => `tab-${++tabSeqRef.current}`, []);
 
+  // Every open tab that has unsaved changes, reading the ACTIVE tab from live
+  // state (its stored snapshot lags until the next switch) and the rest from
+  // their snapshots. Used by the window-close guard so background tabs can't be
+  // discarded silently. TABS-04.
+  const collectDirtyTabs = useCallback(() => {
+    const live = liveRef.current;
+    const activeId = activeTabIdRef.current;
+    return tabsRef.current
+      .map((t) => {
+        const isActive = t.id === activeId;
+        return {
+          id: t.id,
+          filePath: isActive ? live.filePath : t.filePath,
+          fileName: isActive ? (live.fileName ?? "Untitled.md") : t.fileName,
+          content: isActive ? live.content : t.content,
+          dirty: isActive
+            ? live.content !== live.originalContent
+            : t.content !== t.originalContent,
+        };
+      })
+      .filter((t) => t.dirty);
+  }, []);
+
   // Write the live editor state back into the active tab's entry.
   const snapshotActiveTab = useCallback(() => {
     const id = activeTabIdRef.current;
@@ -579,7 +602,9 @@ function AppContent() {
     try {
       Window.getCurrent()
         .onCloseRequested((event) => {
-          if (contentRef.current !== originalContentRef.current) {
+          // Guard ALL tabs, not just the active one — a dirty background tab used
+          // to be discarded silently on Alt+F4 / taskbar close. TABS-04.
+          if (collectDirtyTabs().length > 0) {
             event.preventDefault();
             setShowUnsavedBeforeClose(true);
           }
@@ -594,6 +619,8 @@ function AppContent() {
       mounted = false;
       unlisten?.();
     };
+    // Registered once; collectDirtyTabs is stable (reads refs).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Close-dialog handlers. destroy() skips the close-requested event, so we
@@ -602,33 +629,30 @@ function AppContent() {
     Window.getCurrent().destroy().catch(() => {/* browser dev mode */});
   }, []);
 
+  // Save EVERY dirty tab, then close. An untitled tab prompts for a location;
+  // cancelling that (or any failed save) aborts the close so nothing is lost. TABS-04.
   const handleSaveAndCloseWindow = useCallback(async () => {
     setShowUnsavedBeforeClose(false);
-    const path = filePathRef.current;
-    if (path) {
+    for (const t of collectDirtyTabs()) {
+      let path = t.filePath;
+      if (!path) {
+        const selected = await save({
+          filters: [{ name: "Markdown", extensions: ["md"] }],
+          defaultPath: t.fileName,
+        });
+        if (!selected) return; // cancelled a save-as → keep the app open
+        path = selected;
+      }
       try {
-        await invoke("save_file", { path, content: contentRef.current });
+        await invoke("save_file", { path, content: t.content });
       } catch (err) {
         const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
-        showToast(msg || "Failed to save file", "error");
+        showToast(msg || `Failed to save ${t.fileName}`, "error");
         return; // don't close on a failed save — the user would lose the buffer
-      }
-    } else {
-      // Untitled buffer: prompt for a location; cancel keeps the app open.
-      const selected = await save({
-        filters: [{ name: "Markdown", extensions: ["md"] }],
-        defaultPath: fileName ?? undefined,
-      });
-      if (!selected) return;
-      try {
-        await invoke("save_file", { path: selected, content: contentRef.current });
-      } catch {
-        showToast("Failed to save file", "error");
-        return;
       }
     }
     forceCloseWindow();
-  }, [fileName, forceCloseWindow, showToast]);
+  }, [collectDirtyTabs, forceCloseWindow, showToast]);
 
   const handleDiscardAndCloseWindow = useCallback(() => {
     setShowUnsavedBeforeClose(false);
@@ -1637,6 +1661,7 @@ function AppContent() {
             onClose={() => setShowUnsavedBeforeClose(false)}
             onDiscard={handleDiscardAndCloseWindow}
             onSave={handleSaveAndCloseWindow}
+            dirtyNames={tabBarItems.filter((t) => t.dirty).map((t) => t.name)}
           />
         </Suspense>
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -184,6 +184,8 @@ function AppContent() {
   // Unsaved-changes dialog for window close (Alt+F4, taskbar close, the title
   // bar X). The Tauri close-requested handler below intercepts ALL of them.
   const [showUnsavedBeforeClose, setShowUnsavedBeforeClose] = useState(false);
+  // Pending dirty-tab close, awaiting the Save/Discard/Cancel dialog. TABS-05.
+  const [closeTabPrompt, setCloseTabPrompt] = useState<{ id: string; fileName: string } | null>(null);
   // Find bar over the reader-mode preview (Ctrl+F when mode === "preview").
   const [previewFindOpen, setPreviewFindOpen] = useState(false);
   // Autosave: save a moment after the user stops typing (Settings → Editor).
@@ -705,22 +707,10 @@ function AppContent() {
     await loadFileDirect(path);
   }, [activateTab, loadFileDirect]);
 
-  // Close a tab. Prompts before discarding unsaved changes; when the active tab
-  // closes, focus the neighbour (or fall back to the welcome screen). TABS-01.
-  const closeTab = useCallback(async (id: string) => {
-    const tab = tabsRef.current.find((t) => t.id === id);
-    if (!tab) return;
+  // Remove a tab and refocus a neighbour (or fall back to the welcome screen).
+  // No dirty check here — callers decide whether to prompt first. TABS-01.
+  const finalizeCloseTab = useCallback((id: string) => {
     const isActive = id === activeTabIdRef.current;
-    const dirty = isActive
-      ? liveRef.current.content !== liveRef.current.originalContent
-      : tab.content !== tab.originalContent;
-    if (dirty) {
-      const discard = await ask(`Discard unsaved changes to "${tab.fileName}"?`, {
-        title: "Close tab",
-        kind: "warning",
-      });
-      if (!discard) return;
-    }
     const nextId = nextActiveAfterClose(tabsRef.current, id);
     const remaining = tabsRef.current.filter((t) => t.id !== id);
     commitTabs(remaining);
@@ -733,6 +723,7 @@ function AppContent() {
       // Last tab closed — return to the clean welcome state.
       setActiveTab(null);
       setProposedDoc(null);
+      bumpDocSwap();
       setFilePath(null);
       setFileName(null);
       setContent("");
@@ -741,7 +732,70 @@ function AppContent() {
       knownMtimeRef.current = 0;
       setLastFile(null);
     }
-  }, [commitTabs, setActiveTab, applyTabToLive]);
+  }, [commitTabs, setActiveTab, applyTabToLive, bumpDocSwap]);
+
+  // Close a tab. A clean tab closes immediately; a dirty one opens the
+  // Save / Discard / Cancel dialog (TABS-05) rather than the old two-button
+  // discard-or-cancel prompt.
+  const closeTab = useCallback((id: string) => {
+    const tab = tabsRef.current.find((t) => t.id === id);
+    if (!tab) return;
+    const isActive = id === activeTabIdRef.current;
+    const dirty = isActive
+      ? liveRef.current.content !== liveRef.current.originalContent
+      : tab.content !== tab.originalContent;
+    if (dirty) {
+      setCloseTabPrompt({ id, fileName: isActive ? (liveRef.current.fileName ?? "Untitled.md") : tab.fileName });
+      return;
+    }
+    finalizeCloseTab(id);
+  }, [finalizeCloseTab]);
+
+  // The effective save target for a tab, reading the active tab from live state.
+  const getTabSaveData = useCallback((id: string) => {
+    const t = tabsRef.current.find((x) => x.id === id);
+    if (!t) return null;
+    const isActive = id === activeTabIdRef.current;
+    const live = liveRef.current;
+    return {
+      filePath: isActive ? live.filePath : t.filePath,
+      fileName: isActive ? (live.fileName ?? "Untitled.md") : t.fileName,
+      content: isActive ? live.content : t.content,
+    };
+  }, []);
+
+  // "Save" in the close-tab dialog: persist the tab (prompting a location for an
+  // untitled buffer), then close it. Cancel/failure keeps the tab open. TABS-05.
+  const handleSaveCloseTab = useCallback(async () => {
+    const prompt = closeTabPrompt;
+    if (!prompt) return;
+    const data = getTabSaveData(prompt.id);
+    if (!data) { setCloseTabPrompt(null); return; }
+    let path = data.filePath;
+    if (!path) {
+      const selected = await save({
+        filters: [{ name: "Markdown", extensions: ["md"] }],
+        defaultPath: data.fileName,
+      });
+      if (!selected) return; // cancelled save-as → keep the tab open
+      path = selected;
+    }
+    try {
+      await invoke("save_file", { path, content: data.content });
+    } catch (err) {
+      const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
+      showToast(msg || "Failed to save file", "error");
+      return; // keep the tab open on a failed save
+    }
+    setCloseTabPrompt(null);
+    finalizeCloseTab(prompt.id);
+  }, [closeTabPrompt, getTabSaveData, showToast, finalizeCloseTab]);
+
+  const handleDiscardCloseTab = useCallback(() => {
+    const prompt = closeTabPrompt;
+    setCloseTabPrompt(null);
+    if (prompt) finalizeCloseTab(prompt.id);
+  }, [closeTabPrompt, finalizeCloseTab]);
 
   // Listen for Tauri drag-drop events
   useEffect(() => {
@@ -1662,6 +1716,20 @@ function AppContent() {
             onDiscard={handleDiscardAndCloseWindow}
             onSave={handleSaveAndCloseWindow}
             dirtyNames={tabBarItems.filter((t) => t.dirty).map((t) => t.name)}
+          />
+        </Suspense>
+      )}
+
+      {/* Save/Discard/Cancel when closing a single dirty tab (Ctrl+W, the tab's
+          × or middle-click). TABS-05. */}
+      {closeTabPrompt && (
+        <Suspense fallback={null}>
+          <UnsavedChangesDialog
+            isOpen={!!closeTabPrompt}
+            onClose={() => setCloseTabPrompt(null)}
+            onDiscard={handleDiscardCloseTab}
+            onSave={handleSaveCloseTab}
+            dirtyNames={[closeTabPrompt.fileName]}
           />
         </Suspense>
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -300,6 +300,9 @@ function AppContent() {
   tabsRef.current = tabs;
   const activeTabIdRef = useRef<string | null>(null);
   activeTabIdRef.current = activeTabId;
+  // Stack of recently-closed tabs (path + caret line) for Ctrl+Shift+T. Only
+  // saved files are recoverable; untitled buffers aren't pushed. TABS-15.
+  const closedTabsRef = useRef<{ path: string; cursorLine?: number }[]>([]);
   const liveRef = useRef({ filePath, fileName, content, originalContent, fileSize });
   liveRef.current = { filePath, fileName, content, originalContent, fileSize };
   // The line we'd return to when this file is re-activated: the caret line while
@@ -836,9 +839,42 @@ function AppContent() {
     await loadFileDirect(path);
   }, [activateTab, loadFileDirect]);
 
+  // Reopen the most recently closed (saved) tab, restoring its caret line. TABS-15.
+  const reopenClosedTab = useCallback(() => {
+    const entry = closedTabsRef.current.pop();
+    if (!entry) return;
+    loadFile(entry.path);
+    if (entry.cursorLine && entry.cursorLine > 1) {
+      const line = entry.cursorLine;
+      window.setTimeout(
+        () => window.dispatchEvent(new CustomEvent("paperling:goto-line", { detail: { line } })),
+        150
+      );
+    }
+  }, [loadFile]);
+
+  // Jump to a tab by position (Ctrl+1..8); index -1 means the last tab (Ctrl+9,
+  // browser convention). TABS-16.
+  const gotoTabByIndex = useCallback((index: number) => {
+    const list = tabsRef.current;
+    if (list.length === 0) return;
+    const target = index === -1 ? list[list.length - 1] : list[index];
+    if (target) activateTab(target.id);
+  }, [activateTab]);
+
   // Remove a tab and refocus a neighbour (or fall back to the welcome screen).
   // No dirty check here — callers decide whether to prompt first. TABS-01.
   const finalizeCloseTab = useCallback((id: string) => {
+    // Remember saved tabs so Ctrl+Shift+T can reopen them. TABS-15.
+    const closing = tabsRef.current.find((t) => t.id === id);
+    if (closing?.filePath) {
+      const isActiveClosing = id === activeTabIdRef.current;
+      closedTabsRef.current.push({
+        path: closing.filePath,
+        cursorLine: isActiveClosing ? currentLineRef.current : closing.cursorLine,
+      });
+      if (closedTabsRef.current.length > 25) closedTabsRef.current.shift();
+    }
     const isActive = id === activeTabIdRef.current;
     const nextId = nextActiveAfterClose(tabsRef.current, id);
     const remaining = tabsRef.current.filter((t) => t.id !== id);
@@ -1315,6 +1351,8 @@ function AppContent() {
     closeActiveTab: () => { if (activeTabIdRef.current) closeTab(activeTabIdRef.current); },
     prevTab: () => cycleTab(-1),
     nextTab: () => cycleTab(1),
+    reopenClosedTab,
+    gotoTab: gotoTabByIndex,
     hasFile, content, mode,
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,6 +98,7 @@ import {
 import { getAutoSave } from "./utils/persistence";
 import { resolveRelativePath } from "./utils/resolveRelativePath";
 import { TabBar, type TabBarItem } from "./components/TabBar";
+import { TabContextMenu } from "./components/TabContextMenu";
 import {
   findTabByPath,
   nextActiveAfterClose,
@@ -1687,6 +1688,45 @@ function AppContent() {
     commitTabs(moveTab(tabsRef.current, fromIndex, toIndex));
   }, [commitTabs]);
 
+  // Close a set of tabs, but only the CLEAN ones — dirty tabs are kept open
+  // (never silently discarded) and reported. Used by the context-menu
+  // "Close others / Close to the right" actions. TABS-12.
+  const closeManyClean = useCallback((ids: string[]) => {
+    let keptDirty = 0;
+    for (const id of ids) {
+      const t = tabsRef.current.find((x) => x.id === id);
+      if (!t) continue;
+      const dirty = id === activeTabIdRef.current
+        ? liveRef.current.content !== liveRef.current.originalContent
+        : t.content !== t.originalContent;
+      if (dirty) { keptDirty++; continue; }
+      finalizeCloseTab(id);
+    }
+    if (keptDirty > 0) {
+      showToast(`Kept ${keptDirty} unsaved tab${keptDirty > 1 ? "s" : ""} open`, "info");
+    }
+  }, [finalizeCloseTab, showToast]);
+
+  const handleTabMenuAction = useCallback((action: "closeOthers" | "closeRight", id: string) => {
+    const list = tabsRef.current;
+    if (action === "closeOthers") {
+      closeManyClean(list.filter((t) => t.id !== id).map((t) => t.id));
+    } else {
+      const idx = list.findIndex((t) => t.id === id);
+      if (idx >= 0) closeManyClean(list.slice(idx + 1).map((t) => t.id));
+    }
+    // Keep the anchor tab focused if it survived.
+    if (tabsRef.current.some((t) => t.id === id) && id !== activeTabIdRef.current) {
+      activateTab(id);
+    }
+  }, [closeManyClean, activateTab]);
+
+  // Right-click menu on a tab: {id, x, y} while open. TABS-12.
+  const [tabMenu, setTabMenu] = useState<{ id: string; x: number; y: number } | null>(null);
+  const handleTabContextMenu = useCallback((id: string, x: number, y: number) => {
+    setTabMenu({ id, x, y });
+  }, []);
+
   return (
     <div className="h-screen flex flex-col bg-[var(--bg-primary)] overflow-hidden transition-colors">
       <TitleBar
@@ -1714,6 +1754,7 @@ function AppContent() {
           onClose={closeTab}
           onNewTab={handleNewFile}
           onReorder={handleReorderTab}
+          onContextMenu={handleTabContextMenu}
         />
       )}
 
@@ -1993,6 +2034,36 @@ function AppContent() {
       {showTour && hasFile && !booting && (
         <Tour onClose={handleCloseTour} onSetMode={setMode} />
       )}
+
+      {/* Tab right-click menu. TABS-12. */}
+      {tabMenu && (() => {
+        const menuTab = tabs.find((t) => t.id === tabMenu.id);
+        const isActiveMenu = tabMenu.id === activeTabId;
+        const menuPath = isActiveMenu ? filePath : (menuTab?.filePath ?? null);
+        const idx = tabs.findIndex((t) => t.id === tabMenu.id);
+        const hasRight = idx >= 0 && idx < tabs.length - 1;
+        const others = tabs.length > 1;
+        return (
+          <TabContextMenu
+            x={tabMenu.x}
+            y={tabMenu.y}
+            onClose={() => setTabMenu(null)}
+            actions={[
+              { label: "Close", icon: "close", onClick: () => closeTab(tabMenu.id) },
+              { label: "Close others", icon: "close_fullscreen", disabled: !others, onClick: () => handleTabMenuAction("closeOthers", tabMenu.id) },
+              { label: "Close to the right", icon: "keyboard_tab", disabled: !hasRight, onClick: () => handleTabMenuAction("closeRight", tabMenu.id) },
+              {
+                label: "Copy path", icon: "content_copy", dividerBefore: true, disabled: !menuPath,
+                onClick: () => { if (menuPath) navigator.clipboard.writeText(menuPath).then(() => showToast("File path copied", "success"), () => showToast("Could not copy path", "error")); },
+              },
+              {
+                label: "Reveal in folder", icon: "folder_open", disabled: !menuPath,
+                onClick: () => { if (menuPath) revealItemInDir(menuPath).catch(() => showToast("Could not reveal file", "error")); },
+              },
+            ]}
+          />
+        );
+      })()}
 
       {/* Toast notifications */}
       <ToastStack toasts={toasts} onDismiss={dismissToast} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -698,6 +698,70 @@ function AppContent() {
     onError: handleAutosaveError,
   });
 
+  // Autosave dirty BACKGROUND tabs too (useAutosave above only covers the active
+  // buffer). A background tab's content only changes when you switch away from
+  // it, so this effect keys on `tabs` — it never re-runs on active-tab keystrokes
+  // (those live in `content`, not the snapshot). Saved tabs get their
+  // originalContent/knownMtime updated, which clears them from the dirty set so
+  // the effect settles without looping. TABS-06.
+  useEffect(() => {
+    if (!autoSaveEnabled) return;
+    const activeId = activeTabIdRef.current;
+    const dirtyBg = tabs.filter(
+      (t) => t.id !== activeId && t.filePath && t.content !== t.originalContent
+    );
+    if (dirtyBg.length === 0) return;
+    const timer = window.setTimeout(async () => {
+      for (const t of dirtyBg) {
+        try {
+          const mtime = await invoke<number>("save_file", { path: t.filePath!, content: t.content });
+          // Only mark saved if the snapshot still holds exactly what we wrote.
+          commitTabs(
+            tabsRef.current.map((x) =>
+              x.id === t.id && x.content === t.content
+                ? { ...x, originalContent: t.content, knownMtime: mtime }
+                : x
+            )
+          );
+        } catch {/* best-effort; the active-tab path surfaces disk errors */}
+      }
+    }, 1500);
+    return () => window.clearTimeout(timer);
+  }, [tabs, autoSaveEnabled, commitTabs]);
+
+  // External-change detection for BACKGROUND tabs. The active tab is handled by
+  // useExternalChangeWatcher; on window focus we also stat every other open
+  // file. A clean background tab silently refreshes its snapshot; a dirty one
+  // gets a one-time conflict warning (its knownMtime is advanced so it won't
+  // re-toast every focus). TABS-06.
+  useEffect(() => {
+    const onFocus = async () => {
+      const activeId = activeTabIdRef.current;
+      const bg = tabsRef.current.filter((t) => t.id !== activeId && t.filePath);
+      for (const t of bg) {
+        try {
+          const info = await invoke<{ modified: number }>("get_file_info", { path: t.filePath! });
+          if (!(t.knownMtime > 0 && info.modified > t.knownMtime)) continue;
+          if (t.content === t.originalContent) {
+            const fd = await invoke<FileData>("read_file", { path: t.filePath! });
+            commitTabs(
+              tabsRef.current.map((x) =>
+                x.id === t.id
+                  ? { ...x, content: fd.content, originalContent: fd.content, fileSize: fd.size, knownMtime: fd.modified ?? 0 }
+                  : x
+              )
+            );
+          } else {
+            commitTabs(tabsRef.current.map((x) => (x.id === t.id ? { ...x, knownMtime: info.modified } : x)));
+            showToast(`"${t.fileName}" changed on disk in a background tab. Saving it will overwrite those changes.`, "error");
+          }
+        } catch {/* file gone / stat failed — surfaced when that tab is saved */}
+      }
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [commitTabs, showToast]);
+
   // Open a file: if it's already in a tab, just switch to it (preserving any
   // unsaved edits there); otherwise load it into a new tab. With tabs there's no
   // need to prompt before opening — the current file stays open in its own tab.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -233,6 +233,15 @@ function AppContent() {
   // "Has a buffer" — true once a file is opened OR a blank Untitled buffer is started
   const hasFile = filePath !== null || fileName !== null;
 
+  // Keep the native window title (taskbar / Alt-Tab) in step with the active
+  // file and its dirty state, so two Paperling windows are distinguishable and
+  // a leading bullet flags unsaved work. Keyed on the dirty BOOLEAN (not raw
+  // content) so it doesn't fire an IPC call on every keystroke. TITLE-01.
+  useEffect(() => {
+    const title = fileName ? `${isDirty ? "• " : ""}${fileName} — Paperling` : "Paperling";
+    Window.getCurrent().setTitle(title).catch(() => {/* browser dev mode */});
+  }, [fileName, isDirty]);
+
   // First-run welcome tour: auto-start the first time a buffer is on screen.
   // The tour anchors to elements (mode toggle, editor panes) that only exist
   // once a file is open, so it can't run over the WelcomeScreen.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,6 +157,11 @@ function AppContent() {
   // the snapshots of every open file (incl. the active one). TABS-01.
   const [tabs, setTabs] = useState<TabState[]>([]);
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
+  // Bumped on every genuine document swap (tab switch, file open, new file) so
+  // the editor can reset its undo history and Ctrl+Z can't reach into the
+  // previously-shown document. See CodeEditor's docSwapId effect. TABS-03.
+  const [docSwapId, setDocSwapId] = useState(0);
+  const bumpDocSwap = useCallback(() => setDocSwapId((n) => n + 1), []);
   const [splitRatio, setSplitRatioState] = usePersistedState<number>(getSplitRatio, setSplitRatio);
   const [aiConfig, setAiConfigState] = useState(() => getAIConfig());
   const [aiEnabled, setAiEnabledState] = usePersistedState<boolean>(getAIEnabled, setAIEnabled);
@@ -321,6 +326,7 @@ function AppContent() {
   // Load a tab's stored snapshot into the live editor state.
   const applyTabToLive = useCallback((tab: TabState) => {
     setProposedDoc(null); // an AI review belongs to the file we're leaving
+    bumpDocSwap(); // new document → editor resets undo history. TABS-03.
     setFilePath(tab.filePath);
     setFileName(tab.fileName);
     setContent(tab.content);
@@ -335,7 +341,7 @@ function AppContent() {
       if (line > 1) window.dispatchEvent(new CustomEvent("paperling:goto-line", { detail: { line } }));
       else window.dispatchEvent(new CustomEvent("paperling:scroll-top"));
     });
-  }, []);
+  }, [bumpDocSwap]);
 
   // Switch to an already-open tab, snapshotting the current one first.
   const activateTab = useCallback((id: string) => {
@@ -365,6 +371,7 @@ function AppContent() {
     setIsLoading(true);
     try {
       const fileData = await invoke<FileData>("read_file", { path });
+      bumpDocSwap(); // new document → editor resets undo history. TABS-03.
       setFilePath(fileData.path);
       setFileName(fileData.name);
       setContent(fileData.content);
@@ -405,7 +412,7 @@ function AppContent() {
     } finally {
       setIsLoading(false);
     }
-  }, [showToast, snapshotActiveTab, commitTabs, setActiveTab, newTabId]);
+  }, [showToast, snapshotActiveTab, commitTabs, setActiveTab, newTabId, bumpDocSwap]);
 
   // Settings flags above persist themselves via usePersistedState; the matching
   // setters (setSavedViewMode, setSplitRatio, …) are passed into that hook.
@@ -500,6 +507,7 @@ function AppContent() {
 
       try {
         const fileData = await invoke<FileData>("read_file", { path: target.path });
+        bumpDocSwap(); // restored document → editor starts with clean undo history
         setFilePath(fileData.path);
         setFileName(fileData.name);
         setContent(fileData.content);
@@ -840,6 +848,7 @@ function AppContent() {
   // stays open in its tab, so nothing is discarded). TABS-01.
   const handleNewFile = useCallback(() => {
     snapshotActiveTab();
+    bumpDocSwap(); // fresh Untitled buffer → editor resets undo history. TABS-03.
     const id = newTabId();
     commitTabs([...tabsRef.current, {
       id, filePath: null, fileName: "Untitled.md",
@@ -855,7 +864,7 @@ function AppContent() {
     knownMtimeRef.current = 0;
     setLastFile(null);
     setMode("code");
-  }, [snapshotActiveTab, commitTabs, setActiveTab, newTabId]);
+  }, [snapshotActiveTab, commitTabs, setActiveTab, newTabId, bumpDocSwap]);
 
   // "Replay the welcome tour" from Settings → About. The tour spotlights
   // editor chrome, so make sure a buffer exists before showing it.
@@ -1491,6 +1500,7 @@ function AppContent() {
             >
               <CodeEditor
                 content={content}
+                docSwapId={docSwapId}
                 onChange={handleContentChange}
                 onCursorChange={handleCursorChange}
                 onSelectionChange={handleSelectionChange}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,6 +97,7 @@ import {
 } from "./utils/persistence";
 import { getAutoSave } from "./utils/persistence";
 import { resolveRelativePath } from "./utils/resolveRelativePath";
+import { errMessage } from "./utils/errors";
 import { TabBar, type TabBarItem } from "./components/TabBar";
 import { TabContextMenu } from "./components/TabContextMenu";
 import {
@@ -454,7 +455,7 @@ function AppContent() {
       // Surface the actual error from Rust so "File too large" / "File not
       // found" reaches the user instead of a generic message — without this,
       // hitting the new 50 MB cap looked exactly like a permission error.
-      const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
+      const msg = errMessage(err);
       showToast(msg || "Failed to open file", "error");
     } finally {
       setIsLoading(false);
@@ -588,7 +589,7 @@ function AppContent() {
           });
           if (p === activePath) activeId = id;
         } catch (err) {
-          const msg = typeof err === "string" ? err : (err as { message?: string })?.message || "";
+          const msg = errMessage(err);
           if (cliFile && p === cliFile) {
             showToast(`Could not open file: ${msg || p}`, "error");
           } else if (/too large/i.test(msg)) {
@@ -706,7 +707,7 @@ function AppContent() {
       try {
         await invoke("save_file", { path, content: t.content });
       } catch (err) {
-        const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
+        const msg = errMessage(err);
         showToast(msg || `Failed to save ${t.fileName}`, "error");
         return; // don't close on a failed save — the user would lose the buffer
       }
@@ -958,7 +959,7 @@ function AppContent() {
     try {
       await invoke("save_file", { path, content: data.content });
     } catch (err) {
-      const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
+      const msg = errMessage(err);
       showToast(msg || "Failed to save file", "error");
       return; // keep the tab open on a failed save
     }
@@ -978,10 +979,10 @@ function AppContent() {
     let unlisten: (() => void) | undefined;
 
     listen<{ paths: string[] }>(TauriEvent.DRAG_DROP, async (event) => {
-      // Open EVERY dropped markdown file in its own tab (the last one wins focus),
-      // rather than only the first. TABS-11.
-      const paths = (event.payload.paths ?? []).filter(
-        (p) => p.endsWith(".md") || p.endsWith(".markdown")
+      // Open EVERY dropped markdown / text file in its own tab (the last one
+      // wins focus), rather than only the first. TABS-11 / TXT-01.
+      const paths = (event.payload.paths ?? []).filter((p) =>
+        /\.(md|markdown|txt|text)$/i.test(p)
       );
       for (const p of paths) {
         await loadFile(p);
@@ -1012,7 +1013,7 @@ function AppContent() {
       await invoke<number>("save_file", { path, content: "" });
       await loadFile(path);
     } catch (err) {
-      const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
+      const msg = errMessage(err);
       showToast(msg || "Could not create note", "error");
     }
   }, [loadFile, showToast]);
@@ -1143,12 +1144,13 @@ function AppContent() {
   const handleOpenFile = useCallback(async () => {
     try {
       // Allow selecting several files at once — each opens in its own tab. TABS-11.
+      // Plain-text files open too (rendered as markdown, which degrades fine). TXT-01.
       const selected = await open({
         multiple: true,
         filters: [
           {
-            name: "Markdown",
-            extensions: ["md", "markdown"],
+            name: "Markdown & text",
+            extensions: ["md", "markdown", "txt", "text"],
           },
         ],
       });
@@ -1190,7 +1192,7 @@ function AppContent() {
       showToast("File saved", "success");
     } catch (err) {
       console.error("Failed to save file:", err);
-      const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
+      const msg = errMessage(err);
       showToast(msg || "Failed to save file", "error");
     }
   }, [content, fileName, showToast, commitTabs]);
@@ -1207,7 +1209,7 @@ function AppContent() {
       showToast("File saved", "success");
     } catch (err) {
       console.error("Failed to save file:", err);
-      const msg = typeof err === "string" ? err : (err as { message?: string })?.message;
+      const msg = errMessage(err);
       showToast(msg || "Failed to save file", "error");
     }
   }, [filePath, content, showToast, handleSaveAs]);

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -59,6 +59,11 @@ interface CodeEditorProps {
     /** Called when the user finishes a review: the final document (accept) or
      *  null (rejected everything — keep the original). */
     onReviewResolve?: (finalDoc: string | null) => void;
+    /** Bumped by App on every genuine document SWAP (tab switch, file open, new
+     *  file) — as opposed to an in-document edit. On each bump the editor clears
+     *  its undo history so Ctrl+Z can't reach back into the previous document (a
+     *  data-loss bug: undo used to "un-swap" the file). TABS-03. */
+    docSwapId?: number;
 }
 
 const EDITOR_FONT_FAMILY =
@@ -156,6 +161,7 @@ function CodeEditorImpl({
     aiConfig,
     reviewDoc,
     onReviewResolve,
+    docSwapId,
 }: CodeEditorProps) {
     const containerRef = useRef<HTMLDivElement>(null);
     const viewRef = useRef<EditorView | null>(null);
@@ -191,10 +197,17 @@ function CodeEditorImpl({
     // effect below skip the O(n) doc.toString() comparison on the common case
     // (the prop change is just our own keystroke echoing back through App state).
     const lastEmittedRef = useRef(content);
+    // Live mirror of the `content` prop, read by the doc-swap effect without
+    // making `content` one of its deps (it must fire ONLY on docSwapId).
+    const contentPropRef = useRef(content);
+    contentPropRef.current = content;
 
     // Reconfigurable extensions.
     const wrapCompRef = useRef(new Compartment());
     const spellCompRef = useRef(new Compartment());
+    // history() lives in a compartment so a document swap can reset undo state
+    // (reconfigure to [] then back) without rebuilding the whole editor. TABS-03.
+    const historyCompRef = useRef(new Compartment());
     // AI review (merge view) state.
     const mergeCompRef = useRef(new Compartment());
     const reviewingRef = useRef(false);
@@ -277,6 +290,7 @@ function CodeEditorImpl({
         const wrapComp = wrapCompRef.current;
         const spellComp = spellCompRef.current;
         const mergeComp = mergeCompRef.current;
+        const historyComp = historyCompRef.current;
 
         const editingKeymap = Prec.highest(keymap.of([
             { key: "Tab", run: (v) => runAction(v, (st) => handleTab(st, false)), shift: (v) => runAction(v, (st) => handleTab(st, true)) },
@@ -357,7 +371,7 @@ function CodeEditorImpl({
                     lineNumbers(),
                     highlightActiveLineGutter(),
                     highlightActiveLine(),
-                    history(),
+                    historyComp.of(history()),
                     drawSelection(),
                     dropCursor(),
                     closeBrackets(),
@@ -511,6 +525,30 @@ function CodeEditorImpl({
         }
         lastEmittedRef.current = content;
     }, [content]);
+
+    // Reset undo history whenever App swaps the whole document for a different
+    // file (tab switch, file open, new file). Without this, Ctrl+Z would undo
+    // the swap itself and restore the PREVIOUS file's text into the current tab —
+    // which autosave could then write to the wrong path. In-document edits
+    // (checkbox toggles, AI, frontmatter) don't bump docSwapId, so they stay
+    // undoable. Robust to effect order: if the content-sync effect above ran
+    // first it recorded the swap in the OLD history, which we then discard; if it
+    // hasn't run yet, `content` already equals the new doc so we set it here.
+    // TABS-03.
+    useEffect(() => {
+        const view = viewRef.current;
+        if (!view) return;
+        const doc = contentPropRef.current;
+        if (doc !== view.state.doc.toString()) {
+            view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: doc } });
+        }
+        lastEmittedRef.current = doc;
+        // Reconfigure the history compartment to a fresh instance — this is the
+        // documented way to clear CodeMirror's undo/redo stacks.
+        view.dispatch({ effects: historyCompRef.current.reconfigure([]) });
+        view.dispatch({ effects: historyCompRef.current.reconfigure(history()) });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [docSwapId]);
 
     // Reconfigure word-wrap / spellcheck when their props change.
     useEffect(() => {

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -37,12 +37,23 @@ const groups: ShortcutGroup[] = [
         ],
     },
     {
+        title: "Tabs",
+        items: [
+            { keys: `${cmd}+N`, description: "New tab" },
+            { keys: `${cmd}+W`, description: "Close tab" },
+            { keys: `${cmd}+Shift+T`, description: "Reopen closed tab" },
+            { keys: `${cmd}+Tab`, description: "Next tab" },
+            { keys: `${cmd}+Shift+Tab`, description: "Previous tab" },
+            { keys: "Alt+←/→", description: "Previous / next tab" },
+            { keys: `${cmd}+1-8`, description: "Jump to tab N" },
+            { keys: `${cmd}+9`, description: "Jump to last tab" },
+        ],
+    },
+    {
         title: "View",
         items: [
             { keys: `${cmd}+E`, description: "Toggle Reader / Code" },
             { keys: `${cmd}+\\`, description: "Toggle split view" },
-            { keys: "Alt+←", description: "Previous tab" },
-            { keys: "Alt+→", description: "Next tab" },
             { keys: "F11", description: "Toggle fullscreen" },
             { keys: `${cmd}+Shift+E`, description: "Toggle file explorer" },
             { keys: `${cmd}+Shift+F`, description: "Search across files" },

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,8 +1,11 @@
-import { memo } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 
 export interface TabBarItem {
     id: string;
+    /** Bare file name — used for the tooltip and accessible name. */
     name: string;
+    /** Display label; may be disambiguated with a folder suffix (TABS-09). */
+    label: string;
     dirty: boolean;
 }
 
@@ -12,42 +15,129 @@ interface TabBarProps {
     onSelect: (id: string) => void;
     onClose: (id: string) => void;
     onNewTab: () => void;
+    /** Drag-reorder: move the tab at fromIndex to toIndex. TABS-10. */
+    onReorder?: (fromIndex: number, toIndex: number) => void;
+    /** Right-click context menu on a tab. TABS-12. */
+    onContextMenu?: (id: string, x: number, y: number) => void;
 }
 
-function TabBarImpl({ tabs, activeId, onSelect, onClose, onNewTab }: TabBarProps) {
+function TabBarImpl({ tabs, activeId, onSelect, onClose, onNewTab, onReorder, onContextMenu }: TabBarProps) {
+    const listRef = useRef<HTMLDivElement>(null);
+    const tabRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+    const [dragIndex, setDragIndex] = useState<number | null>(null);
+    const [overIndex, setOverIndex] = useState<number | null>(null);
+
+    // Keep the active tab scrolled into view when it changes (e.g. Ctrl+Tab to a
+    // tab that's currently off-screen in an overflowing bar). TABS-13.
+    useEffect(() => {
+        if (!activeId) return;
+        tabRefs.current.get(activeId)?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }, [activeId, tabs.length]);
+
+    // Vertical wheel scrolls the bar horizontally, like a browser tab strip.
+    const onWheel = (e: React.WheelEvent) => {
+        const el = listRef.current;
+        if (!el || e.deltaY === 0) return;
+        el.scrollLeft += e.deltaY;
+    };
+
+    // Roving-tabindex keyboard navigation across the tablist. TABS-14.
+    const onKeyDown = (e: React.KeyboardEvent, index: number) => {
+        const focusAndSelect = (i: number) => {
+            const t = tabs[i];
+            if (!t) return;
+            onSelect(t.id);
+            tabRefs.current.get(t.id)?.focus();
+        };
+        if (e.key === "ArrowRight") {
+            e.preventDefault();
+            focusAndSelect((index + 1) % tabs.length);
+        } else if (e.key === "ArrowLeft") {
+            e.preventDefault();
+            focusAndSelect((index - 1 + tabs.length) % tabs.length);
+        } else if (e.key === "Home") {
+            e.preventDefault();
+            focusAndSelect(0);
+        } else if (e.key === "End") {
+            e.preventDefault();
+            focusAndSelect(tabs.length - 1);
+        } else if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onSelect(tabs[index].id);
+        } else if (e.key === "Delete" || e.key === "Backspace") {
+            e.preventDefault();
+            onClose(tabs[index].id);
+        }
+    };
+
     return (
         <div
+            ref={listRef}
             role="tablist"
             aria-label="Open files"
+            onWheel={onWheel}
             className="h-9 shrink-0 flex items-stretch overflow-x-auto bg-[var(--bg-titlebar)] border-b border-[var(--border)] no-select"
         >
-            {tabs.map((tab) => {
+            {tabs.map((tab, index) => {
                 const isActive = tab.id === activeId;
+                const isDropTarget = overIndex === index && dragIndex !== null && dragIndex !== index;
                 return (
                     <div
                         key={tab.id}
+                        ref={(el) => {
+                            if (el) tabRefs.current.set(tab.id, el);
+                            else tabRefs.current.delete(tab.id);
+                        }}
                         role="tab"
                         aria-selected={isActive}
+                        tabIndex={isActive ? 0 : -1}
                         title={tab.name}
+                        draggable={!!onReorder}
+                        onKeyDown={(e) => onKeyDown(e, index)}
+                        onDragStart={(e) => {
+                            setDragIndex(index);
+                            e.dataTransfer.effectAllowed = "move";
+                            // Firefox requires data to be set for a drag to start.
+                            e.dataTransfer.setData("text/plain", tab.id);
+                        }}
+                        onDragOver={(e) => {
+                            if (dragIndex === null) return;
+                            e.preventDefault();
+                            e.dataTransfer.dropEffect = "move";
+                            if (overIndex !== index) setOverIndex(index);
+                        }}
+                        onDrop={(e) => {
+                            e.preventDefault();
+                            if (dragIndex !== null && dragIndex !== index) onReorder?.(dragIndex, index);
+                            setDragIndex(null);
+                            setOverIndex(null);
+                        }}
+                        onDragEnd={() => { setDragIndex(null); setOverIndex(null); }}
                         onMouseDown={(e) => {
                             // Middle-click closes, like a browser.
                             if (e.button === 1) { e.preventDefault(); onClose(tab.id); }
                             else if (e.button === 0) onSelect(tab.id);
                         }}
-                        className={`group/tab relative flex items-center gap-2 pl-3 pr-2 max-w-[200px] cursor-pointer border-r border-[var(--border)] transition-colors ${
+                        onContextMenu={(e) => {
+                            if (!onContextMenu) return;
+                            e.preventDefault();
+                            onContextMenu(tab.id, e.clientX, e.clientY);
+                        }}
+                        className={`group/tab relative flex items-center gap-2 pl-3 pr-2 shrink-0 min-w-[110px] max-w-[200px] cursor-pointer border-r border-[var(--border)] transition-colors outline-none ${
                             isActive
                                 ? "bg-[var(--bg-primary)] text-[var(--text-primary)]"
                                 : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"
-                        }`}
+                        } ${isDropTarget ? "ring-1 ring-inset ring-[var(--accent)]" : ""}`}
                     >
                         {/* Active-tab top accent */}
                         {isActive && <span className="absolute left-0 top-0 h-[2px] w-full bg-[var(--accent)]" aria-hidden="true" />}
                         <span className="material-symbols-outlined text-[14px] shrink-0 opacity-70">description</span>
-                        <span className="truncate text-xs">{tab.name}</span>
+                        <span className="truncate text-xs">{tab.label}</span>
                         {/* Dirty dot doubles as the close target on hover. */}
                         <button
                             onMouseDown={(e) => { e.stopPropagation(); }}
                             onClick={(e) => { e.stopPropagation(); onClose(tab.id); }}
+                            tabIndex={-1}
                             aria-label={`Close ${tab.name}`}
                             title="Close"
                             className="shrink-0 w-4 h-4 flex items-center justify-center rounded hover:bg-[var(--bg-hover)] text-[var(--text-muted)] hover:text-[var(--text-primary)]"

--- a/src/components/TabContextMenu.tsx
+++ b/src/components/TabContextMenu.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from "react";
+
+export interface TabMenuAction {
+    label: string;
+    icon: string;
+    onClick: () => void;
+    disabled?: boolean;
+    /** Renders a thin separator above this item. */
+    dividerBefore?: boolean;
+}
+
+interface TabContextMenuProps {
+    x: number;
+    y: number;
+    actions: TabMenuAction[];
+    onClose: () => void;
+}
+
+/**
+ * Small floating menu for a tab's right-click actions (close variants, copy
+ * path, reveal). Closes on outside click, Escape, scroll, or blur. TABS-12.
+ */
+export function TabContextMenu({ x, y, actions, onClose }: TabContextMenuProps) {
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const onDown = (e: MouseEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+        };
+        const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+        document.addEventListener("mousedown", onDown);
+        document.addEventListener("keydown", onKey);
+        window.addEventListener("blur", onClose);
+        window.addEventListener("resize", onClose);
+        return () => {
+            document.removeEventListener("mousedown", onDown);
+            document.removeEventListener("keydown", onKey);
+            window.removeEventListener("blur", onClose);
+            window.removeEventListener("resize", onClose);
+        };
+    }, [onClose]);
+
+    // Keep the menu on-screen: nudge left/up if it would overflow the viewport.
+    const width = 220;
+    const left = Math.min(x, window.innerWidth - width - 8);
+    const top = Math.min(y, window.innerHeight - actions.length * 34 - 8);
+
+    return (
+        <div
+            ref={ref}
+            role="menu"
+            style={{ left, top, width }}
+            className="fixed z-[120] py-1 rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] shadow-2xl text-sm no-select"
+        >
+            {actions.map((a, i) => (
+                <div key={i}>
+                    {a.dividerBefore && <div className="my-1 border-t border-[var(--border)]" />}
+                    <button
+                        role="menuitem"
+                        disabled={a.disabled}
+                        onClick={() => { a.onClick(); onClose(); }}
+                        className="w-full flex items-center gap-2.5 px-3 py-1.5 text-left text-[var(--text-secondary)] enabled:hover:bg-[var(--bg-hover)] enabled:hover:text-[var(--text-primary)] disabled:opacity-40 disabled:cursor-default transition-colors"
+                    >
+                        <span className="material-symbols-outlined text-[16px] shrink-0">{a.icon}</span>
+                        <span className="truncate">{a.label}</span>
+                    </button>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/components/UnsavedChangesDialog.tsx
+++ b/src/components/UnsavedChangesDialog.tsx
@@ -7,6 +7,10 @@ interface UnsavedChangesDialogProps {
     onClose: () => void;
     onDiscard: () => void;
     onSave: () => void;
+    /** Names of the files with unsaved changes. When more than one is present the
+     *  dialog lists them and the buttons read "Save all" / "Discard all". Omit or
+     *  pass a single name for the original single-file wording. */
+    dirtyNames?: string[];
 }
 
 export function UnsavedChangesDialog({
@@ -14,8 +18,10 @@ export function UnsavedChangesDialog({
     onClose,
     onDiscard,
     onSave,
+    dirtyNames,
 }: UnsavedChangesDialogProps) {
     const saveButtonRef = useRef<HTMLButtonElement>(null);
+    const many = (dirtyNames?.length ?? 0) > 1;
 
     return (
         <Modal
@@ -41,7 +47,7 @@ export function UnsavedChangesDialog({
                             Unsaved Changes
                         </h2>
                         <p className="text-sm text-[var(--text-secondary)]">
-                            Your changes will be lost
+                            {many ? `${dirtyNames!.length} files have unsaved changes` : "Your changes will be lost"}
                         </p>
                     </div>
                 </div>
@@ -50,8 +56,20 @@ export function UnsavedChangesDialog({
             {/* Body */}
             <div className="px-5 pb-4">
                 <p id="unsaved-dialog-desc" className="text-sm text-[var(--text-secondary)] leading-relaxed">
-                    You have unsaved changes. Do you want to save them before closing?
+                    {many
+                        ? "These files have unsaved changes. Do you want to save them before closing?"
+                        : "You have unsaved changes. Do you want to save them before closing?"}
                 </p>
+                {many && (
+                    <ul className="mt-3 max-h-40 overflow-y-auto rounded-lg border border-[var(--border)] bg-[var(--bg-secondary)] divide-y divide-[var(--border)]">
+                        {dirtyNames!.map((name, i) => (
+                            <li key={`${name}-${i}`} className="flex items-center gap-2 px-3 py-1.5 text-sm text-[var(--text-primary)]">
+                                <span className="material-symbols-outlined text-[14px] text-[var(--accent)] shrink-0">circle</span>
+                                <span className="truncate">{name}</span>
+                            </li>
+                        ))}
+                    </ul>
+                )}
             </div>
 
             {/* Actions */}
@@ -66,14 +84,14 @@ export function UnsavedChangesDialog({
                     onClick={onDiscard}
                     className="px-4 py-2 text-sm font-medium text-[var(--danger)] hover:bg-[var(--danger)]/10 rounded-lg transition-colors"
                 >
-                    Don't Save
+                    {many ? "Discard all" : "Don't Save"}
                 </button>
                 <button
                     ref={saveButtonRef}
                     onClick={onSave}
                     className="px-4 py-2 text-sm font-medium text-[var(--accent-text)] bg-[var(--accent)] hover:bg-[var(--accent-hover)] rounded-lg transition-colors"
                 >
-                    Save
+                    {many ? "Save all" : "Save"}
                 </button>
             </div>
         </Modal>

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -22,9 +22,13 @@ export interface ShortcutHandlers {
     openSearch?: () => void;
     /** Close the active tab (Ctrl+W). */
     closeActiveTab?: () => void;
-    /** Switch to the previous/next tab (Alt+Left / Alt+Right). */
+    /** Switch to the previous/next tab (Alt+Left/Right, Ctrl+Shift+Tab / Ctrl+Tab). */
     prevTab?: () => void;
     nextTab?: () => void;
+    /** Reopen the most recently closed tab (Ctrl+Shift+T). */
+    reopenClosedTab?: () => void;
+    /** Jump to a tab by index; -1 means the last tab (Ctrl+1..9). */
+    gotoTab?: (index: number) => void;
     hasFile: boolean;
     content: string;
     /** Current view mode — Ctrl+F routes to the preview find bar in reader
@@ -132,6 +136,35 @@ export function useGlobalShortcuts(handlers: ShortcutHandlers) {
             if (e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey && e.key === "ArrowRight") {
                 e.preventDefault();
                 if (s.hasFile) s.nextTab?.();
+                return;
+            }
+            // Ctrl+Tab / Ctrl+Shift+Tab - cycle tabs (the browser/VS Code pair),
+            // and Ctrl+PageDown / Ctrl+PageUp as the other common alias. TABS-16.
+            if (e.ctrlKey && !e.altKey && !e.metaKey && e.key === "Tab") {
+                e.preventDefault();
+                if (s.hasFile) (e.shiftKey ? s.prevTab : s.nextTab)?.();
+                return;
+            }
+            if (e.ctrlKey && !e.altKey && !e.metaKey && !e.shiftKey && e.key === "PageDown") {
+                e.preventDefault();
+                if (s.hasFile) s.nextTab?.();
+                return;
+            }
+            if (e.ctrlKey && !e.altKey && !e.metaKey && !e.shiftKey && e.key === "PageUp") {
+                e.preventDefault();
+                if (s.hasFile) s.prevTab?.();
+                return;
+            }
+            // Ctrl+Shift+T - reopen the most recently closed tab. TABS-15.
+            if (e.ctrlKey && e.shiftKey && !e.altKey && !e.metaKey && (e.key === "t" || e.key === "T")) {
+                e.preventDefault();
+                s.reopenClosedTab?.();
+                return;
+            }
+            // Ctrl+1..9 - jump to tab N (Ctrl+9 = last tab, like browsers). TABS-16.
+            if (e.ctrlKey && !e.altKey && !e.metaKey && !e.shiftKey && e.key >= "1" && e.key <= "9") {
+                e.preventDefault();
+                if (s.hasFile) s.gotoTab?.(e.key === "9" ? -1 : Number(e.key) - 1);
                 return;
             }
             // ? - Show cheatsheet (only when no input is focused)

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Normalise the many shapes an error can arrive in — a Rust command rejects with
+ * a plain string, a thrown JS Error carries `.message`, and some rejections are
+ * neither — into a single display string. Replaces the `typeof err === "string"
+ * ? err : (err as {message?: string})?.message` incantation duplicated across
+ * the app. QUALITY-02.
+ */
+export function errMessage(err: unknown, fallback = ""): string {
+    if (typeof err === "string") return err || fallback;
+    if (err && typeof err === "object" && "message" in err) {
+        const m = (err as { message?: unknown }).message;
+        if (typeof m === "string" && m) return m;
+    }
+    return fallback;
+}

--- a/src/utils/persistence.test.ts
+++ b/src/utils/persistence.test.ts
@@ -37,9 +37,9 @@ describe("recent files", () => {
         expect(list.map((f) => f.path)).toEqual(["/a.md", "/b.md"]);
     });
 
-    it("caps the list at 10 entries", () => {
-        for (let i = 0; i < 15; i++) addRecentFile(`/f${i}.md`, `f${i}`);
-        expect(getRecentFiles()).toHaveLength(10);
+    it("caps the list at 25 entries", () => {
+        for (let i = 0; i < 30; i++) addRecentFile(`/f${i}.md`, `f${i}`);
+        expect(getRecentFiles()).toHaveLength(25);
     });
 
     it("removes and clears", () => {

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -73,6 +73,31 @@ export const clearRecentFiles = (): void => safeSet(KEY_RECENT_FILES, []);
 export const getLastFile = (): string | null => safeGet<string | null>(KEY_LAST_FILE, null);
 export const setLastFile = (path: string | null): void => safeSet(KEY_LAST_FILE, path);
 
+// Full multi-tab session, so a relaunch reopens every tab the user had — not
+// just the single last file. Only files with a path are stored (untitled
+// buffers have no content persisted here); `activeIndex` points into `tabs`.
+// getLastFile stays as a migration fallback for sessions saved before this. TABS-07.
+const KEY_SESSION = "paperling:session";
+export interface SessionTab {
+    path: string;
+    /** 1-based caret/scroll line to restore. */
+    cursorLine?: number;
+}
+export interface SessionState {
+    tabs: SessionTab[];
+    activeIndex: number;
+}
+export const getSession = (): SessionState | null => {
+    const s = safeGet<SessionState | null>(KEY_SESSION, null);
+    if (!s || !Array.isArray(s.tabs)) return null;
+    // Defend against a malformed/hand-edited value.
+    const tabs = s.tabs.filter((t): t is SessionTab => !!t && typeof t.path === "string");
+    if (tabs.length === 0) return null;
+    const activeIndex = Number.isInteger(s.activeIndex) ? Math.min(Math.max(0, s.activeIndex), tabs.length - 1) : 0;
+    return { tabs, activeIndex };
+};
+export const setSession = (s: SessionState | null): void => safeSet(KEY_SESSION, s);
+
 export const getSavedViewMode = (): "preview" | "code" | "split" =>
     safeGet<"preview" | "code" | "split">(KEY_VIEW_MODE, "preview");
 export const setSavedViewMode = (m: "preview" | "code" | "split"): void => safeSet(KEY_VIEW_MODE, m);

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -29,7 +29,9 @@ const KEY_LAST_FILE = "paperling:lastFile";
 const KEY_VIEW_MODE = "paperling:viewMode";
 const KEY_SPLIT_RATIO = "paperling:splitRatio";
 
-const MAX_RECENT = 10;
+// Multi-file/tab workflows make 10 feel tight; 25 keeps the palette's recents
+// useful without unbounded growth.
+const MAX_RECENT = 25;
 
 const safeGet = <T>(key: string, fallback: T): T => {
     try {

--- a/src/utils/tabsModel.test.ts
+++ b/src/utils/tabsModel.test.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { findTabByPath, isTabDirty, nextActiveAfterClose, type TabState } from "./tabsModel";
+import {
+  findTabByPath,
+  isTabDirty,
+  nextActiveAfterClose,
+  nextUntitledName,
+  findReusableUntitledTab,
+  computeTabLabels,
+  moveTab,
+  type TabState,
+} from "./tabsModel";
 
 const tab = (id: string, filePath: string | null, content = "x", originalContent = "x"): TabState => ({
-  id, filePath, fileName: filePath?.split("/").pop() ?? "Untitled.md",
+  id, filePath, fileName: filePath?.replace(/\\/g, "/").split("/").pop() ?? "Untitled.md",
   content, originalContent, fileSize: 0, knownMtime: 0,
 });
 
@@ -43,5 +52,83 @@ describe("nextActiveAfterClose", () => {
   });
   it("returns null for an unknown id", () => {
     expect(nextActiveAfterClose(tabs, "nope")).toBeNull();
+  });
+});
+
+describe("nextUntitledName", () => {
+  const untitled = (id: string, name: string): TabState => ({
+    id, filePath: null, fileName: name, content: "", originalContent: "", fileSize: 0, knownMtime: 0,
+  });
+  it("starts at Untitled-1.md", () => {
+    expect(nextUntitledName([])).toBe("Untitled-1.md");
+  });
+  it("skips names already in use", () => {
+    expect(nextUntitledName([untitled("1", "Untitled-1.md")])).toBe("Untitled-2.md");
+  });
+  it("fills the lowest gap", () => {
+    expect(nextUntitledName([untitled("1", "Untitled-1.md"), untitled("3", "Untitled-3.md")])).toBe("Untitled-2.md");
+  });
+  it("ignores saved files with the same name", () => {
+    expect(nextUntitledName([tab("1", "/x/Untitled-1.md")])).toBe("Untitled-1.md");
+  });
+});
+
+describe("findReusableUntitledTab", () => {
+  it("finds a pristine empty untitled buffer", () => {
+    const tabs = [tab("1", "/a.md"), { ...tab("2", null), content: "", originalContent: "" }];
+    expect(findReusableUntitledTab(tabs)?.id).toBe("2");
+  });
+  it("ignores an untitled buffer that has content", () => {
+    const tabs = [{ ...tab("2", null), content: "hi", originalContent: "" }];
+    expect(findReusableUntitledTab(tabs)).toBeUndefined();
+  });
+  it("ignores saved files", () => {
+    expect(findReusableUntitledTab([tab("1", "/a.md")])).toBeUndefined();
+  });
+});
+
+describe("computeTabLabels", () => {
+  it("shows the bare name when unique", () => {
+    const labels = computeTabLabels([{ id: "1", fileName: "a.md", filePath: "/x/a.md" }]);
+    expect(labels.get("1")).toBe("a.md");
+  });
+  it("appends the distinguishing parent folder for duplicates", () => {
+    const labels = computeTabLabels([
+      { id: "1", fileName: "README.md", filePath: "/proj/docs/README.md" },
+      { id: "2", fileName: "README.md", filePath: "/proj/src/README.md" },
+    ]);
+    expect(labels.get("1")).toBe("README.md — docs");
+    expect(labels.get("2")).toBe("README.md — src");
+  });
+  it("walks further up when the immediate parent also collides", () => {
+    const labels = computeTabLabels([
+      { id: "1", fileName: "README.md", filePath: "/a/docs/README.md" },
+      { id: "2", fileName: "README.md", filePath: "/b/docs/README.md" },
+    ]);
+    expect(labels.get("1")).toBe("README.md — a/docs");
+    expect(labels.get("2")).toBe("README.md — b/docs");
+  });
+  it("handles Windows separators", () => {
+    const labels = computeTabLabels([
+      { id: "1", fileName: "note.md", filePath: "C:\\one\\note.md" },
+      { id: "2", fileName: "note.md", filePath: "C:\\two\\note.md" },
+    ]);
+    expect(labels.get("1")).toBe("note.md — one");
+    expect(labels.get("2")).toBe("note.md — two");
+  });
+});
+
+describe("moveTab", () => {
+  const tabs = [tab("1", "/a.md"), tab("2", "/b.md"), tab("3", "/c.md")];
+  it("moves a tab to a later position", () => {
+    expect(moveTab(tabs, 0, 2).map((t) => t.id)).toEqual(["2", "3", "1"]);
+  });
+  it("moves a tab to an earlier position", () => {
+    expect(moveTab(tabs, 2, 0).map((t) => t.id)).toEqual(["3", "1", "2"]);
+  });
+  it("returns the same array for a no-op or out-of-range move", () => {
+    expect(moveTab(tabs, 1, 1)).toBe(tabs);
+    expect(moveTab(tabs, -1, 0)).toBe(tabs);
+    expect(moveTab(tabs, 0, 9)).toBe(tabs);
   });
 });

--- a/src/utils/tabsModel.ts
+++ b/src/utils/tabsModel.ts
@@ -43,3 +43,87 @@ export function nextActiveAfterClose(tabs: TabState[], closingId: string): strin
   if (remaining.length === 0) return null;
   return (remaining[idx] ?? remaining[idx - 1] ?? remaining[remaining.length - 1]).id;
 }
+
+/**
+ * The name for a new Untitled buffer, numbered so repeated Ctrl+N don't all read
+ * "Untitled.md". Returns the lowest "Untitled-N.md" not currently in use by an
+ * unsaved tab (N starts at 1). TABS-08.
+ */
+export function nextUntitledName(tabs: TabState[]): string {
+  const used = new Set(
+    tabs.filter((t) => t.filePath === null).map((t) => t.fileName)
+  );
+  for (let n = 1; ; n++) {
+    const candidate = `Untitled-${n}.md`;
+    if (!used.has(candidate)) return candidate;
+  }
+}
+
+/**
+ * An existing untitled buffer that is empty and pristine (no path, no content) —
+ * worth reusing on "New file" instead of stacking another identical blank tab.
+ * TABS-08.
+ */
+export function findReusableUntitledTab(tabs: TabState[]): TabState | undefined {
+  return tabs.find((t) => t.filePath === null && t.content === "" && t.originalContent === "");
+}
+
+/** Folder segments of a path in natural (root → parent) order. `a/b/c/x.md` →
+ *  ["a","b","c"]. Handles both `/` and `\` separators. Null → []. */
+function parentSegments(filePath: string | null): string[] {
+  if (!filePath) return [];
+  const parts = filePath.replace(/\\/g, "/").split("/").filter(Boolean);
+  return parts.slice(0, -1); // drop the file name itself
+}
+
+/**
+ * Display label per tab: just the file name when unique, else the file name plus
+ * the shortest trailing folder path that distinguishes it from the other tabs
+ * sharing that name — like `README.md — docs`. TABS-09.
+ */
+export function computeTabLabels(
+  tabs: Array<{ id: string; fileName: string; filePath: string | null }>
+): Map<string, string> {
+  const labels = new Map<string, string>();
+  const byName = new Map<string, typeof tabs>();
+  for (const t of tabs) {
+    const arr = byName.get(t.fileName) ?? [];
+    arr.push(t);
+    byName.set(t.fileName, arr);
+  }
+  for (const [name, group] of byName) {
+    if (group.length === 1) {
+      labels.set(group[0].id, name);
+      continue;
+    }
+    const withSegs = group.map((t) => ({ id: t.id, segs: parentSegments(t.filePath) }));
+    const maxDepth = Math.max(1, ...withSegs.map((g) => g.segs.length));
+    for (const g of withSegs) {
+      let suffix = "";
+      for (let d = 1; d <= maxDepth; d++) {
+        const mine = g.segs.slice(-d).join("/");
+        const collision = withSegs.some((o) => o.id !== g.id && o.segs.slice(-d).join("/") === mine);
+        suffix = mine;
+        if (!collision) break;
+      }
+      labels.set(g.id, suffix ? `${name} — ${suffix}` : name);
+    }
+  }
+  return labels;
+}
+
+/** Move a tab from one index to another, returning a new array. Out-of-range or
+ *  no-op moves return the original array unchanged. Used for drag-reorder. TABS-10. */
+export function moveTab(tabs: TabState[], fromIndex: number, toIndex: number): TabState[] {
+  if (
+    fromIndex === toIndex ||
+    fromIndex < 0 || fromIndex >= tabs.length ||
+    toIndex < 0 || toIndex >= tabs.length
+  ) {
+    return tabs;
+  }
+  const copy = tabs.slice();
+  const [item] = copy.splice(fromIndex, 1);
+  copy.splice(toIndex, 0, item);
+  return copy;
+}

--- a/suggestion.md
+++ b/suggestion.md
@@ -1,0 +1,192 @@
+# Paperling: Improvement Suggestions
+
+A full review of the codebase (v1.0.44) with a focus on robustness, user friendliness, and the new tabs feature. Organized by priority so it can be worked through top to bottom. File references point at the current code.
+
+---
+
+## 1. Critical: bugs and data-loss risks in the current tab implementation
+
+These are real defects in what shipped, not polish. Fix these before adding any new tab features.
+
+### 1.1 Undo (Ctrl+Z) after a tab switch restores the PREVIOUS file's content
+
+The app keeps ONE CodeMirror instance and swaps the whole document on tab switch (`CodeEditor.tsx` ~line 505: `view.dispatch({ changes: { from: 0, to: doc.length, insert: content } })`). That dispatch is a normal, undoable transaction recorded by `history()`.
+
+Consequence: open file A, switch to tab B, press Ctrl+Z. The editor "undoes" the document swap and file B's tab now shows file A's content. If autosave is on, file A's content can then be written to file B's path. This is the single most dangerous bug in the tab feature.
+
+**Fix (recommended, architectural):** keep one `EditorState` per tab instead of one string. On switch, snapshot `view.state` into the tab and restore with `view.setState(tab.editorState)`. This fixes undo isolation AND gives you per-tab selection, scroll position, folds, and search state for free (it replaces the current `cursorLine` approximation from TABS-02).
+
+**Fix (minimal, if you want a quick patch first):** dispatch the swap with `annotations: Transaction.addToHistory.of(false)` and explicitly clear/reset history on switch. This stops the disaster but still loses per-tab undo history, so treat it as a stopgap.
+
+### 1.2 Window close silently discards unsaved changes in BACKGROUND tabs
+
+`onCloseRequested` in `App.tsx` (~line 568) only checks `contentRef.current !== originalContentRef.current`, i.e. the active tab. If tab A is dirty but tab B is active and clean, Alt+F4 closes without any prompt and tab A's edits are gone. `handleSaveAndCloseWindow` likewise only saves the active buffer.
+
+**Fix:** the close check must scan `tabsRef.current` too (`isTabDirty` already exists in `tabsModel.ts`). Upgrade `UnsavedChangesDialog` to list all dirty tabs by name and offer "Save all / Discard all / Cancel". Untitled dirty tabs need a save-as prompt per tab or an explicit "will be discarded" line in the dialog.
+
+### 1.3 Autosave and external-change detection only cover the active tab
+
+- `useAutosave` receives the live `filePath`/`content`, so a dirty background tab never autosaves, even with autosave enabled. Users will reasonably assume "autosave on" means all open files.
+- `useExternalChangeWatcher` stats only the active file on window focus. If a background tab's file changes on disk, nothing is detected until that tab is activated, and even then `activateTab` does NOT re-stat the file, so the user can be looking at stale content until the next window blur/focus cycle.
+
+**Fix:**
+- Autosave: after the active-buffer save, also flush any dirty background tabs (they have `filePath`, `content`, `knownMtime` in their snapshots). Or simpler: autosave a tab when it is deactivated (snapshot time is a natural save point).
+- External changes: on `activateTab`, stat the incoming tab's file and run the same clean-reload / dirty-warn logic. On window focus, loop over all open tabs, not just the active one (a single `get_file_info` per tab is cheap; you could also add a batched Rust command).
+
+### 1.4 Close-tab prompt has no "Save" option
+
+`closeTab` (`App.tsx` ~line 678) uses `ask("Discard unsaved changes...?")`, a two-button dialog: discard or cancel. Every other editor offers three choices. To save-then-close today the user must cancel, switch to the tab, Ctrl+S, then close again.
+
+**Fix:** reuse `UnsavedChangesDialog` (it already has Save / Discard / Cancel) for tab close, not just window close.
+
+### 1.5 Session restore and `lastFile` fight with the tabs model
+
+- Only ONE file is restored at launch (the boot effect seeds a single tab). Users who had five tabs open get one back.
+- `applyTabToLive` calls `setLastFile(tab.filePath)` on every switch, `handleNewFile` calls `setLastFile(null)`, and closing the last tab calls `setLastFile(null)`. So creating a new tab while three files are open wipes the restore target entirely: quit now and next launch shows the welcome screen.
+
+**Fix:** replace the single `lastFile` key with a persisted session: `paperling:session = { tabs: [{ path, cursorLine }], activeIndex }` (paths only, never content). Write it on tab open/close/switch and on window close. On boot, restore all tabs lazily: load the active one eagerly, load the others on first activation (store just path + name until then) so launch stays fast. Keep `lastFile` reading as a one-time migration fallback.
+
+---
+
+## 2. Tab feature: making it feel complete
+
+### 2.1 Architecture: consider making tabs the source of truth
+
+Right now the live editor state IS the active tab, with refs mirroring state and snapshot/restore on every switch (`snapshotActiveTab` / `applyTabToLive`, plus five parallel `useRef` mirrors). It works, but every new feature (save all, per-tab autosave, per-tab watcher) has to reason about "live vs snapshot" and the ref-mirroring dance in `App.tsx` keeps growing.
+
+Suggested refactor once 1.1 lands: `tabs: TabState[]` (each holding a CodeMirror `EditorState` or at least `{ path, name, editorState, knownMtime }`) plus `activeTabId`, with derived getters for the active tab. `filePath`/`content`/`originalContent`/`fileSize` stop being separate `useState`s. This removes the whole snapshot/restore concept and its edge cases (Save As already needs special tab syncing today, see `handleSaveAs`). Consider a small reducer (`useReducer`) or a tiny store (zustand) so tab operations become testable actions instead of callback chains.
+
+Memory note: with per-tab strings or EditorStates, a 50 MB file duplicated into `content` + `originalContent` per tab adds up. For `originalContent`, consider storing a hash (dirty check) plus reloading from disk on "revert" instead of a full second copy.
+
+### 2.2 Missing table-stakes tab interactions
+
+In rough order of user impact:
+
+1. **Reopen closed tab: Ctrl+Shift+T.** Keep a small stack of recently closed tab paths (+ cursor line). Cheap to build, universally expected.
+2. **Ctrl+Tab / Ctrl+Shift+Tab** to cycle tabs, in addition to Alt+Left/Right. Also **Ctrl+PgDn / Ctrl+PgUp** (the VS Code/browser pair). Alt+Left alone conflicts with "navigate back" muscle memory from other editors.
+3. **Ctrl+1 through Ctrl+9** to jump to tab N (Ctrl+9 = last tab, like browsers).
+4. **Drag to reorder tabs.** HTML drag events or pointer-based reordering on the `TabBar`; the model just needs an `moveTab(fromIdx, toIdx)` helper in `tabsModel.ts` (easy to unit test).
+5. **Tab context menu (right-click):** Close, Close Others, Close to the Right, Close Saved, Copy Path, Reveal in Folder. You already have `revealItemInDir` and copy-path in the palette; this is mostly wiring. The Close-many variants need the dirty-check loop from 1.2.
+6. **Pin tabs** (pinned tabs shrink to icon-only, always leftmost, Ctrl+W skips them). Nice-to-have, do after the above.
+7. **"Save All"** command (palette + Ctrl+Alt+S is a common binding) once background tabs can be saved.
+
+### 2.3 Tab labels: duplicates and untitled buffers
+
+- Two open files both named `README.md` render identically. Disambiguate with the parent folder like VS Code: `README.md — docs` vs `README.md — src`. Compute the minimal distinguishing suffix in `tabsModel.ts` (pure, testable).
+- Every new buffer is `Untitled.md`. Number them: `Untitled-1.md`, `Untitled-2.md`. Also: `findTabByPath` never matches null paths, so Ctrl+N repeatedly stacks identical-looking tabs; numbering makes this sane. Consider reusing an existing EMPTY untitled tab instead of creating another.
+
+### 2.4 Tab bar overflow behavior
+
+`TabBar.tsx` uses `overflow-x-auto` with `max-w-[200px]` per tab and no min width. With many tabs:
+
+- There is no min-width, so nothing stops unreadable slivers on very narrow windows.
+- A horizontal scrollbar on a 36px-tall strip is awkward; wire mouse wheel to horizontal scroll (`onWheel` translating deltaY to scrollLeft) like browsers do.
+- Add an overflow affordance: a dropdown button listing all open tabs (with dirty dots) when the bar overflows, or at minimum auto-scroll the active tab into view on activation (`scrollIntoView({ inline: "nearest" })` after switch; today activating a hidden tab via Alt+Right leaves it out of view).
+
+### 2.5 Tab keyboard accessibility
+
+Tabs are `div role="tab"` activated by `onMouseDown` only. They are not focusable and cannot be operated by keyboard at all (the WAI-ARIA tabs pattern expects Tab to focus the tablist and Left/Right + Enter to move/activate). Add `tabIndex` (roving tabindex: 0 on active, -1 on others), `onKeyDown` for Arrow/Home/End/Enter/Space, and Delete to close. This also matters for screen readers, and the ROADMAP already lists an accessibility pass.
+
+### 2.6 Tabs and the rest of the app
+
+- **Command palette:** add an "Open tabs" section (switch to tab by name) and a "Close tab" command. The palette is your power-user surface; tabs should be reachable from it.
+- **Drag-and-drop multiple files:** the DRAG_DROP handler takes `paths[0]` only. With tabs there is no reason not to open every dropped `.md` in its own tab.
+- **Open dialog:** `open({ multiple: false })` in `handleOpenFile`; flip to `multiple: true` and loop, same reasoning.
+- **File explorer / global search results:** already route through `loadFile`, which reuses existing tabs. Good. But `handleOpenSearchResult` jumps to a line with a fixed 120 ms `setTimeout`; on a large file that loses the race and lands at the top. Fire the goto-line after the load resolves (loadFile is async, await it) or dispatch it from the same requestAnimationFrame path `applyTabToLive` uses.
+- **Per-tab view mode (optional):** `mode` is global. Reasonable default, but remembering that "notes.md was in reader, draft.md was in split" per tab is a small delight once TabState is the source of truth. Ship as a setting if unsure.
+- **Middle-click:** you handle button 1 on mousedown; also `preventDefault` on `auxclick`/`mouseup` so WebView2 never triggers autoscroll cursor mode on Windows.
+
+---
+
+## 3. Robustness (beyond tabs)
+
+### 3.1 Real file watching instead of focus polling
+
+External changes are only detected on window focus (`useExternalChangeWatcher`) and the file explorer refreshes on focus too. If Paperling and a terminal/AI tool are visible side by side (increasingly common: people run Claude/agents that edit files while watching the preview), edits on disk never appear until the user clicks away and back. Add the `notify` crate in Rust (or `tauri-plugin-fs` watch) to watch open files + the explorer directory and emit a `file-changed` event to the webview. Keep the focus check as fallback. This turns Paperling into a genuinely good "live markdown preview for agent workflows" tool, which is a real niche.
+
+### 3.2 Crash recovery drafts
+
+The close-requested interception protects against intentional close, but a crash, WebView2 failure, or forced OS update loses every dirty buffer, and untitled buffers entirely. Periodically (every ~30 s, and on tab deactivate) write dirty buffers to an app-data drafts folder (`$APPDATA/paperling/drafts/<hash>.md` plus a small manifest). On launch, if drafts exist that are newer than their files (or are untitled), offer recovery. Delete a draft on clean save/close. This is the biggest single robustness win available and is invisible when everything works.
+
+### 3.3 Line endings are silently normalized
+
+CodeMirror normalizes documents to `\n`. A CRLF file opened and saved comes back as LF, which makes noisy git diffs and confuses Windows users (your core audience). Detect the dominant EOL in `read_file` (or in the frontend before creating the editor state), store it on the tab, and re-apply on save. One field, big trust win.
+
+### 3.4 Encoding tolerance
+
+`read_file` (Rust) presumably rejects or mangles non-UTF-8 files. Detect BOM/UTF-16 (a Notepad classic on Windows) and either convert transparently (remember the encoding for save) or fail with a clear "this file is UTF-16" message rather than a generic error.
+
+### 3.5 Durability of the atomic save
+
+The temp-file-plus-rename in `save_file` is correct against partial writes, but there is no fsync before the rename; on power loss the rename can survive while the data does not. Call `file.sync_all()` on the temp file before renaming (and ideally fsync the directory on Linux). Cheap insurance for an editor whose whole job is not losing words. Also note: rename-over-target breaks hard links and resets some ACLs/metadata; acceptable trade-off, but preserve file mode on Unix when you do the macOS/Linux builds on the roadmap.
+
+### 3.6 Settings storage
+
+Everything persists in localStorage. WebView2 profile data can be wiped by "reset app", Windows cleanup tools, or corporate policy, and it is invisible to users who back things up. Consider migrating persistence.ts to a JSON file in app-data via a small Rust command or `tauri-plugin-store` (keep the localStorage read as migration). This also makes settings portable and debuggable. Low urgency, high "my settings vanished" complaint prevention.
+
+### 3.7 Number normalization bug class in `mtime`
+
+You compare `info.modified > known` with mtimes flowing through several layers (Rust u64 ms → JSON → JS number → refs → tab snapshots). One place stores `fileData.modified ?? 0` and another awaits `save_file`'s return. Worth an integration test: save, external touch, focus, assert exactly one reload toast. The mtime plumbing across tabs (each tab has `knownMtime`, plus the global `knownMtimeRef`) is exactly where a stale value will eventually hide.
+
+---
+
+## 4. User friendliness / ease of use
+
+1. **Window title.** Set the native window title to `name — Paperling` (with a dirty marker) via `Window.setTitle` on tab switch/dirty change. Alt-Tab and the taskbar currently cannot tell two Paperling scenarios apart.
+2. **Recent files: raise the cap and surface them more.** `MAX_RECENT = 10` is tight once tabs make multi-file work normal. Raise to 20 to 30, add "clear recents" (exists) and pin-to-recents. Consider a jump-list integration on Windows (Tauri supports taskbar jump lists via plugins) so right-clicking the taskbar icon opens recent files.
+3. **File explorer upgrades.** It is a flat list of siblings that closes on selection. With tabs, the natural next step (already "Later" on the roadmap): make it a pinnable sidebar (not an overlay that steals focus), keep it open after selecting, mark open-in-tab files and dirty state, and add basic file ops (new file here, rename, delete to trash) with inline UI. Rename/delete need Rust commands plus tab-path fixups; scope carefully but "new note in this folder" alone is high value for the wikilink workflow.
+4. **`.txt` support.** You accept `.md`/`.markdown` everywhere (open dialog, drag-drop filter, explorer listing). Plain `.txt` opening is a common ask for a lightweight editor and costs almost nothing (skip preview features gracefully).
+5. **Reveal keyboard shortcut conflicts early.** Alt+Left/Right for tabs will surprise people who expect word navigation... actually Alt+arrows are safe, but document them in the cheatsheet next to the new Ctrl+Tab bindings so all tab shortcuts live in one visible row. The cheatsheet and Tour should both gain a tabs entry (the Tour currently teaches modes/themes but not tabs, and tabs are your newest concept).
+6. **Autosave default.** Consider defaulting autosave ON for files with a path (keep off for untitled). You already have external-change detection and atomic writes; the modern expectation (Obsidian, Notion, VS Code with autosave) is that words are never lost. At minimum, prompt once: "Turn on autosave?" after the first unsaved-changes dialog.
+7. **Toast fatigue.** "File saved" on every Ctrl+S is noise once autosave is common; the status-bar dot already communicates it. Reserve toasts for failures and unusual events.
+8. **Search-in-files polish.** Results jump has the timing race (2.6). Also consider showing the match count cap ("300 files max") in the UI when hit, so truncation is never silent.
+
+---
+
+## 5. Performance
+
+1. **Preview re-parse is O(document) per debounce tick.** The debounce scaling (PREVIEW-01) is good, but react-markdown still re-parses and re-renders the entire document. For the "large file" tier, consider memoizing per-block: split source into top-level blocks (cheap line scan), render each block through its own memoized component, and only re-render blocks whose source changed. This is the standard trick (Milkdown/Typora-style) and turns typing in a 5k-line doc from "re-render everything" into "re-render one paragraph". It is a meaty change; do it behind a flag and only if users report lag beyond the debounce.
+2. **Dirty checks on large strings.** `isDirty` (`content !== originalContent`) is O(n) worst case per render, and `tabBarItems` compares every inactive tab's full content inside a `useMemo`. Fine today; if you adopt per-tab EditorStates, track dirtiness with a changed-since-save flag (CodeMirror gives you doc identity cheaply) instead of string compares.
+3. **Bundle: verify mermaid and katex are lazy.** Mermaid alone is ~1 MB. `MermaidBlock` should dynamic-import mermaid on first diagram encounter, and katex CSS/fonts should only load when math is present. If already done, ignore; if not, this is the biggest remaining cold-start lever after your existing lazy-loading work (which is genuinely well done).
+4. **Tab switch cost.** With `view.setState` (per 1.1) a switch is O(1)-ish. With the current full-document dispatch it re-parses and re-highlights the whole file. Another reason 1.1 is the right fix.
+
+---
+
+## 6. Code health and testing
+
+1. **App.tsx is 1,700 lines** and owns file IO, tabs, palette items, shortcuts, close handling, AI wiring, and layout. The tab refactor (2.1) is the natural moment to extract: `useTabs()` (all tab state + operations), `useFileIO()` (load/save/save-as), `usePaletteItems()`. Target: App.tsx under ~600 lines of composition. This directly helps the "hand to Opus to implement" workflow too: smaller files, safer diffs.
+2. **Test the tab flows, not just the model.** `tabsModel.test.ts` covers the pure helpers, but every bug in section 1 lives in the App-level glue (snapshot/restore, close paths, boot seeding). Add React Testing Library tests: open two files (mock invoke), edit one, switch, assert content isolation; close dirty tab, assert dialog; Ctrl+Z after switch (regression for 1.1); Alt+F4 with dirty background tab (regression for 1.2).
+3. **Event-bus coupling.** Cross-component communication runs through ~10 window CustomEvents (`paperling:*`). Workable, but they are stringly-typed and invisible to TypeScript. Centralize them: one `events.ts` with typed `emit`/`on` helpers and a union of event names/payloads. Zero runtime change, much safer refactoring.
+4. **Error message extraction is duplicated ~8 times** (`typeof err === "string" ? err : (err as {message?...})`). Extract `errMessage(err): string` into utils.
+5. **CI checks.** Ensure `tsc`, tests, and `cargo test` run on PRs (they may already); add `cargo clippy -- -D warnings` and a basic `eslint` config if missing.
+
+---
+
+## 7. Suggested implementation order (for the Opus handoff)
+
+Phase 1 (correctness, do first, roughly a week of focused work):
+1. Per-tab CodeMirror `EditorState` + `view.setState` on switch (fixes 1.1, improves 2.4-adjacent restore fidelity and 5.4).
+2. Dirty-check ALL tabs on window close + upgraded UnsavedChangesDialog with per-tab list and Save All (1.2).
+3. Three-way Save/Discard/Cancel on tab close (1.4).
+4. Stat the incoming file on tab activation; extend focus check to all tabs (1.3 external half).
+5. Autosave flush on tab deactivate (1.3 autosave half).
+
+Phase 2 (session + expected interactions):
+6. Persisted multi-tab session restore replacing `lastFile` (1.5).
+7. Ctrl+Tab / Ctrl+PgUp/PgDn / Ctrl+1..9 / Ctrl+Shift+T reopen-closed (2.2 items 1 to 3).
+8. Duplicate-name disambiguation + numbered untitled tabs (2.3).
+9. Tab bar overflow: wheel scroll, scroll-active-into-view, min-width (2.4).
+10. Keyboard accessibility for the tablist (2.5).
+
+Phase 3 (robustness):
+11. Crash-recovery drafts (3.2).
+12. EOL preservation (3.3) and fsync-before-rename (3.5).
+13. Native file watcher (3.1).
+14. Window title sync (4.1).
+
+Phase 4 (delight):
+15. Tab context menu, drag reorder, pinning (2.2 items 4 to 6).
+16. Palette "Open tabs" section, multi-file drop/open (2.6).
+17. Explorer upgrades, `.txt` support, per-block preview memoization as needed.
+
+Each phase is shippable on its own. Phase 1 items are individually small PRs; keep them separate so regressions are bisectable.

--- a/suggestion.md
+++ b/suggestion.md
@@ -4,6 +4,35 @@ A full review of the codebase (v1.0.44) with a focus on robustness, user friendl
 
 ---
 
+## Implementation status (branch `feat/tabs-robustness`)
+
+Most of this document has now been implemented and committed on the `feat/tabs-robustness` branch (each item its own commit, all with `tsc` + tests + production build passing; Rust changes have `cargo test` passing).
+
+**Done:**
+
+- **1.1** Undo isolation on tab switch — history reset via `docSwapId` + a history compartment (TABS-03).
+- **1.2** Window close prompts for ALL dirty tabs, with a multi-file Save all / Discard all dialog (TABS-04).
+- **1.3** Background-tab autosave + focus-time external-change detection for every open tab (TABS-06).
+- **1.4** Save / Discard / Cancel dialog on dirty tab close (TABS-05).
+- **1.5** Full multi-tab session restore, replacing single-file `lastFile` (TABS-07).
+- **2.2** Ctrl+Tab / Ctrl+Shift+Tab / Ctrl+PageUp-Down / Ctrl+1-9 / Ctrl+Shift+T reopen-closed (TABS-15/16).
+- **2.3** Numbered/reused untitled buffers + duplicate-name folder disambiguation (TABS-08/09).
+- **2.4** Tab bar overflow: wheel-scroll, scroll-active-into-view, min-width (TABS-13).
+- **2.5** Keyboard a11y for the tablist (roving tabindex, arrows, Home/End, Delete) (TABS-14).
+- **2.2 (4-5)** Drag-reorder (TABS-10) + right-click context menu (TABS-12).
+- **2.6** Palette "Open tabs" section + Close-tab command, multi-file open/drop, search-jump race fix (TABS-11, SEARCH-01).
+- **3.3 / 3.5** EOL preservation + fsync-before-rename in `save_file` (EOL-01, SAVE-02).
+- **4.1** Native window title sync (TITLE-01).
+- **4.2 / 4.4 / 6.4** Recents cap raised to 25, `.txt` open/drop support, `errMessage` helper (TXT-01, QUALITY-02).
+
+**Intentionally deferred (need a running Tauri app to verify — not safe to ship untested on real documents):**
+
+- **3.1** Native file watcher (`notify` crate) — new Rust dependency + watch-thread lifecycle + reload-loop risk. The focus-time detection (1.3) covers the common cases in the meantime.
+- **3.2** Crash-recovery drafts — fs-permission/quota-sensitive storage + a recovery UI + draft/tab reconciliation. Deserves its own design pass with the app running.
+- **2.2 (6)** Tab pinning, **3.4** encoding tolerance (UTF-16/BOM), **3.6** settings-in-app-data, **5.x** per-block preview memoization, **6.1** App.tsx split, **6.3** typed event bus — larger or lower-priority; left as follow-ups.
+
+---
+
 ## 1. Critical: bugs and data-loss risks in the current tab implementation
 
 These are real defects in what shipped, not polish. Fix these before adding any new tab features.


### PR DESCRIPTION
Implements the `feat/tabs-robustness` roadmap from `suggestion.md` (Fable's review). Each item is its own commit; `tsc`, 225 JS tests, 14 Rust tests, and the production build all pass.

## Phase 1 — critical data-loss fixes
- **Undo isolation (TABS-03):** Ctrl+Z after a tab switch / file open no longer un-swaps the document and pastes the previous file into the current tab. History resets on genuine doc swaps via a `docSwapId` signal + history compartment; in-document edits stay undoable.
- **Window close (TABS-04):** Alt+F4 / taskbar close now checks EVERY tab, not just the active one. Dirty background tabs are no longer discarded silently; the dialog lists them with Save all / Discard all.
- **Background tabs (TABS-06):** dirty background tabs autosave; on focus, every open file is stat'd for external changes (clean → refresh, dirty → warn once).
- **Tab close (TABS-05):** three-way Save / Discard / Cancel instead of the old two-button prompt.
- **Session restore (TABS-07):** relaunch reopens the full set of tabs (paths + active index + caret line), replacing the single-file `lastFile`.

## Phase 2 — finishing the tab feature
- Shortcuts: Ctrl+Tab / Ctrl+Shift+Tab, Ctrl+PageUp/Down, Ctrl+1–8 (Ctrl+9 = last), Ctrl+Shift+T reopen closed (TABS-15/16).
- Numbered/reused untitled buffers, duplicate-name folder disambiguation (TABS-08/09).
- Tab bar overflow (wheel-scroll, scroll-active-into-view, min-width), keyboard a11y, drag-reorder, right-click context menu (TABS-10/12/13/14).
- Palette "Open tabs" section + Close-tab command, multi-file open/drop, search-jump race fix (TABS-11, SEARCH-01).

## Phase 3 / 4 — robustness + housekeeping
- `save_file` fsyncs before the atomic rename and preserves the file's line endings (LF↔CRLF) so Windows files don't get rewritten into noisy diffs (SAVE-02, EOL-01, +3 Rust tests).
- Native window title reflects file + dirty state (TITLE-01).
- `errMessage` helper, recents cap 10→25, `.txt`/`.text` support (QUALITY-02, TXT-01).

## Deferred (need a running Tauri app to verify — not safe to ship untested)
- Native file watcher (`notify` crate) and crash-recovery drafts. Rationale is documented in `suggestion.md`.

New tests: 14 tabsModel unit tests, 3 Rust save/EOL tests.