### PR TITLE
fix(export): shim Node globals so DOCX export works in the webview

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1",
         "@turbodocx/html-to-docx": "^1.22.0",
+        "buffer": "^6.0.3",
         "katex": "^0.16.47",
         "material-symbols": "^0.44.12",
         "mermaid": "^11.16.0",
@@ -592,11 +593,15 @@
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ=="],
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -877,6 +882,8 @@
     "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "image-size": ["image-size@2.0.2", "", { "bin": { "image-size": "bin/image-size.js" } }, "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w=="],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
     "@turbodocx/html-to-docx": "^1.22.0",
+    "buffer": "^6.0.3",
     "katex": "^0.16.47",
     "material-symbols": "^0.44.12",
     "mermaid": "^11.16.0",

--- a/src/utils/exportUtils.test.ts
+++ b/src/utils/exportUtils.test.ts
@@ -124,4 +124,12 @@ describe("exportToDocx", () => {
         // not an HTML blob with a .docx extension.
         expect(Array.from(bytes.slice(0, 4))).toEqual([0x50, 0x4b, 0x03, 0x04]);
     }, 20000);
+
+    // NOTE (EXPORT-05): the webview provides no Node globals, and the
+    // converter's browser build reaches for global/Buffer/process anyway —
+    // exportToDocx shims them via ensureDocxRuntime before loading the chunk.
+    // That scenario is untestable under vitest (removing Node's own globals
+    // takes the runner down); it was verified against the built bundle in a
+    // real browser, where conversion fails without the shims and succeeds
+    // with them.
 });

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -504,6 +504,24 @@ type HtmlToDocx = (
     footer?: string | null
 ) => Promise<ArrayBuffer | Blob | Uint8Array>;
 
+// @turbodocx/html-to-docx's browser build still reaches for Node's `global`,
+// `Buffer` and `process`; the webview provides none of them, so conversion
+// threw "global is not defined" the moment the chunk ran. Tests never caught
+// it because vitest runs in Node, which supplies all three. Shim them right
+// before the library loads — the Buffer polyfill is itself dynamically
+// imported, so none of this weighs on cold start. EXPORT-05.
+async function ensureDocxRuntime(): Promise<void> {
+    const g = globalThis as Record<string, unknown>;
+    if (typeof g.global === "undefined") g.global = g;
+    if (typeof g.process === "undefined") g.process = { env: {} };
+    if (typeof g.Buffer === "undefined") {
+        // In the browser bundle "buffer" resolves to the npm polyfill package;
+        // under Node (vitest) it resolves to the builtin. Both export Buffer.
+        const { Buffer } = await import("buffer");
+        g.Buffer = Buffer;
+    }
+}
+
 export async function exportToDocx(
     htmlContent: string,
     fileName: string,
@@ -530,6 +548,7 @@ export async function exportToDocx(
     });
     if (!filePath) return false;
 
+    await ensureDocxRuntime();
     const mod = await import('@turbodocx/html-to-docx');
     // The package uses `export =`; the function is the default export under the
     // browser/ESM build. Fall back to the namespace itself for the CJS shape.


### PR DESCRIPTION
DOCX export threw 'global is not defined' in every packaged build: the converter's browser build expects Node globals the webview lacks. Adds a lazy shim (global/process/Buffer via the buffer polyfill) before the converter chunk loads. Verified against the built bundle in a real browser (fails without shims, valid OOXML zip with them). Full suite green (262). Pre-existing bug, not from the current batch.