### PR TITLE
feat: remember window size and position across launches (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Paperling remembers your window.** Size, position and whether it was
+  maximized are restored the next time you launch, instead of always reopening
+  at the default 1000x700 in the middle of the screen. Thanks to
+  [@andychey](https://github.com/andychey).
+
 ## [1.0.49] - 2026-07-12
 
 ### Added

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,7 @@ tauri-plugin-mcp-bridge = "0.11"
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-window-state = "2"
 
 # Silent "Save as PDF" export: render the document in a hidden WebView2 and call
 # its native PrintToPdf (no OS print dialog). Versions track what wry/tauri

--- a/src-tauri/capabilities/desktop.json
+++ b/src-tauri/capabilities/desktop.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "desktop-capability",
+  "description": "Desktop-only capabilities for the main window",
+  "platforms": [
+    "macOS",
+    "windows",
+    "linux"
+  ],
+  "windows": [
+    "main"
+  ],
+  "permissions": [
+    "window-state:default"
+  ],
+  "capabilities": []
+}

--- a/src-tauri/capabilities/desktop.json
+++ b/src-tauri/capabilities/desktop.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "desktop-capability",
-  "description": "Desktop-only capabilities for the main window",
+  "description": "Desktop-only permissions for the main window. window-state persists window geometry (size, position, maximized) across launches; it has no mobile counterpart, hence the platform-scoped file.",
   "platforms": [
     "macOS",
     "windows",
@@ -12,6 +12,5 @@
   ],
   "permissions": [
     "window-state:default"
-  ],
-  "capabilities": []
+  ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,12 +67,20 @@ pub fn run() {
     //               Reopening fullscreen behind its back desyncs the title bar
     //               and eats the first F11 press.
     //   DECORATIONS meaningless for a window that is always decorations:false.
+    //
+    // Filtered to "main" as well, because the plugin manages EVERY window and
+    // PDF export spins up its own (pdf.rs, label "pdf-export-{seq}"). Those are
+    // deliberately hidden and deliberately sized to US Letter at 96dpi; letting
+    // the plugin persist and then re-apply their geometry would mean a stale
+    // saved size silently overriding the size pdf.rs asks for. A denylist can't
+    // express this since the labels carry a counter.
     #[cfg(desktop)]
     {
         use tauri_plugin_window_state::StateFlags;
         builder = builder.plugin(
             tauri_plugin_window_state::Builder::default()
                 .with_state_flags(StateFlags::SIZE | StateFlags::POSITION | StateFlags::MAXIMIZED)
+                .with_filter(|label| label == "main")
                 .build(),
         );
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,9 +2,12 @@ mod ai;
 mod commands;
 mod pdf;
 
-use commands::{read_file, save_file, get_file_info, list_directory_files, search_files, save_image, read_image_file, get_ai_key, set_ai_key};
-use tauri::{Manager, Emitter};
+use commands::{
+    get_ai_key, get_file_info, list_directory_files, read_file, read_image_file, save_file,
+    save_image, search_files, set_ai_key,
+};
 use std::sync::Mutex;
+use tauri::{Emitter, Manager};
 
 /// File path passed on the command line (double-clicking a .md in the OS).
 /// Held until the frontend asks for it via `get_cli_file`.
@@ -34,7 +37,7 @@ fn get_cli_file(state: tauri::State<CliFile>) -> Option<String> {
 pub fn run() {
     let cli_file = md_arg(&std::env::args().collect::<Vec<_>>());
 
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default()
         // Must be the first plugin so it wins the instance lock race.
         // A second launch (double-clicking another .md while Paperling runs)
         // forwards its argv here and exits; we surface the window and hand
@@ -50,7 +53,14 @@ pub fn run() {
         }))
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_fs::init())
-        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_dialog::init());
+
+    #[cfg(desktop)]
+    {
+        builder = builder.plugin(tauri_plugin_window_state::Builder::default().build());
+    }
+
+    builder
         .setup(|app| {
             // Updater (GitHub latest.json) + process (relaunch after install)
             // are desktop-only plugins, hence registered here behind cfg

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -55,9 +55,26 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init());
 
+    // Remembers where the window was and how big it was across launches.
+    // Geometry ONLY — the plugin's default flag set is all(), and three of
+    // those flags fight code we already have:
+    //   VISIBLE     restore_state ends in `show() + set_focus()`, which fires
+    //               at window-ready and so undoes `visible: false` in
+    //               tauri.conf.json. That flag plus revealMainWindow() is what
+    //               kills the white startup flash on the dark theme.
+    //   FULLSCREEN  useFullscreen tracks fullscreen in a ref because
+    //               isFullscreen() lies on frameless windows (FULLSCREEN-01).
+    //               Reopening fullscreen behind its back desyncs the title bar
+    //               and eats the first F11 press.
+    //   DECORATIONS meaningless for a window that is always decorations:false.
     #[cfg(desktop)]
     {
-        builder = builder.plugin(tauri_plugin_window_state::Builder::default().build());
+        use tauri_plugin_window_state::StateFlags;
+        builder = builder.plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_state_flags(StateFlags::SIZE | StateFlags::POSITION | StateFlags::MAXIMIZED)
+                .build(),
+        );
     }
 
     builder


### PR DESCRIPTION
Takes over #116 from @andychey, whose commit is preserved here as-is, with two follow-up commits fixing real problems in how the plugin was wired up.

## 1. The flag set was too broad

The plugin was registered with `Builder::default()`, which uses `StateFlags::all()`: `SIZE | POSITION | MAXIMIZED | VISIBLE | DECORATIONS | FULLSCREEN`. Three of those collide with code we already have.

**VISIBLE** is the damaging one. `restore_state()` ends in:

```rust
if flags.contains(StateFlags::VISIBLE) && should_show {
    self.show()?;
    self.set_focus()?;
}
```

and it runs from `on_window_ready`, so the window is revealed before React has painted. That is exactly what `visible: false` in `tauri.conf.json` plus `revealMainWindow()` exist to prevent, and it brings back the white startup flash on the dark theme documented in `src/utils/appWindow.ts`. It fires on a cold profile too: `should_show` defaults to `true` when there is no saved state, and on later launches the saved `visible` is `true` anyway, because state is written on `CloseRequested` while the window is still visible.

**FULLSCREEN** reopens the window fullscreen while `useFullscreen` still believes it is not. That hook tracks the flag in a ref deliberately, because `isFullscreen()` returns unreliable values on frameless windows (FULLSCREEN-01). The title bar would show the wrong icon and the first F11 press would do nothing.

**DECORATIONS** is a no-op for a window that is always `decorations: false`.

`SIZE | POSITION | MAXIMIZED` delivers what the feature promised and nothing else.

## 2. The plugin was tracking the PDF export windows

The plugin manages every window the app creates, not just `main`, and PDF export builds one per export in `pdf.rs`:

```rust
let label = format!("pdf-export-{seq}");
let window = WebviewWindowBuilder::new(&app, &label, WebviewUrl::External(url))
    .visible(false)
    .inner_size(816.0, 1056.0)   // US Letter at 96dpi
```

Two consequences. The state file grows an entry per export label. Worse, the plugin re-applies the saved size on the next export that reuses the label, and its `set_size` runs after the builder's `inner_size`, so the saved value wins: change the page size in `pdf.rs` later and anyone with an existing state file keeps exporting at the old one.

Worth noting that with the original `all()` flags this was worse still: on the first export of a fresh profile `should_show` stays `true`, so the plugin would have called `show()` and `set_focus()` on the deliberately hidden export window, flashing a blank window and stealing focus mid-export.

`with_denylist` takes exact labels and cannot match a counter, so this filters on the label instead: `with_filter(|label| label == "main")`. The filter gates both restore and save.

## Also

- Dropped a stray `"capabilities": []` key from the new capability file. It is not a field in the Tauri capability schema; serde ignores it, so the build passed, but it should not be there.
- Filled in the capability description to match the style of `default.json`.
- Changelog entry under Unreleased, crediting @andychey.

## Known gap

`src-tauri/Cargo.lock` is tracked but has no `tauri-plugin-window-state` entry, and there is no Rust toolchain on this machine to regenerate it. Nothing breaks: no workflow passes `--locked`, so cargo resolves and writes the lock in the runner, and `cargo-deny` still audits the full resolved graph. It should be committed from the next machine that has cargo.

## Testing

CI covers compilation and clippy with `-D warnings` on all four platforms, which is also what proves the capability file parses and `window-state:default` is a real permission, since `generate_context!` validates both at build time.

The behaviours themselves are runtime-only and need a manual pass on a real build:

- launch cold, confirm no white flash
- resize and move, quit, relaunch, confirm geometry comes back
- quit while maximized, confirm it reopens maximized
- quit while fullscreen, confirm it reopens windowed
- export a PDF twice in one session, confirm no stray window appears and output is unchanged