### PR TITLE
Sidebar overlay fix + AI review / editor polish (#112, #111)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,6 +140,11 @@ const AI_SHORTCUT = IS_MAC ? "⌘J" : "Alt+J";
 // padding-right when it's open so content reflows beside it (not under it).
 const AI_PANEL_WIDTH = 400;
 
+// Width of the left-side drawers (FileExplorer / TableOfContents); they are
+// `fixed left-0 w-72` (18rem = 288px), so the editor reserves this much
+// padding-left when one is open so content reflows beside it (not under it).
+const SIDEBAR_WIDTH = 288;
+
 // The launch-file resolution must run exactly once per webview load. React
 // StrictMode double-invokes effects in dev: without this guard the second run
 // would find the CLI file already consumed (the backend take()s it) and start
@@ -1940,7 +1945,14 @@ function AppContent() {
             // right-0 (above the status bar), which keeps window controls at the edge.
             // min() mirrors the panel's own w-[400px] max-w-[90vw] so a narrow
             // window reserves only as much space as the panel actually takes.
-            style={{ paddingRight: showAIPanel ? `min(${AI_PANEL_WIDTH}px, 90vw)` : 0, transition: "padding-right 0.15s ease" }}
+            // The left drawers (FileExplorer / TableOfContents) are likewise fixed
+            // at left-0, so reserve padding-left when one is open so they reflow the
+            // editor beside them instead of overlaying it.
+            style={{
+                paddingLeft: (showFileExplorer || showTOC) ? `${SIDEBAR_WIDTH}px` : 0,
+                paddingRight: showAIPanel ? `min(${AI_PANEL_WIDTH}px, 90vw)` : 0,
+                transition: "padding 0.15s ease",
+            }}
           >
             <div
               data-split-left

--- a/src/components/AIBubble.test.tsx
+++ b/src/components/AIBubble.test.tsx
@@ -13,11 +13,11 @@ describe("AIBubble", () => {
         expect(container.firstChild).toBeNull();
     });
 
-    it("shows only selection-free actions when nothing is selected", () => {
+    it("shows no action buttons when nothing is selected", () => {
         render(
             <AIBubble anchor={{ x: 0, y: 0 }} selectedText="" config={cfg} onReplace={noop} onInsert={noop} onClose={noop} />
         );
-        expect(screen.getByText("Continue")).toBeInTheDocument();
+        expect(screen.queryByText("Continue")).toBeNull();
         expect(screen.queryByText("Rewrite")).toBeNull();
     });
 

--- a/src/components/AIBubble.tsx
+++ b/src/components/AIBubble.tsx
@@ -18,7 +18,6 @@ const ACTIONS: Array<{ id: AIAction; label: string; icon: string; needsSelection
     { id: "rewrite", label: "Rewrite", icon: "auto_fix_high", needsSelection: true },
     { id: "shorten", label: "Shorten", icon: "compress", needsSelection: true },
     { id: "expand", label: "Expand", icon: "expand", needsSelection: true },
-    { id: "continue", label: "Continue", icon: "play_arrow", needsSelection: false },
     { id: "translate", label: "Translate → EN", icon: "translate", needsSelection: true },
 ];
 

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -356,26 +356,27 @@ function CodeEditorImpl({
                 }
                 // Detect when the user has resolved every chunk individually via the
                 // gutter buttons (Accept-all/Reject-all clear reviewingRef themselves).
-                // Only on doc-changing updates — resolving a chunk edits the doc; a
-                // bare selection change never completes a review.
-                if (update.docChanged) {
-                    let chunkCount = -1;
-                    try { chunkCount = getChunks(update.state)?.chunks.length ?? -1; } catch { /* merge field not ready */ }
-                    if (chunkCount > 0) reviewHadChunksRef.current = true;
-                    // Only finalize AFTER we've seen at least one chunk: the merge
-                    // field can briefly report 0 chunks right after entering review.
-                    if (reviewHadChunksRef.current && chunkCount === 0) {
-                        // Defer: dispatching synchronously from inside the update
-                        // listener is re-entrant and unsafe. Re-check in the rAF that
-                        // nothing else (a manual Accept/Reject-all) resolved it first.
-                        requestAnimationFrame(() => {
-                            const v = viewRef.current;
-                            if (!v || !reviewingRef.current) return;
-                            let stillZero = false;
-                            try { stillZero = (getChunks(v.state)?.chunks.length ?? -1) === 0; } catch { /* ignore */ }
-                            if (stillZero) finishReview(v.state.doc.toString());
-                        });
-                    }
+                // NOT gated on docChanged: accepting a chunk folds the change into the
+                // merge view's ORIGINAL side and leaves the editor doc unchanged
+                // (docChanged = false), so accepting every chunk one-by-one would never
+                // be observed if we only ran this on doc-changing updates. Rejecting a
+                // chunk does change the doc, but running unconditionally covers both.
+                let chunkCount = -1;
+                try { chunkCount = getChunks(update.state)?.chunks.length ?? -1; } catch { /* merge field not ready */ }
+                if (chunkCount > 0) reviewHadChunksRef.current = true;
+                // Only finalize AFTER we've seen at least one chunk: the merge
+                // field can briefly report 0 chunks right after entering review.
+                if (reviewHadChunksRef.current && chunkCount === 0) {
+                    // Defer: dispatching synchronously from inside the update
+                    // listener is re-entrant and unsafe. Re-check in the rAF that
+                    // nothing else (a manual Accept/Reject-all) resolved it first.
+                    requestAnimationFrame(() => {
+                        const v = viewRef.current;
+                        if (!v || !reviewingRef.current) return;
+                        let stillZero = false;
+                        try { stillZero = (getChunks(v.state)?.chunks.length ?? -1) === 0; } catch { /* ignore */ }
+                        if (stillZero) finishReview(v.state.doc.toString());
+                    });
                 }
             } else if (update.docChanged) {
                 const value = update.state.doc.toString();

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -111,7 +111,10 @@ const editorTheme = EditorView.theme({
         border: "none",
         borderRight: "1px solid var(--border-subtle)",
     },
-    ".cm-activeLine": { backgroundColor: "var(--bg-hover)" },
+    // Semi-transparent so the selection layer beneath shows through: --bg-hover is
+    // opaque and paints on the content line ON TOP of the selection, which would
+    // otherwise hide the selection background on the caret's line.
+    ".cm-activeLine": { backgroundColor: "color-mix(in srgb, var(--bg-hover) 55%, transparent)" },
     ".cm-activeLineGutter": { backgroundColor: "transparent", color: "var(--text-primary)" },
     ".cm-cursor, .cm-dropCursor": { borderLeftColor: "var(--accent)" },
     "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -201,6 +201,7 @@ function CodeEditorImpl({
     const onImagePasteRef = useRef(onImagePaste); onImagePasteRef.current = onImagePaste;
     const onErrorRef = useRef(onError); onErrorRef.current = onError;
     const onNoticeRef = useRef(onNotice); onNoticeRef.current = onNotice;
+    const onReviewResolveRef = useRef(onReviewResolve); onReviewResolveRef.current = onReviewResolve;
     const filePathRef = useRef(filePath); filePathRef.current = filePath;
     // Base names (without .md) of the sibling files, for `[[` autocomplete. Kept
     // in a ref so the once-created completion source always sees the latest list.
@@ -229,6 +230,10 @@ function CodeEditorImpl({
     const reviewingRef = useRef(false);
     const reviewOriginalRef = useRef("");
     const lastReviewRef = useRef<string | null>(null);
+    // Whether the current review has ever reported at least one chunk. Guards
+    // against a false "all resolved" completion: right after entering review the
+    // merge field can momentarily report 0 chunks before it computes them.
+    const reviewHadChunksRef = useRef(false);
 
     // `[[` autocomplete: when the caret is inside an open wikilink target, offer
     // the folder's other markdown files. Reads wikiNamesRef (refreshed below) so
@@ -348,6 +353,29 @@ function CodeEditorImpl({
                 if (accepted !== null && accepted !== lastEmittedRef.current) {
                     lastEmittedRef.current = accepted;
                     onChangeRef.current?.(accepted);
+                }
+                // Detect when the user has resolved every chunk individually via the
+                // gutter buttons (Accept-all/Reject-all clear reviewingRef themselves).
+                // Only on doc-changing updates — resolving a chunk edits the doc; a
+                // bare selection change never completes a review.
+                if (update.docChanged) {
+                    let chunkCount = -1;
+                    try { chunkCount = getChunks(update.state)?.chunks.length ?? -1; } catch { /* merge field not ready */ }
+                    if (chunkCount > 0) reviewHadChunksRef.current = true;
+                    // Only finalize AFTER we've seen at least one chunk: the merge
+                    // field can briefly report 0 chunks right after entering review.
+                    if (reviewHadChunksRef.current && chunkCount === 0) {
+                        // Defer: dispatching synchronously from inside the update
+                        // listener is re-entrant and unsafe. Re-check in the rAF that
+                        // nothing else (a manual Accept/Reject-all) resolved it first.
+                        requestAnimationFrame(() => {
+                            const v = viewRef.current;
+                            if (!v || !reviewingRef.current) return;
+                            let stillZero = false;
+                            try { stillZero = (getChunks(v.state)?.chunks.length ?? -1) === 0; } catch { /* ignore */ }
+                            if (stillZero) finishReview(v.state.doc.toString());
+                        });
+                    }
                 }
             } else if (update.docChanged) {
                 const value = update.state.doc.toString();
@@ -589,7 +617,12 @@ function CodeEditorImpl({
         if (!view) return;
         if (reviewDoc != null) {
             if (reviewingRef.current && reviewDoc === lastReviewRef.current) return;
-            if (!reviewingRef.current) reviewOriginalRef.current = view.state.doc.toString();
+            if (!reviewingRef.current) {
+                reviewOriginalRef.current = view.state.doc.toString();
+                // Fresh review: reset the chunk-seen guard here (not on every
+                // re-render) so a mid-review re-render can't reset it.
+                reviewHadChunksRef.current = false;
+            }
             reviewingRef.current = true;
             lastReviewRef.current = reviewDoc;
             setReviewActive(true);
@@ -616,17 +649,26 @@ function CodeEditorImpl({
         }
     }, [reviewDoc]);
 
+    // Tear down the merge view and resolve with `final` (the current editor doc,
+    // which — once every chunk is accepted/rejected — already equals the final
+    // result). Shared by acceptAllChanges and the individual-resolve completion
+    // path in the updateListener. Stable identity (reads only refs) so the
+    // one-time updateListener can call it without going stale.
+    const finishReview = useCallback((final: string) => {
+        reviewingRef.current = false;
+        lastReviewRef.current = null;
+        reviewHadChunksRef.current = false;
+        setReviewActive(false);
+        viewRef.current?.dispatch({ effects: mergeCompRef.current.reconfigure([]) });
+        lastEmittedRef.current = final; // keep the App content-sync from re-dispatching
+        onReviewResolveRef.current?.(final);
+    }, []);
+
     const acceptAllChanges = useCallback(() => {
         const view = viewRef.current;
         if (!view) return;
-        const final = view.state.doc.toString();
-        reviewingRef.current = false;
-        lastReviewRef.current = null;
-        setReviewActive(false);
-        view.dispatch({ effects: mergeCompRef.current.reconfigure([]) });
-        lastEmittedRef.current = final; // keep the App content-sync from re-dispatching
-        onReviewResolve?.(final);
-    }, [onReviewResolve]);
+        finishReview(view.state.doc.toString());
+    }, [finishReview]);
 
     const rejectAllChanges = useCallback(() => {
         const view = viewRef.current;

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -297,6 +297,12 @@ function CodeEditorImpl({
             return;
         }
         const sel = view.state.selection.main;
+        if (sel.from === sel.to) {
+            // Every remaining AI action needs a selection; opening the bubble with
+            // an empty selection would show no action buttons at all.
+            onNoticeRef.current?.("Select some text to use AI assist.");
+            return;
+        }
         const coords = view.coordsAtPos(sel.head);
         const rect = view.scrollDOM.getBoundingClientRect();
         const x = coords ? coords.left : rect.left + 28;

--- a/src/index.css
+++ b/src/index.css
@@ -393,6 +393,17 @@ select:focus-visible,
   color: var(--selection-text);
 }
 
+/* AI chat composer selection in the LIGHT and PAPER themes only: the global
+   --selection-bg is near-black/dark-brown, which over the near-white input reads
+   as an almost-solid block that hides the text. Blend it heavily toward the input
+   background for a light tint, and keep dark primary text so the selection stays
+   readable. Dark/Dracula are already fine (selection lighter than the input). */
+[data-theme="light"] .ai-composer ::selection,
+[data-theme="paper"] .ai-composer ::selection {
+  background: color-mix(in srgb, var(--selection-bg) 22%, var(--bg-input));
+  color: var(--text-primary);
+}
+
 /* ===== Material Icons ===== */
 .material-symbols-outlined {
   font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;


### PR DESCRIPTION
Batch of confirmed fixes from issue #112 and the #111 feedback thread. Tested via Test Build installers on Windows; tsc clean and all 280 unit tests pass.

- **fix(layout)**: File Explorer / Outline no longer overlay the editor (#112) — the editor reserves left padding when a left drawer is open, mirroring the AI panel.
- **fix(editor)**: selection stays visible on the caret's active line (#111 A) — active-line background is now semi-transparent so it doesn't hide the selection.
- **fix(ai-review)**: the accept/reject toolbar auto-dismisses when every chunk is resolved individually — both by rejecting and by accepting (#111 D). Accepting a chunk doesn't change the editor doc, so the completion check runs on every review update.
- **fix(ai-chat)**: composer text selection is readable in the light and paper themes (#111 E).
- **fix(ai-assist)**: removed the selection-free "Continue" action (a lone useless button on an empty click); AI assist now needs a selection and shows a hint otherwise.

No version bump, no release, no updater manifest.