### PR TITLE
fix(deps): resolve the postcss and dompurify advisories via overrides

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,8 +65,9 @@
   },
   "overrides": {
     "@babel/core": "^7.29.6",
+    "dompurify": "^3.4.12",
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "rollup": "^4.59.0",
     "undici": "^7.28.0",
   },
@@ -759,7 +760,7 @@
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
-    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
+    "dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -1127,7 +1128,7 @@
 
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
-    "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
+    "postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
@@ -1469,7 +1470,7 @@
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
-    "postcss/nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
+    "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "rehype-katex/katex": ["katex@0.16.45", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA=="],
 

--- a/package.json
+++ b/package.json
@@ -71,8 +71,9 @@
   },
   "overrides": {
     "@babel/core": "^7.29.6",
+    "dompurify": "^3.4.12",
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "rollup": "^4.59.0",
     "undici": "^7.28.0"
   }


### PR DESCRIPTION
## Problem

`osv-scan` flags two advisories in `bun.lock` that **no Dependabot PR will ever fix**:

| Package | Was | Now | Advisory |
|---|---|---|---|
| postcss | 8.5.16 | **8.5.23** | [GHSA-r28c-9q8g-f849](https://osv.dev/GHSA-r28c-9q8g-f849) (7.5 High) |
| dompurify | 3.4.11 | **3.4.12** | [GHSA-c2j3-45gr-mqc4](https://osv.dev/GHSA-c2j3-45gr-mqc4) |

Neither is a direct dependency. postcss arrives through the build toolchain, dompurify through mermaid. Dependabot version updates only move direct deps, and it has [no security-update support for bun](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories), so nothing targets them. They were reachable from the existing constraints all along, just pinned low in the lockfile.

## Why overrides and not `bun update`

I tried `bun update` first and it was actively misleading:

```
+ "dompurify": "^3.4.12"        (promoted to a direct dependency)
+ "mermaid/dompurify": ["dompurify@3.4.11", ...]   ← advisory survives here
```

It hoisted a fresh top-level copy that nothing imports while mermaid kept its own vulnerable 3.4.11 under a nested key. The scan result would have looked better while the shipped code was unchanged.

The override lifts every consumer at once. `bun.lock` now contains exactly one `postcss` and one `dompurify`, no nested copies. This is the same mechanism already used for `@babel/core`, `picomatch`, `rollup`, and `undici`.

## Compatibility

`3.4.12` satisfies mermaid's declared `^3.3.3`, so nothing is forced outside its supported range.

Verified locally on bun 1.3.14 (same version CI uses):
- `bun install --frozen-lockfile` — clean, no changes
- `bun run build` — passes
- `bun run test` — **280/280 across 29 files**

Diff is 3 lines of `package.json` plus the re-resolved lockfile entries.