### PR TITLE
feat: Add Windows ARM64 CI Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest, ubuntu-24.04, macos-latest]
+        platform: [windows-latest, windows-11-arm, ubuntu-24.04, macos-latest]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,9 @@ jobs:
       matrix:
         include:
           - platform: windows-latest
-            args: ''
+            args: '--target x86_64-pc-windows-msvc'
+          - platform: windows-11-arm
+            args: '--target aarch64-pc-windows-msvc'
           - platform: ubuntu-24.04
             args: ''
           - platform: macos-latest


### PR DESCRIPTION
# Overview
I've got a windows 11 arm laptop and it would be awesome to just grab a release instead of having to build from source. `windows-11-arm` is a free-tier-for-public runner ([source](https://docs.github.com/en/actions/reference/runners/github-hosted-runners))

# Testing
I ran the project locally, seems fine. Tests pass except for what appears to be all frontend tests requiring `localstorage`. Unsure if this is a windows11 arm thing, Windows thing, or just a "pre-existing" thing. Happy to investigate and address as part of this PR if needed.

This is difficult to test as changes are only CI, let me know if I can help perform any additional verification.

# Note
It looks like your `src-tauri/Cargo.lock` is not hooked up to CI/release, as it's using an older version (`1.0.44`) instead of current latest on this branch (`1.0.48`)