### PR TITLE
Show subfolders in the file explorer. Resolves  #90

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ I wanted something you just open and write in: it renders Markdown beautifully w
 
 Dark, Light, Paper, and Dracula.
 
-| Dark | Light | Paper |
-|:----:|:-----:|:-----:|
+|                                   Dark                                   |                                   Light                                    |                                   Paper                                    |
+| :----------------------------------------------------------------------: | :------------------------------------------------------------------------: | :------------------------------------------------------------------------: |
 | <img src="images/theme-dark.png" width="280" alt="Paperling Dark theme"> | <img src="images/theme-light.png" width="280" alt="Paperling Light theme"> | <img src="images/theme-paper.png" width="280" alt="Paperling Paper theme"> |
 
 ### File explorer &amp; command palette
 
-| File explorer | Command palette |
-|:-------------:|:---------------:|
+|                                          File explorer                                          |                                  Command palette                                   |
+| :---------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------: |
 | <img src="images/file-explorer.png" width="420" alt="Paperling file explorer with reader mode"> | <img src="images/command-palette.png" width="420" alt="Paperling command palette"> |
 
 ## Features
@@ -116,7 +116,7 @@ Dark, Light, Paper, and Dracula.
 - **External-change detection** — reload or keep your version when the file changes outside the app
 - **Recent files** on the welcome screen — missing files marked
 - **Restore last opened file** on launch
-- **File Explorer** for the current folder
+- **File Explorer** with folder navigation
 - **Outline pane** that follows the cursor
 
 ### <img src="images/art/icon-theme-swatches.png" width="26" alt=""> Customization
