### PR TITLE
feat(settings): one-click AI provider presets

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -10,6 +10,7 @@ import {
     getAutoSave, setAutoSave,
     getOpenInReader, setOpenInReader,
 } from "../utils/persistence";
+import { AI_PROVIDERS, matchProvider, type AIProvider } from "../utils/aiProviders";
 import { attachFocusTrap } from "../utils/focusTrap";
 import { isValidEndpoint, runAIAction } from "../utils/aiAssist";
 import mascotWave from "../assets/mascot/mascot-wave.png";
@@ -116,6 +117,13 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
         setAiTest({ state: "idle" });
         if (!next.endpoint || isValidEndpoint(next.endpoint)) setAIConfig(next);
     };
+
+    // Derived, not stored: the provider pill is whichever preset the current
+    // endpoint equals, so hand-edited endpoints simply select nothing.
+    const activeProvider = matchProvider(ai.endpoint);
+    // Fills endpoint + default model; the key is deliberately left alone so
+    // re-picking a provider never wipes a pasted key.
+    const applyProvider = (p: AIProvider) => updateAi({ endpoint: p.endpoint, model: p.defaultModel });
 
     const testAIConnection = async () => {
         setAiTest({ state: "testing" });
@@ -351,6 +359,31 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                     </span>
                                 </div>
                                 <div className="space-y-3">
+                                    <div>
+                                        <span className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider">Provider</span>
+                                        <div className="mt-1 flex flex-wrap gap-2" role="group" aria-label="AI provider presets">
+                                            {AI_PROVIDERS.map((p) => {
+                                                const active = activeProvider?.id === p.id;
+                                                return (
+                                                    <button
+                                                        key={p.id}
+                                                        type="button"
+                                                        onClick={() => applyProvider(p)}
+                                                        aria-pressed={active}
+                                                        className={`px-3 py-1.5 text-sm rounded-[var(--radius-md)] border transition-colors ${active
+                                                            ? "bg-[var(--accent)] text-[var(--accent-text)] border-[var(--accent)]"
+                                                            : "border-[var(--border)] text-[var(--text-primary)] hover:bg-[var(--bg-hover)]"}`}
+                                                    >
+                                                        {p.name}
+                                                    </button>
+                                                );
+                                            })}
+                                        </div>
+                                        <span className="block mt-1 text-[11px] text-[var(--text-muted)]">
+                                            Pick a provider to fill in the endpoint and model; then just paste your API key.
+                                            Any other OpenAI-compatible endpoint works too, entered below.
+                                        </span>
+                                    </div>
                                     <label className="block">
                                         <span className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider">Endpoint URL</span>
                                         <input
@@ -381,9 +414,12 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                             type="password"
                                             value={ai.apiKey}
                                             onChange={(e) => updateAi({ apiKey: e.target.value })}
-                                            placeholder="(optional for local providers)"
+                                            placeholder={activeProvider?.keyOptional ? "(not needed for this provider)" : activeProvider ? `paste your ${activeProvider.name} API key` : "(optional for local providers)"}
                                             className="mt-1 w-full px-3 py-2 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-md)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)] font-mono"
                                         />
+                                        {activeProvider && (
+                                            <span className="block mt-1 text-[11px] text-[var(--text-muted)]">{activeProvider.keyHint}</span>
+                                        )}
                                     </label>
                                     <div className="flex items-center gap-3">
                                         <button

--- a/src/utils/aiProviders.test.ts
+++ b/src/utils/aiProviders.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { AI_PROVIDERS, matchProvider } from "./aiProviders";
+
+describe("matchProvider", () => {
+    it("matches every preset by its own endpoint", () => {
+        for (const p of AI_PROVIDERS) {
+            expect(matchProvider(p.endpoint)?.id).toBe(p.id);
+        }
+    });
+
+    it("tolerates surrounding whitespace and trailing slashes", () => {
+        expect(matchProvider("  https://api.openai.com/v1/chat/completions/ ")?.id).toBe("openai");
+    });
+
+    it("returns null for empty and hand-configured endpoints", () => {
+        expect(matchProvider("")).toBeNull();
+        expect(matchProvider("   ")).toBeNull();
+        expect(matchProvider("https://my-proxy.example.com/v1/chat/completions")).toBeNull();
+    });
+
+    it("every preset endpoint is a valid https/http URL", () => {
+        for (const p of AI_PROVIDERS) {
+            const u = new URL(p.endpoint);
+            expect(["http:", "https:"]).toContain(u.protocol);
+        }
+    });
+});

--- a/src/utils/aiProviders.ts
+++ b/src/utils/aiProviders.ts
@@ -1,0 +1,50 @@
+// Provider presets for the AI settings page: picking one fills the endpoint
+// and a sensible default model, leaving only the API key to paste. Every
+// preset speaks the OpenAI Chat Completions protocol (Gemini through its
+// OpenAI-compatibility layer), which is the one protocol the app implements,
+// so no per-provider request code exists or is needed. AI-05.
+
+export interface AIProvider {
+    id: string;
+    name: string;
+    endpoint: string;
+    defaultModel: string;
+    /** Shown under the API key field while this provider is selected. */
+    keyHint: string;
+    /** Local providers need no key; relaxes the field's placeholder. */
+    keyOptional?: boolean;
+}
+
+export const AI_PROVIDERS: AIProvider[] = [
+    {
+        id: "gemini",
+        name: "Google Gemini",
+        endpoint: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+        defaultModel: "gemini-2.5-flash",
+        keyHint: "Get a free key at aistudio.google.com/apikey and paste it above.",
+    },
+    {
+        id: "openai",
+        name: "OpenAI",
+        endpoint: "https://api.openai.com/v1/chat/completions",
+        defaultModel: "gpt-4o-mini",
+        keyHint: "Create a key at platform.openai.com/api-keys and paste it above.",
+    },
+    {
+        id: "ollama",
+        name: "Ollama (local)",
+        endpoint: "http://localhost:11434/v1/chat/completions",
+        defaultModel: "llama3.2",
+        keyHint: "No key needed. Everything stays on your machine.",
+        keyOptional: true,
+    },
+];
+
+const normalize = (url: string) => url.trim().replace(/\/+$/, "");
+
+/** The preset whose endpoint matches, or null (empty or hand-configured). */
+export function matchProvider(endpoint: string): AIProvider | null {
+    const e = normalize(endpoint);
+    if (!e) return null;
+    return AI_PROVIDERS.find((p) => normalize(p.endpoint) === e) ?? null;
+}


### PR DESCRIPTION
Provider pills on the AI settings page (Gemini / OpenAI / Ollama): picking one auto-fills endpoint + default model, user only pastes the API key. Key-source hint per provider. Selection is derived from the endpoint, nothing new is persisted, custom endpoints unaffected. Gates green (266 tests).