### PR TITLE
fix: three community-reported issues (#146, #147, #148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Unreadable text selection.** Selecting text in the editor showed a dark
-  block over dark text in the Light and Paper themes, so you could see what was
-  selected but not read it. Both themes now tint the selection instead. Thanks
-  to [@skycommand](https://github.com/skycommand).
+- **Hard-to-see text selection.** In the Light and Paper themes, selecting text
+  in the editor painted a dark block over dark text, so you could see what was
+  selected but not read it; both themes now tint the selection instead. In every
+  theme, the highlight on the line you are typing on also washed the selection
+  out on that line, which is the one line every selection touches. That
+  highlight now steps aside while text is selected. Thanks to
+  [@skycommand](https://github.com/skycommand).
 - **The About page now shows the version you are running.** Settings, About
   reported only the app name, which made it awkward to file a bug report.
   Thanks to [@skycommand](https://github.com/skycommand).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   maximized are restored the next time you launch, instead of always reopening
   at the default 1000x700 in the middle of the screen. Thanks to
   [@andychey](https://github.com/andychey).
+- **Familiar shortcuts.** Ctrl+F4 also closes the current tab, and F1 also
+  opens the command palette, alongside the existing Ctrl+W and Ctrl+P. Thanks
+  to [@skycommand](https://github.com/skycommand).
+
+### Fixed
+
+- **Unreadable text selection.** Selecting text in the editor showed a dark
+  block over dark text in the Light and Paper themes, so you could see what was
+  selected but not read it. Both themes now tint the selection instead. Thanks
+  to [@skycommand](https://github.com/skycommand).
+- **The About page now shows the version you are running.** Settings, About
+  reported only the app name, which made it awkward to file a bug report.
+  Thanks to [@skycommand](https://github.com/skycommand).
 
 ## [1.0.49] - 2026-07-12
 

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -4,7 +4,6 @@ import {
     EditorView,
     keymap,
     lineNumbers,
-    highlightActiveLine,
     highlightActiveLineGutter,
     drawSelection,
     dropCursor,
@@ -38,6 +37,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { matchWikilinkPrefix, rankFileNames, toWikiName } from "../utils/wikilinkComplete";
 import { applyTableOp, findTableAt, locateCell, type Align } from "../utils/tableModel";
 import { toCmKey } from "../config/keybindings";
+import { highlightCaretLine } from "../utils/caretLineHighlight";
 import type { Scroller } from "../utils/scrollSync";
 
 interface CodeEditorProps {
@@ -111,10 +111,10 @@ const editorTheme = EditorView.theme({
         border: "none",
         borderRight: "1px solid var(--border-subtle)",
     },
-    // Semi-transparent so the selection layer beneath shows through: --bg-hover is
-    // opaque and paints on the content line ON TOP of the selection, which would
-    // otherwise hide the selection background on the caret's line.
-    ".cm-activeLine": { backgroundColor: "color-mix(in srgb, var(--bg-hover) 55%, transparent)" },
+    // Fully opaque again: highlightCaretLine drops this decoration entirely
+    // while a selection exists, so it can no longer paint over the selection
+    // layer, and the caret-only case gets a line tint you can actually see.
+    ".cm-activeLine": { backgroundColor: "var(--bg-hover)" },
     ".cm-activeLineGutter": { backgroundColor: "transparent", color: "var(--text-primary)" },
     ".cm-cursor, .cm-dropCursor": { borderLeftColor: "var(--accent)" },
     "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
@@ -421,7 +421,9 @@ function CodeEditorImpl({
                 extensions: [
                     lineNumbers(),
                     highlightActiveLineGutter(),
-                    highlightActiveLine(),
+                    // Not CodeMirror's highlightActiveLine: ours yields while a
+                    // selection is up, so the line tint can't hide it (#146).
+                    highlightCaretLine,
                     historyComp.of(history()),
                     drawSelection(),
                     dropCursor(),

--- a/src/components/SettingsModal.about.test.tsx
+++ b/src/components/SettingsModal.about.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { ThemeProvider } from "../context/ThemeContext";
+
+// The About panel resolves the version through the Tauri core API, which has no
+// IPC host under jsdom — stub it so the panel behaves as it does in the app.
+vi.mock("@tauri-apps/api/app", () => ({ getVersion: async () => "9.9.9" }));
+
+import { SettingsModal } from "./SettingsModal";
+
+// Vitest runs without `globals`, so React Testing Library never registers its
+// own afterEach cleanup; do it here or the second render finds two dialogs.
+afterEach(cleanup);
+
+describe("Settings → About", () => {
+    it("reports the running version (#148)", async () => {
+        render(
+            <ThemeProvider>
+                <SettingsModal isOpen onClose={() => { }} />
+            </ThemeProvider>,
+        );
+        fireEvent.click(screen.getByRole("button", { name: /about/i }));
+
+        expect(await screen.findByText("v9.9.9")).toBeInTheDocument();
+    });
+
+    it("hides the version rather than showing a placeholder when it can't be read", async () => {
+        vi.resetModules();
+        vi.doMock("@tauri-apps/api/app", () => ({
+            getVersion: async () => { throw new Error("no IPC host"); },
+        }));
+        // Re-import BOTH through the reset registry: a fresh SettingsModal paired
+        // with the stale ThemeProvider would be reading a different context object.
+        const { SettingsModal: Fresh } = await import("./SettingsModal");
+        const { ThemeProvider: FreshProvider } = await import("../context/ThemeContext");
+
+        render(
+            <FreshProvider>
+                <Fresh isOpen onClose={() => { }} />
+            </FreshProvider>,
+        );
+        fireEvent.click(screen.getByRole("button", { name: /about/i }));
+
+        // The panel still renders; it just carries no version chip.
+        expect(await screen.findByText("A minimal markdown editor")).toBeInTheDocument();
+        await waitFor(() => expect(screen.queryByText(/^v\d/)).not.toBeInTheDocument());
+    });
+});

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -473,9 +473,11 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                         <div className="flex items-baseline gap-2">
                                             <span className="text-[var(--text-primary)] font-semibold">Paperling</span>
                                             {/* Convention: the About box reports the running version (#148).
-                                                Selectable so it can be pasted straight into a bug report. */}
+                                                Selectable so it can be pasted straight into a bug report, and
+                                                --text-secondary rather than --text-muted because a version people
+                                                are meant to read back to you has to be legible in every theme. */}
                                             {appVersion && (
-                                                <span className="text-[11px] font-mono text-[var(--text-muted)] select-text">
+                                                <span className="text-[11px] font-mono text-[var(--text-secondary)] select-text">
                                                     v{appVersion}
                                                 </span>
                                             )}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -101,6 +101,12 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     const [autoSave, setAutoSaveLocal] = useState(getAutoSave);
     const [openInReader, setOpenInReaderLocal] = useState(getOpenInReader);
 
+    // The running app's version for the About panel (#148). Read from the Tauri
+    // core API rather than a build-time constant so it always reflects the
+    // installed binary; empty in a plain browser (`vite dev`), where the row is
+    // simply not rendered.
+    const [appVersion, setAppVersion] = useState("");
+
     const [ai, setAi] = useState(getAIConfig);
     const [aiEnabled, setAiEnabledLocal] = useState(getAIEnabled);
     const aiEndpointInvalid = ai.endpoint.length > 0 && !isValidEndpoint(ai.endpoint);
@@ -153,6 +159,19 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
             detach();
         };
     }, [isOpen, onClose]);
+
+    // Resolve the app version once the modal is first opened (#148). Lazily
+    // imported so a plain browser session, where the Tauri IPC doesn't exist,
+    // doesn't pay for or fail on the import at module load.
+    useEffect(() => {
+        if (!isOpen || appVersion) return;
+        let cancelled = false;
+        import("@tauri-apps/api/app")
+            .then(({ getVersion }) => getVersion())
+            .then((v) => { if (!cancelled) setAppVersion(v); })
+            .catch(() => { /* not running under Tauri — the row stays hidden */ });
+        return () => { cancelled = true; };
+    }, [isOpen, appVersion]);
 
     // Persist AI fields on close. The endpoint/model/key inputs save on blur,
     // but Escape-to-close or backdrop-click can fire before the input loses
@@ -451,7 +470,16 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                 <div className="flex items-center gap-3">
                                     <img src="/icon.svg" alt="Paperling" className="w-10 h-10" />
                                     <div>
-                                        <div className="text-[var(--text-primary)] font-semibold">Paperling</div>
+                                        <div className="flex items-baseline gap-2">
+                                            <span className="text-[var(--text-primary)] font-semibold">Paperling</span>
+                                            {/* Convention: the About box reports the running version (#148).
+                                                Selectable so it can be pasted straight into a bug report. */}
+                                            {appVersion && (
+                                                <span className="text-[11px] font-mono text-[var(--text-muted)] select-text">
+                                                    v{appVersion}
+                                                </span>
+                                            )}
+                                        </div>
                                         <div className="text-[11px]">A minimal markdown editor</div>
                                     </div>
                                 </div>

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { attachFocusTrap } from "../utils/focusTrap";
-import { formatShortcut, withMod, aiShortcutLabel } from "../config/keybindings";
+import { formatShortcut, formatAliases, withMod, aiShortcutLabel } from "../config/keybindings";
 import iconKeyboard from "../assets/mascot/icon-keyboard.png";
 
 interface ShortcutCheatsheetProps {
@@ -11,6 +11,9 @@ interface ShortcutCheatsheetProps {
 interface Shortcut {
     keys: string;
     description: string;
+    /** Secondary combo shown as "… or F1" — kept out of `keys` so filtering and
+     *  the primary chip stay clean. */
+    alsoKeys?: string;
 }
 
 interface ShortcutGroup {
@@ -28,7 +31,7 @@ const groups: ShortcutGroup[] = [
         items: [
             { keys: formatShortcut("openFile"), description: "Open file" },
             { keys: formatShortcut("newFile"), description: "New file (new tab)" },
-            { keys: formatShortcut("closeTab"), description: "Close tab" },
+            { keys: formatShortcut("closeTab"), description: "Close tab", alsoKeys: formatAliases("closeTab")[0] },
             { keys: formatShortcut("save"), description: "Save" },
             { keys: formatShortcut("saveAs"), description: "Save As…" },
         ],
@@ -37,7 +40,7 @@ const groups: ShortcutGroup[] = [
         title: "Tabs",
         items: [
             { keys: formatShortcut("newFile"), description: "New tab" },
-            { keys: formatShortcut("closeTab"), description: "Close tab" },
+            { keys: formatShortcut("closeTab"), description: "Close tab", alsoKeys: formatAliases("closeTab")[0] },
             { keys: formatShortcut("reopenClosedTab"), description: "Reopen closed tab" },
             { keys: formatShortcut("nextTab"), description: "Next tab" },
             { keys: formatShortcut("prevTab"), description: "Previous tab" },
@@ -55,7 +58,7 @@ const groups: ShortcutGroup[] = [
             { keys: formatShortcut("toggleFileExplorer"), description: "Toggle file explorer" },
             { keys: formatShortcut("searchInFolder"), description: "Search across files" },
             { keys: formatShortcut("toggleTOC"), description: "Toggle outline" },
-            { keys: formatShortcut("palette"), description: "Command palette" },
+            { keys: formatShortcut("palette"), description: "Command palette", alsoKeys: formatAliases("palette")[0] },
             { keys: formatShortcut("settings"), description: "Open settings" },
             { keys: formatShortcut("cheatsheet"), description: "Show this cheatsheet" },
         ],
@@ -146,7 +149,10 @@ export function ShortcutCheatsheet({ isOpen, onClose }: ShortcutCheatsheetProps)
         ? groups
             .map((g) => ({
                 ...g,
-                items: g.items.filter((it) => it.description.toLowerCase().includes(q) || it.keys.toLowerCase().includes(q)),
+                items: g.items.filter((it) =>
+                    it.description.toLowerCase().includes(q)
+                    || it.keys.toLowerCase().includes(q)
+                    || !!it.alsoKeys?.toLowerCase().includes(q)),
             }))
             .filter((g) => g.items.length > 0)
         : groups;
@@ -193,7 +199,15 @@ export function ShortcutCheatsheet({ isOpen, onClose }: ShortcutCheatsheetProps)
                                 {g.items.map((it, i) => (
                                     <li key={i} className="flex items-center justify-between gap-3">
                                         <span className="text-sm text-[var(--text-primary)]">{it.description}</span>
-                                        <span className="flex items-center gap-1 shrink-0">{renderKey(it.keys)}</span>
+                                        <span className="flex items-center gap-1 shrink-0">
+                                            {renderKey(it.keys)}
+                                            {it.alsoKeys && (
+                                                <>
+                                                    <span className="text-[11px] text-[var(--text-muted)]">or</span>
+                                                    {renderKey(it.alsoKeys)}
+                                                </>
+                                            )}
+                                        </span>
                                     </li>
                                 ))}
                             </ul>

--- a/src/config/keybindings.test.ts
+++ b/src/config/keybindings.test.ts
@@ -59,6 +59,44 @@ describe("keybindings on macOS", () => {
     });
 });
 
+describe("alias bindings (#147)", () => {
+    beforeEach(() => setPlatform("Win32"));
+
+    it("closes a tab on Ctrl+F4 as well as Ctrl+W", async () => {
+        const kb = await loadFresh();
+        expect(kb.matchesBinding(kev({ key: "w", ctrlKey: true }), "closeTab")).toBe(true);
+        expect(kb.matchesBinding(kev({ key: "F4", ctrlKey: true }), "closeTab")).toBe(true);
+        // Bare F4 and Alt+F4 must NOT close the tab — Alt+F4 closes the window.
+        expect(kb.matchesBinding(kev({ key: "F4" }), "closeTab")).toBe(false);
+        expect(kb.matchesBinding(kev({ key: "F4", altKey: true }), "closeTab")).toBe(false);
+    });
+
+    it("opens the command palette on F1 as well as Ctrl+P", async () => {
+        const kb = await loadFresh();
+        expect(kb.matchesBinding(kev({ key: "p", ctrlKey: true }), "palette")).toBe(true);
+        expect(kb.matchesBinding(kev({ key: "F1" }), "palette")).toBe(true);
+        expect(kb.matchesBinding(kev({ key: "F1", ctrlKey: true }), "palette")).toBe(false);
+    });
+
+    it("keeps aliases scoped to their own action", async () => {
+        const kb = await loadFresh();
+        expect(kb.matchesBinding(kev({ key: "F1" }), "closeTab")).toBe(false);
+        expect(kb.matchesBinding(kev({ key: "F4", ctrlKey: true }), "palette")).toBe(false);
+        // F11 (fullscreen) must not be swallowed by the F1 alias.
+        expect(kb.matchesBinding(kev({ key: "F11" }), "palette")).toBe(false);
+        expect(kb.matchesBinding(kev({ key: "F11" }), "fullscreen")).toBe(true);
+    });
+
+    it("displays the primary combo, and exposes aliases separately", async () => {
+        const kb = await loadFresh();
+        expect(kb.formatShortcut("closeTab")).toBe("Ctrl+W");
+        expect(kb.formatShortcut("palette")).toBe("Ctrl+P");
+        expect(kb.formatAliases("closeTab")).toEqual(["Ctrl+F4"]);
+        expect(kb.formatAliases("palette")).toEqual(["F1"]);
+        expect(kb.formatAliases("save")).toEqual([]);
+    });
+});
+
 describe("keybindings on Windows/Linux", () => {
     beforeEach(() => setPlatform("Win32"));
 

--- a/src/config/keybindings.ts
+++ b/src/config/keybindings.ts
@@ -72,6 +72,22 @@ export const BINDINGS = {
 
 export type BindingId = keyof typeof BINDINGS;
 
+/**
+ * Secondary combos that fire the same action as their primary binding, for
+ * muscle memory carried in from other apps (#147). Ctrl+F4 is the long-standing
+ * Windows "close document" combo, and F1 is VS Code's command-palette alias
+ * alongside Ctrl+P.
+ *
+ * These are matched but NOT displayed: the cheatsheet and menus stay on the
+ * primary so they don't turn into a list of synonyms. Alt+F4 (close window) is
+ * unaffected — it never reaches this config, the Tauri close-requested handler
+ * owns it.
+ */
+export const ALIASES: Partial<Record<BindingId, Binding[]>> = {
+    closeTab: [{ key: "F4", mod: true }],
+    palette: [{ key: "F1" }],
+};
+
 /** Is the primary modifier (Cmd on Mac, Ctrl elsewhere) the one pressed here? */
 export function isModPressed(e: KeyboardEvent): boolean {
     return isMac ? e.metaKey : e.ctrlKey;
@@ -89,8 +105,12 @@ const isSymbolKey = (key: string) => key.length === 1 && !/[a-z0-9]/i.test(key);
 
 /** Does a keyboard event match the given binding, resolving `mod` per platform? */
 export function matchesBinding(e: KeyboardEvent, id: BindingId): boolean {
-    const b: Binding = BINDINGS[id];
+    if (matchesOne(e, BINDINGS[id])) return true;
+    return (ALIASES[id] ?? []).some((alias) => matchesOne(e, alias));
+}
 
+/** Match a single combo. `matchesBinding` layers the aliases on top of this. */
+function matchesOne(e: KeyboardEvent, b: Binding): boolean {
     if (e.key.toLowerCase() !== b.key.toLowerCase()) return false;
 
     // Primary/secondary modifier resolution.
@@ -156,6 +176,11 @@ export function formatBinding(b: Binding): string {
 /** Display string for a registered binding, e.g. formatShortcut("saveAs"). */
 export function formatShortcut(id: BindingId): string {
     return formatBinding(BINDINGS[id]);
+}
+
+/** Display strings for a binding's secondary combos, if it has any (#147). */
+export function formatAliases(id: BindingId): string[] {
+    return (ALIASES[id] ?? []).map(formatBinding);
 }
 
 /** Prefix an arbitrary label with the primary modifier: mod("1–8") → "⌘1–8". */

--- a/src/index.css
+++ b/src/index.css
@@ -95,8 +95,12 @@
   --scrollbar-thumb: #d4d4d4;
   --scrollbar-hover: #a3a3a3;
 
-  --selection-bg: #171717;
-  --selection-text: #ffffff;
+  /* A light tint, NOT a near-black slab: CodeMirror's drawSelection paints this
+     BEHIND the text and never applies --selection-text, so a dark selection
+     background left dark editor text unreadable (#146). Keeping the selection
+     lighter than the text means it reads correctly on both surfaces. */
+  --selection-bg: #d9d3c8;
+  --selection-text: #171717;
 }
 
 /* Paper Theme */
@@ -142,8 +146,10 @@
   --scrollbar-thumb: #c9c0ae;
   --scrollbar-hover: #a69d8d;
 
-  --selection-bg: #5c4033;
-  --selection-text: #faf8f3;
+  /* Warm tan tint of the brown accent, light enough that the editor's dark text
+     stays readable on top of it (see the light-theme note above, #146). */
+  --selection-bg: #d5c5a9;
+  --selection-text: #3d3d3d;
 }
 
 /* Dracula Theme */
@@ -391,17 +397,6 @@ select:focus-visible,
 ::selection {
   background: var(--selection-bg);
   color: var(--selection-text);
-}
-
-/* AI chat composer selection in the LIGHT and PAPER themes only: the global
-   --selection-bg is near-black/dark-brown, which over the near-white input reads
-   as an almost-solid block that hides the text. Blend it heavily toward the input
-   background for a light tint, and keep dark primary text so the selection stays
-   readable. Dark/Dracula are already fine (selection lighter than the input). */
-[data-theme="light"] .ai-composer ::selection,
-[data-theme="paper"] .ai-composer ::selection {
-  background: color-mix(in srgb, var(--selection-bg) 22%, var(--bg-input));
-  color: var(--text-primary);
 }
 
 /* ===== Material Icons ===== */

--- a/src/index.css
+++ b/src/index.css
@@ -99,7 +99,7 @@
      BEHIND the text and never applies --selection-text, so a dark selection
      background left dark editor text unreadable (#146). Keeping the selection
      lighter than the text means it reads correctly on both surfaces. */
-  --selection-bg: #d9d3c8;
+  --selection-bg: #cbc4b8;
   --selection-text: #171717;
 }
 
@@ -148,7 +148,7 @@
 
   /* Warm tan tint of the brown accent, light enough that the editor's dark text
      stays readable on top of it (see the light-theme note above, #146). */
-  --selection-bg: #d5c5a9;
+  --selection-bg: #c9b591;
   --selection-text: #3d3d3d;
 }
 

--- a/src/theme.contrast.test.ts
+++ b/src/theme.contrast.test.ts
@@ -55,9 +55,10 @@ describe("theme selection contrast", () => {
 
     it.each(THEMES)("%s keeps the selection distinguishable from the editor background", (selector) => {
         const vars = themeVars(selector);
-        // Low bar on purpose — this only catches a selection that vanishes into
-        // the page, which is the other half of #146.
-        expect(contrast(vars["--selection-bg"], vars["--bg-editor"])).toBeGreaterThanOrEqual(1.3);
+        // The other half of #146: a selection that vanishes into the page. 1.45
+        // is where the four themes currently sit (dark, the strongest, is 1.9);
+        // anything much below reads as "did my selection take?".
+        expect(contrast(vars["--selection-bg"], vars["--bg-editor"])).toBeGreaterThanOrEqual(1.45);
     });
 
     it.each(THEMES)("%s recolors natively-selected text readably too", (selector) => {

--- a/src/theme.contrast.test.ts
+++ b/src/theme.contrast.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Selected text in the editor is NOT recolored: CodeMirror's drawSelection
+// paints --selection-bg as a layer BEHIND the content, so the text keeps its
+// syntax color and --selection-text never applies there. That made the light and
+// paper themes unreadable when selected (#146) — a near-black selection block
+// under near-black text. The invariant below is what guarantees it can't
+// regress: every theme's selection background must contrast with the theme's
+// own text color, not just with the text color it *wishes* selected text had.
+
+const css = readFileSync(resolve(__dirname, "index.css"), "utf-8");
+
+/** Pull one theme's custom properties out of index.css by its selector. */
+function themeVars(selector: string): Record<string, string> {
+    // Blocks are flat (no nesting), so up to the first closing brace is the block.
+    const start = css.indexOf(selector);
+    if (start === -1) throw new Error(`theme block not found: ${selector}`);
+    const block = css.slice(start, css.indexOf("}", start));
+    const vars: Record<string, string> = {};
+    for (const [, name, value] of block.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+        vars[name] = value.trim();
+    }
+    return vars;
+}
+
+function luminance(hex: string): number {
+    const h = hex.replace("#", "");
+    const channel = (i: number) => {
+        const v = parseInt(h.slice(i * 2, i * 2 + 2), 16) / 255;
+        return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+    };
+    return 0.2126 * channel(0) + 0.7152 * channel(1) + 0.0722 * channel(2);
+}
+
+function contrast(a: string, b: string): number {
+    const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+    return (hi + 0.05) / (lo + 0.05);
+}
+
+const THEMES = [
+    ['[data-theme="dark"]', "dark"],
+    ['[data-theme="light"]', "light"],
+    ['[data-theme="paper"]', "paper"],
+    ['[data-theme="dracula"]', "dracula"],
+] as const;
+
+describe("theme selection contrast", () => {
+    it.each(THEMES)("%s keeps unrecolored text readable on the selection", (selector) => {
+        const vars = themeVars(selector);
+        expect(vars["--selection-bg"]).toMatch(/^#[0-9a-f]{6}$/i);
+        expect(contrast(vars["--selection-bg"], vars["--text-primary"])).toBeGreaterThanOrEqual(4.5);
+    });
+
+    it.each(THEMES)("%s keeps the selection distinguishable from the editor background", (selector) => {
+        const vars = themeVars(selector);
+        // Low bar on purpose — this only catches a selection that vanishes into
+        // the page, which is the other half of #146.
+        expect(contrast(vars["--selection-bg"], vars["--bg-editor"])).toBeGreaterThanOrEqual(1.3);
+    });
+
+    it.each(THEMES)("%s recolors natively-selected text readably too", (selector) => {
+        const vars = themeVars(selector);
+        // The global ::selection rule (preview, inputs) DOES apply
+        // --selection-text, so that pairing has to hold as well.
+        expect(contrast(vars["--selection-bg"], vars["--selection-text"])).toBeGreaterThanOrEqual(4.5);
+    });
+});

--- a/src/utils/caretLineHighlight.test.ts
+++ b/src/utils/caretLineHighlight.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { EditorState, EditorSelection } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { highlightCaretLine } from "./caretLineHighlight";
+import { installCodeMirrorDomPolyfills } from "../test/codemirrorDom";
+
+beforeAll(installCodeMirrorDomPolyfills);
+
+let view: EditorView | null = null;
+afterEach(() => {
+    view?.destroy();
+    view = null;
+});
+
+/** Mount a two-line document with the given selection. */
+function mount(selection: { anchor: number; head?: number }) {
+    view = new EditorView({
+        state: EditorState.create({
+            doc: "first line\nsecond line",
+            selection,
+            extensions: [highlightCaretLine],
+        }),
+        parent: document.body,
+    });
+    return view;
+}
+
+const activeLines = (v: EditorView) => v.dom.querySelectorAll(".cm-activeLine").length;
+
+describe("highlightCaretLine", () => {
+    it("marks the caret's line when nothing is selected", () => {
+        expect(activeLines(mount({ anchor: 3 }))).toBe(1);
+    });
+
+    it("marks no line while text is selected, so the tint can't hide it (#146)", () => {
+        expect(activeLines(mount({ anchor: 2, head: 6 }))).toBe(0);
+    });
+
+    it("drops the highlight as soon as a selection is made, and restores it after", () => {
+        const v = mount({ anchor: 3 });
+        expect(activeLines(v)).toBe(1);
+
+        // Select backwards across the line break: the head lands on line 1, the
+        // exact case where CodeMirror's own highlighter would still decorate.
+        v.dispatch({ selection: { anchor: 15, head: 2 } });
+        expect(activeLines(v)).toBe(0);
+
+        v.dispatch({ selection: { anchor: 4 } });
+        expect(activeLines(v)).toBe(1);
+    });
+
+    it("decorates a shared line only once for multiple cursors", () => {
+        // Two cursors on line 1, one on line 2 — a duplicate line decoration
+        // would throw, so this pins the dedupe as much as the count.
+        view = new EditorView({
+            state: EditorState.create({
+                doc: "first line\nsecond line",
+                selection: EditorSelection.create(
+                    [EditorSelection.cursor(2), EditorSelection.cursor(5), EditorSelection.cursor(14)],
+                    0,
+                ),
+                extensions: [highlightCaretLine, EditorState.allowMultipleSelections.of(true)],
+            }),
+            parent: document.body,
+        });
+        expect(activeLines(view)).toBe(2);
+    });
+});

--- a/src/utils/caretLineHighlight.ts
+++ b/src/utils/caretLineHighlight.ts
@@ -1,0 +1,49 @@
+import { Decoration, ViewPlugin, type DecorationSet, type EditorView, type ViewUpdate } from "@codemirror/view";
+import type { Range } from "@codemirror/state";
+
+/**
+ * Active-line highlight that steps aside while text is selected (#146).
+ *
+ * CodeMirror's own `highlightActiveLine` decorates the line holding each
+ * range's *head* whether or not that range is empty. The decoration lands on
+ * the content line, which paints ABOVE the selection layer, so the line tint
+ * sat on top of the selection on the one line every selection is guaranteed to
+ * touch. Users reported exactly that: a selection they could not see.
+ *
+ * Making the tint semi-transparent only softened it (the selection still read
+ * at ~1.2:1 against the line). Dropping the decoration entirely while a
+ * selection exists is what the mainstream editors do, and it lets the tint stay
+ * fully opaque for the caret-only case, where it is actually doing its job.
+ */
+const caretLine = Decoration.line({ class: "cm-activeLine" });
+
+function caretLineDeco(view: EditorView): DecorationSet {
+    const { ranges } = view.state.selection;
+    if (ranges.some((r) => !r.empty)) return Decoration.none;
+
+    const deco: Range<Decoration>[] = [];
+    let lastLineStart = -1;
+    for (const r of ranges) {
+        const line = view.lineBlockAt(r.head);
+        // Multiple cursors can share a line; decorate it once (CodeMirror's own
+        // highlighter guards the same way, and a duplicate range throws).
+        if (line.from > lastLineStart) {
+            deco.push(caretLine.range(line.from));
+            lastLineStart = line.from;
+        }
+    }
+    return Decoration.set(deco);
+}
+
+export const highlightCaretLine = ViewPlugin.fromClass(
+    class {
+        decorations: DecorationSet;
+        constructor(view: EditorView) {
+            this.decorations = caretLineDeco(view);
+        }
+        update(update: ViewUpdate) {
+            if (update.docChanged || update.selectionSet) this.decorations = caretLineDeco(update.view);
+        }
+    },
+    { decorations: (v) => v.decorations },
+);


### PR DESCRIPTION
Fixes the three issues [@skycommand](https://github.com/skycommand) filed against 1.0.49.

Closes #146, closes #147, closes #148.

### #146 — text selection unreadable / invisible

Two distinct problems were reported under one issue, and both needed work.

**Light and Paper: the selection was visible but its text was not readable.** CodeMirror's `drawSelection` paints `--selection-bg` *behind* the content, so the text keeps its syntax color and `--selection-text` never applies. Both themes set that token to a near-black slab, so dark text sat on a dark block. Both now use a tint with dark selected text, which reads correctly on the CodeMirror layer and on the native `::selection` used by the preview and inputs. The `.ai-composer` override added for the same symptom is now redundant and would make the composer selection nearly invisible, so it is removed.

**Every theme: the selection was washed out on the caret's line.** `highlightActiveLine` decorates the line holding each range's *head* whether or not the range is empty, and that decoration paints above the selection layer, so the one line every selection is guaranteed to touch was the one where the selection barely showed. Measured against the line tint it was 1.19 to 1.34, versus 1.5 to 1.9 elsewhere. 09c10c9 softened this by making the tint semi-transparent; this PR replaces the extension with one that yields entirely while a selection exists (what mainstream editors do) and restores full opacity for the caret-only case, where the tint is actually doing its job.

With the wash gone the theme tints carry their own weight. Final numbers, all four themes:

| theme | selection vs editor background | selected text on selection |
|---|---|---|
| dark | 1.91 | 10.4 |
| light | 1.73 | 10.4 |
| paper | 1.88 | 5.4 |
| dracula | 1.56 | 8.6 |

### #147 — familiar key bindings

Ctrl+F4 now also closes the current tab and F1 now also opens the command palette.

Implemented as an `ALIASES` map next to `BINDINGS` rather than widening every binding to an array: `matchesBinding` falls through to the secondary combos, while `formatShortcut` keeps returning the primary so the cheatsheet and menus do not become a list of synonyms. The cheatsheet shows the alias as a muted "or F1" chip and its filter searches it. Alt+F4 is untouched, the Tauri close-requested handler still owns window close.

### #148 — About dialog reports no version

Settings, About now shows the running version next to the app name. It is read from the Tauri core API (already covered by `core:default`, no capability change) rather than a build-time constant, so it always matches the installed binary. The import is lazy and failures are swallowed: under `vite dev` there is no IPC host, and the row hides rather than rendering `vundefined`.

### Tests

302 tests across 32 files, plus `tsc` and the frontend build. New regression coverage:

- `src/theme.contrast.test.ts` pins the invariant that actually broke: every theme's selection background must contrast with that theme's own text color, not only with the color it wishes selected text had, plus a visibility floor against the editor background.
- `src/utils/caretLineHighlight.test.ts` mounts a real editor and asserts no line is decorated while a selection is up, including the backwards-selection case where the head lands on the first line.
- `src/config/keybindings.test.ts` covers the aliases, including that bare F4 and Alt+F4 do not close a tab and that F11 is not swallowed by the F1 alias.
- `src/components/SettingsModal.about.test.tsx` covers the version row and its hidden-on-failure fallback.

Installers for a real-machine check come from the Test Build workflow rather than a local Tauri build.