@@ -137,15 +137,15 @@ Download the latest release from the [Releases](https://github.com/Razee4315/Pap
 
 ### Available Formats
 
-| Platform | Formats |
-|----------|---------|
+| Platform    | Formats                                    |
+| ----------- | ------------------------------------------ |
 | **Windows** | `.msi` installer · `.exe` (NSIS) installer |
-| **macOS** | `.dmg` (Apple Silicon) |
-| **Linux** | `.AppImage` · `.deb` · `.rpm` |
+| **macOS**   | `.dmg` (Apple Silicon)                     |
+| **Linux**   | `.AppImage` · `.deb` · `.rpm`              |
 
 > **Note:** builds aren't code-signed yet, so Windows SmartScreen or macOS
-> Gatekeeper may warn on first launch. On Windows choose *More info → Run anyway*;
-> on macOS right-click the app and choose *Open*. Auto-update packages are signed
+> Gatekeeper may warn on first launch. On Windows choose _More info → Run anyway_;
+> on macOS right-click the app and choose _Open_. Auto-update packages are signed
 > and verified before installing.
 
 ## Development
@@ -177,22 +177,22 @@ bun run tauri build
 
 A few essentials — press `?` inside the app for the full searchable list.
 
-| Action | Shortcut |
-|--------|----------|
-| Command palette | Ctrl+P |
-| Cheatsheet | ? |
-| Settings | Ctrl+, |
-| New file | Ctrl+N |
-| Open file | Ctrl+O |
-| Save | Ctrl+S |
-| Save As | Ctrl+Shift+S |
-| Toggle Reader / Code | Ctrl+E |
-| Toggle Split view | Ctrl+\\ |
-| File explorer / Outline | Ctrl+Shift+E / Ctrl+Shift+O |
-| Find / Replace | Ctrl+F / Ctrl+H |
-| Bold / Italic / Link | Ctrl+B / Ctrl+I / Ctrl+K |
-| Toggle blockquote | Ctrl+/ |
-| AI panel / assist | Alt+J (Windows) · ⌘J (macOS/Linux) |
+| Action                  | Shortcut                           |
+| ----------------------- | ---------------------------------- |
+| Command palette         | Ctrl+P                             |
+| Cheatsheet              | ?                                  |
+| Settings                | Ctrl+,                             |
+| New file                | Ctrl+N                             |
+| Open file               | Ctrl+O                             |
+| Save                    | Ctrl+S                             |
+| Save As                 | Ctrl+Shift+S                       |
+| Toggle Reader / Code    | Ctrl+E                             |
+| Toggle Split view       | Ctrl+\\                            |
+| File explorer / Outline | Ctrl+Shift+E / Ctrl+Shift+O        |
+| Find / Replace          | Ctrl+F / Ctrl+H                    |
+| Bold / Italic / Link    | Ctrl+B / Ctrl+I / Ctrl+K           |
+| Toggle blockquote       | Ctrl+/                             |
+| AI panel / assist       | Alt+J (Windows) · ⌘J (macOS/Linux) |
 
 ## Tech Stack
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2914,7 +2914,7 @@ dependencies = [
 
 [[package]]
 name = "paperling"
-version = "1.0.44"
+version = "1.0.48"
 dependencies = [
  "keyring",
  "serde",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -79,7 +79,11 @@ async fn detect_file_eol(path: &str) -> Eol {
     };
     for i in 0..n {
         if buf[i] == b'\n' {
-            return if i > 0 && buf[i - 1] == b'\r' { Eol::Crlf } else { Eol::Lf };
+            return if i > 0 && buf[i - 1] == b'\r' {
+                Eol::Crlf
+            } else {
+                Eol::Lf
+            };
         }
     }
     Eol::Lf
@@ -136,13 +140,13 @@ pub async fn read_file(path: String) -> Result<FileData, CommandError> {
     let content = tokio::fs::read_to_string(&file_path)
         .await
         .map_err(|e| CommandError::ReadError(e.to_string()))?;
-    
+
     let name = file_path
         .file_name()
         .and_then(|n| n.to_str())
         .map(|s| s.to_string())
         .unwrap_or_else(|| "Untitled".to_string());
-    
+
     let line_count = content.lines().count();
 
     Ok(FileData {
@@ -228,21 +232,21 @@ pub async fn save_file(path: String, content: String) -> Result<u64, CommandErro
 #[tauri::command]
 pub async fn get_file_info(path: String) -> Result<FileInfo, CommandError> {
     let file_path = PathBuf::from(&path);
-    
+
     if !file_path.exists() {
         return Err(CommandError::FileNotFound(path));
     }
-    
+
     let metadata = tokio::fs::metadata(&file_path)
         .await
         .map_err(|e| CommandError::ReadError(e.to_string()))?;
-    
+
     let name = file_path
         .file_name()
         .and_then(|n| n.to_str())
         .map(|s| s.to_string())
         .unwrap_or_else(|| "Untitled".to_string());
-    
+
     Ok(FileInfo {
         path,
         name,
@@ -265,51 +269,75 @@ pub struct FileInfo {
 pub struct FileEntry {
     pub name: String,
     pub path: String,
+    pub is_dir: bool,
 }
 
 /// List all markdown files in a directory
 #[tauri::command]
 pub async fn list_directory_files(directory: String) -> Result<Vec<FileEntry>, CommandError> {
     let dir_path = PathBuf::from(&directory);
-    
+
     if !dir_path.exists() {
         return Err(CommandError::FileNotFound(directory));
     }
-    
+
     if !dir_path.is_dir() {
-        return Err(CommandError::ReadError("Path is not a directory".to_string()));
+        return Err(CommandError::ReadError(
+            "Path is not a directory".to_string(),
+        ));
     }
-    
+
     let mut entries = Vec::new();
-    
+
     let mut read_dir = tokio::fs::read_dir(&dir_path)
         .await
         .map_err(|e| CommandError::ReadError(e.to_string()))?;
-    
-    while let Some(entry) = read_dir.next_entry().await.map_err(|e| CommandError::ReadError(e.to_string()))? {
+
+    while let Some(entry) = read_dir
+        .next_entry()
+        .await
+        .map_err(|e| CommandError::ReadError(e.to_string()))?
+    {
         let path = entry.path();
-        
-        // Only include .md files
-        if path.is_file() {
+
+        let entry_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+
+        // Skip hidden files and directories (starting with a dot)
+        if entry_name.starts_with('.') {
+            continue;
+        }
+
+        if path.is_dir() {
+            // Add directories
+            entries.push(FileEntry {
+                name: entry_name,
+                path: path.to_string_lossy().to_string(),
+                is_dir: true,
+            });
+        } else if path.is_file() {
+            // Only include .md files
             if let Some(ext) = path.extension() {
                 if ext == "md" || ext == "markdown" {
-                    let name = path
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .map(|s| s.to_string())
-                        .unwrap_or_default();
-                    
                     entries.push(FileEntry {
-                        name,
+                        name: entry_name,
                         path: path.to_string_lossy().to_string(),
+                        is_dir: false,
                     });
                 }
             }
         }
     }
-    
-    // Sort alphabetically, case-insensitively.
-    entries.sort_by_key(|a| a.name.to_lowercase());
+
+    // Sort: Directories first, then alphabetically case-insensitive
+    entries.sort_by(|a, b| {
+        b.is_dir
+            .cmp(&a.is_dir)
+            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+    });
 
     Ok(entries)
 }
@@ -368,7 +396,11 @@ pub async fn search_files(
 /// it can be unit-tested without a Tauri/async harness. `query` is assumed
 /// non-empty and already trimmed.
 fn search_markdown_tree(root: PathBuf, query: &str, case_sensitive: bool) -> Vec<FileSearchResult> {
-    let needle = if case_sensitive { query.to_string() } else { query.to_lowercase() };
+    let needle = if case_sensitive {
+        query.to_string()
+    } else {
+        query.to_lowercase()
+    };
     let mut results: Vec<FileSearchResult> = Vec::new();
     let mut files_scanned = 0usize;
     let mut stack = vec![root];
@@ -474,17 +506,23 @@ fn search_markdown_tree(root: PathBuf, query: &str, case_sensitive: bool) -> Vec
 fn sanitize_image_name(name: &str) -> Result<String, CommandError> {
     let trimmed = name.trim();
     if trimmed.is_empty() || trimmed == "." || trimmed == ".." {
-        return Err(CommandError::WriteError("Invalid image filename".to_string()));
+        return Err(CommandError::WriteError(
+            "Invalid image filename".to_string(),
+        ));
     }
     if trimmed.contains('\0') {
-        return Err(CommandError::WriteError("Invalid image filename".to_string()));
+        return Err(CommandError::WriteError(
+            "Invalid image filename".to_string(),
+        ));
     }
     // Reject both path separators explicitly, on every platform. On Unix a
     // backslash is a legal filename character, so the Path::file_name() check
     // below would let a Windows-style "..\foo.png" traversal payload through;
     // rejecting separators up front keeps the behavior identical cross-platform.
     if trimmed.contains('/') || trimmed.contains('\\') {
-        return Err(CommandError::WriteError("Invalid image filename".to_string()));
+        return Err(CommandError::WriteError(
+            "Invalid image filename".to_string(),
+        ));
     }
     // Reject any path-like input — only a bare basename is allowed.
     let basename = std::path::Path::new(trimmed)
@@ -492,7 +530,9 @@ fn sanitize_image_name(name: &str) -> Result<String, CommandError> {
         .and_then(|s| s.to_str())
         .ok_or_else(|| CommandError::WriteError("Invalid image filename".to_string()))?;
     if basename != trimmed {
-        return Err(CommandError::WriteError("Invalid image filename".to_string()));
+        return Err(CommandError::WriteError(
+            "Invalid image filename".to_string(),
+        ));
     }
     // Enforce extension whitelist (case-insensitive). A name with no extension,
     // or one whose extension isn't a known image type, is rejected — this is
@@ -535,9 +575,9 @@ pub async fn save_image(
     // Create images subdirectory
     let images_dir = parent_dir.join("images");
     if !images_dir.exists() {
-        tokio::fs::create_dir_all(&images_dir)
-            .await
-            .map_err(|e| CommandError::WriteError(format!("Failed to create images directory: {}", e)))?;
+        tokio::fs::create_dir_all(&images_dir).await.map_err(|e| {
+            CommandError::WriteError(format!("Failed to create images directory: {}", e))
+        })?;
     }
 
     // Full path for the image (basename only, no traversal possible).
@@ -564,11 +604,15 @@ fn validate_rel_path(rel: &str) -> Result<(), CommandError> {
     // checks below would miss them.
     let b = rel.as_bytes();
     if b.len() >= 2 && b[0].is_ascii_alphabetic() && b[1] == b':' {
-        return Err(CommandError::ReadError("Image path must be relative".to_string()));
+        return Err(CommandError::ReadError(
+            "Image path must be relative".to_string(),
+        ));
     }
     let p = std::path::Path::new(rel);
     if p.is_absolute() {
-        return Err(CommandError::ReadError("Image path must be relative".to_string()));
+        return Err(CommandError::ReadError(
+            "Image path must be relative".to_string(),
+        ));
     }
     for comp in p.components() {
         match comp {
@@ -669,7 +713,9 @@ pub fn set_ai_key(key: String) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_eol, sanitize_image_name, save_file, search_markdown_tree, validate_rel_path, Eol};
+    use super::{
+        apply_eol, sanitize_image_name, save_file, search_markdown_tree, validate_rel_path, Eol,
+    };
 
     #[test]
     fn search_finds_matches_recursively_and_case_insensitively() {
@@ -700,7 +746,8 @@ mod tests {
 
     #[test]
     fn search_skips_hidden_and_ignored_dirs() {
-        let dir = std::env::temp_dir().join(format!("paperling-search-skip-{}", std::process::id()));
+        let dir =
+            std::env::temp_dir().join(format!("paperling-search-skip-{}", std::process::id()));
         let hidden = dir.join(".git");
         let modules = dir.join("node_modules");
         std::fs::create_dir_all(&hidden).unwrap();
@@ -775,8 +822,13 @@ mod tests {
             // Seed a CRLF file, then "edit" it with LF-only content (as the editor
             // would hand us) and confirm the CRLF convention survives the save.
             std::fs::write(&path, "one\r\ntwo\r\n").unwrap();
-            save_file(path.clone(), "one\ntwo\nthree".into()).await.unwrap();
-            assert_eq!(std::fs::read_to_string(&path).unwrap(), "one\r\ntwo\r\nthree");
+            save_file(path.clone(), "one\ntwo\nthree".into())
+                .await
+                .unwrap();
+            assert_eq!(
+                std::fs::read_to_string(&path).unwrap(),
+                "one\r\ntwo\r\nthree"
+            );
 
             // A brand-new file keeps the editor's LF.
             let lf_path = dir.join("new.md").to_string_lossy().to_string();
@@ -808,7 +860,10 @@ mod tests {
     #[test]
     fn accepts_basename() {
         assert_eq!(sanitize_image_name("foo.png").unwrap(), "foo.png");
-        assert_eq!(sanitize_image_name("image-1234-abc.jpg").unwrap(), "image-1234-abc.jpg");
+        assert_eq!(
+            sanitize_image_name("image-1234-abc.jpg").unwrap(),
+            "image-1234-abc.jpg"
+        );
     }
 
     #[test]

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -7,6 +7,7 @@ import mascotShrug from "../assets/mascot/mascot-shrug.png";
 interface FileEntry {
     name: string;
     path: string;
+    is_dir: boolean;
 }
 
 interface FileExplorerProps {
@@ -25,6 +26,7 @@ export function FileExplorer({
     const [files, setFiles] = useState<FileEntry[]>([]);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [currentViewDir, setCurrentViewDir] = useState<string | null>(null);
     const panelRef = useRef<HTMLElement>(null);
 
     // Get directory from current file path
@@ -35,26 +37,33 @@ export function FileExplorer({
         return lastSlash > 0 ? filePath.substring(0, lastSlash) : null;
     };
 
+    // Initialize the view directory when opening the panel
     useEffect(() => {
-        if (isOpen && currentFilePath) {
+        if (isOpen && currentFilePath && !currentViewDir) {
             const directory = getDirectory(currentFilePath);
-            if (directory) {
-                loadFiles(directory);
-            }
+            setCurrentViewDir(directory);
+        } else if (!isOpen) {
+            // Reset view when closed so it snaps back to the active file next time
+            setCurrentViewDir(null); 
         }
     }, [isOpen, currentFilePath]);
+
+    // Load files whenever the currentViewDir changes
+    useEffect(() => {
+        if (isOpen && currentViewDir) {
+            loadFiles(currentViewDir);
+        }
+    }, [isOpen, currentViewDir]);
 
     // Refresh when the window regains focus — files may have been created or
     // deleted in another app while the explorer sat open. Mirrors App's
     // external-change-on-focus detection so the list never goes stale.
     useEffect(() => {
-        if (!isOpen) return;
-        const directory = getDirectory(currentFilePath);
-        if (!directory) return;
-        const onFocus = () => loadFiles(directory);
+        if (!isOpen || !currentViewDir) return;
+        const onFocus = () => loadFiles(currentViewDir);
         window.addEventListener("focus", onFocus);
         return () => window.removeEventListener("focus", onFocus);
-    }, [isOpen, currentFilePath]);
+    }, [isOpen, currentViewDir]);
 
     // Escape key to close and focus management + focus trap
     useEffect(() => {
@@ -93,14 +102,26 @@ export function FileExplorer({
         }
     };
 
-    const handleFileClick = (path: string) => {
-        onFileSelect(path);
-        onClose();
+    const handleEntryClick = (entry: FileEntry) => {
+        if (entry.is_dir) {
+            // Navigate into the folder
+            setCurrentViewDir(entry.path);
+        } else {
+            // Select the file and close
+            onFileSelect(entry.path);
+            onClose();
+        }
+    };
+    
+    const handleGoUp = () => {
+        if (currentViewDir) {
+            const parentDir = getDirectory(currentViewDir);
+            if (parentDir) setCurrentViewDir(parentDir);
+        }
     };
 
-    const directory = getDirectory(currentFilePath);
-    const directoryName = directory
-        ? directory.replace(/\\/g, "/").split("/").pop()
+    const directoryName = currentViewDir
+        ? currentViewDir.replace(/\\/g, "/").split("/").pop()
         : "Files";
 
     return (
@@ -109,20 +130,31 @@ export function FileExplorer({
             role="navigation"
             aria-label="File explorer"
             tabIndex={-1}
-            className={`fixed left-0 top-12 bottom-7 w-72 bg-[var(--bg-secondary)] border-r border-[var(--border)] z-50 shadow-2xl flex flex-col overflow-hidden transition-transform duration-200 ease-out ${isOpen ? "translate-x-0" : "-translate-x-full"
-                }`}
+            className={`fixed left-0 top-12 bottom-7 w-72 bg-[var(--bg-secondary)] border-r border-[var(--border)] z-50 shadow-2xl flex flex-col overflow-hidden transition-transform duration-200 ease-out ${
+                isOpen ? "translate-x-0" : "-translate-x-full"
+            }`}
         >
             {/* Header */}
             <div className="h-10 shrink-0 px-4 flex items-center justify-between border-b border-[var(--border)] bg-[var(--bg-titlebar)]">
                 <div className="flex items-center gap-2 text-sm font-semibold text-[var(--text-primary)] no-select">
+                    <button
+                        onClick={handleGoUp}
+                        aria-label="Go up one folder"
+                        title="Go up"
+                        className="btn-press flex items-center justify-center w-6 h-6 rounded hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] transition-colors mr-1"
+                    >
+                        <span className="material-symbols-outlined text-[18px]">
+                            arrow_upward
+                        </span>
+                    </button>
                     <span className="material-symbols-outlined text-[18px]">
                         folder_open
                     </span>
-                    <span className="truncate max-w-[180px]">{directoryName}</span>
+                    <span className="truncate max-w-[140px]" title={directoryName}>{directoryName}</span>
                 </div>
                 <div className="flex items-center gap-1">
                     <button
-                        onClick={() => { const d = getDirectory(currentFilePath); if (d) loadFiles(d); }}
+                        onClick={() => currentViewDir && loadFiles(currentViewDir)}
                         aria-label="Refresh file list"
                         title="Refresh"
                         className="btn-press flex items-center justify-center w-7 h-7 rounded-lg hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
@@ -157,25 +189,26 @@ export function FileExplorer({
                 ) : files.length === 0 ? (
                     <div className="flex flex-col items-center justify-center gap-3 py-10 text-sm text-[var(--text-secondary)]">
                         <img src={mascotCarry} alt="" aria-hidden="true" draggable={false} className="w-20 h-20 object-contain select-none opacity-90" />
-                        <span>No markdown files here</span>
+                        <span>Folder is empty</span>
                     </div>
                 ) : (
-                    <ul className="py-2" role="listbox" aria-label="Markdown files">
+                    <ul className="py-2" role="listbox" aria-label="Files and folders">
                         {files.map((file, index) => {
-                            const isActive = file.path === currentFilePath;
+                            const isActive = file.path === currentFilePath && !file.is_dir;
                             return (
                                 <li key={file.path} className="stagger-item" style={{ animationDelay: `${index * 0.03}s` }}>
                                     <button
-                                        onClick={() => handleFileClick(file.path)}
+                                        onClick={() => handleEntryClick(file)}
                                         role="option"
                                         aria-selected={isActive}
-                                        className={`btn-press w-full px-4 py-2 text-left text-sm flex items-center gap-2 transition-colors ${isActive
-                                            ? "bg-[var(--accent)] text-[var(--accent-text)]"
-                                            : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-                                            }`}
+                                        className={`btn-press w-full px-4 py-2 text-left text-sm flex items-center gap-2 transition-colors ${
+                                            isActive
+                                                ? "bg-[var(--accent)] text-[var(--accent-text)]"
+                                                : "text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+                                        }`}
                                     >
                                         <span className="material-symbols-outlined text-[16px]">
-                                            description
+                                            {file.is_dir ? "folder" : "description"}
                                         </span>
                                         <span className="truncate">{file.name}</span>
                                     </button>
@@ -186,5 +219,5 @@ export function FileExplorer({
                 )}
             </div>
         </aside>
-    );
+);
 }


### PR DESCRIPTION
### Solving issue
This PR solves the #90 issue.

### What problem does this solve?

The file explorer only lists markdown files in the current file's immediate folder. If your notes live in subfolders, you cannot browse into them from the sidebar.

### Why

The Rust `list_directory_files` command in `src-tauri/src/commands.rs` reads a single directory and returns only `.md` and `.markdown` files, skipping subdirectories. The explorer in `src/components/FileExplorer.tsx` renders that flat list.

### Proposed solution

1. Return directory entries too (with an `is_dir` flag) and let the UI load a folder's contents when it is expanded
2. A button is included in the top bar to go to the parent folder

### Changes made

1. Implemented proposed solution both in `src-tauri/src/commands.rs` and `src/components/FileExplorer.tsx`.
2. Updated README.md to update the features.