### PR TITLE
AI panel batch: LM Studio preset, configurable history depth, composer undo fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Familiar shortcuts.** Ctrl+F4 also closes the current tab, and F1 also
   opens the command palette, alongside the existing Ctrl+W and Ctrl+P. Thanks
   to [@skycommand](https://github.com/skycommand).
+- **LM Studio preset.** The AI settings now offer LM Studio next to Gemini,
+  OpenAI and Ollama: pick it and the local server endpoint fills itself, no
+  API key needed. (#115)
+- **Chat history depth setting.** Choose how many previous chat turns are sent
+  with each AI panel message (Settings → AI, default 8). Lower it to save
+  tokens with local models, or set 0 to make every message start fresh. (#111)
 
 ### Fixed
 
@@ -29,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The About page now shows the version you are running.** Settings, About
   reported only the app name, which made it awkward to file a bug report.
   Thanks to [@skycommand](https://github.com/skycommand).
+- **Undo in the AI chat box.** Ctrl+Z now works while typing a message in the
+  AI panel; the composer no longer resets the native undo history on Linux.
+  (#111)
 
 ## [1.0.49] - 2026-07-12
 

--- a/src/components/AIPanel.tsx
+++ b/src/components/AIPanel.tsx
@@ -3,6 +3,7 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { streamChat, buildAskMessages, buildAgentMessages, parseEdits, type ChatMessage } from "../utils/aiChat";
 import type { AIConfig } from "../utils/aiAssist";
+import { getAIHistoryTurns } from "../utils/persistence";
 import mascotWizard from "../assets/mascot/mascot-wizard.png";
 
 interface AIPanelProps {
@@ -23,13 +24,16 @@ interface UIMessage {
     content: string;
 }
 
-// Keep the last N turns as conversation context (token efficiency — the document
-// itself is attached only to the latest turn inside buildAskMessages).
-const MAX_HISTORY_TURNS = 8;
+// The number of prior turns sent as conversation context is a user setting
+// (Settings → AI, default 8), read live per send — the document itself is
+// attached only to the latest turn inside buildAskMessages.
 
 export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConfig, onProposeEdit }: AIPanelProps) {
     const [messages, setMessages] = useState<UIMessage[]>([]);
     const [input, setInput] = useState("");
+    // Ref twin of `input` so the open-effect can restore the draft without
+    // re-running on every keystroke.
+    const inputDraftRef = useRef("");
     const [mode, setMode] = useState<"ask" | "agent">("ask");
     const [busy, setBusy] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -39,7 +43,16 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
 
     const configured = !!aiConfig.endpoint && !!aiConfig.model;
 
-    useEffect(() => { if (isOpen) inputRef.current?.focus(); }, [isOpen]);
+    // On open, the textarea has just remounted (closing renders null): restore
+    // any draft from the state mirror into the uncontrolled DOM node, then focus.
+    useEffect(() => {
+        if (!isOpen) return;
+        const el = inputRef.current;
+        if (el) {
+            el.value = inputDraftRef.current;
+            el.focus();
+        }
+    }, [isOpen]);
     useEffect(() => {
         const el = scrollRef.current;
         if (el) el.scrollTop = el.scrollHeight;
@@ -63,13 +76,18 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
         if (!text || busy) return;
         if (!configured) { setError("Configure an AI endpoint in Settings → AI first."); return; }
         setError(null);
+        // The textarea is uncontrolled (see below) — clear the DOM value directly
+        // and keep the state mirror in sync for the send button / auto-grow.
+        if (inputRef.current) inputRef.current.value = "";
+        inputDraftRef.current = "";
         setInput("");
 
         // Prior turns as plain Q/A (no document) — the doc is attached only to the
         // newest user turn by buildAskMessages.
-        const history: ChatMessage[] = messages
-            .slice(-MAX_HISTORY_TURNS * 2)
-            .map((m) => ({ role: m.role, content: m.content }));
+        const turns = getAIHistoryTurns();
+        const history: ChatMessage[] = turns > 0
+            ? messages.slice(-turns * 2).map((m) => ({ role: m.role, content: m.content }))
+            : [];
 
         const withUser: UIMessage[] = [...messages, { role: "user", content: text }, { role: "assistant", content: "" }];
         const assistantIdx = withUser.length - 1;
@@ -244,10 +262,15 @@ export function AIPanel({ isOpen, onClose, note, fileName, selectionText, aiConf
             {configured && (
                 <div className="shrink-0 p-3 pt-2">
                     <div className="ai-composer flex items-end gap-2 bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-lg)] px-3 py-2 shadow-sm transition-all duration-150">
+                        {/* Uncontrolled on purpose: a controlled textarea has React
+                            re-assign value/defaultValue on renders, which WebKitGTK
+                            treats as a programmatic edit and purges the native undo
+                            stack — Ctrl+Z stopped working on Linux (#111). `input`
+                            is a read-only mirror kept via onChange. */}
                         <textarea
                             ref={inputRef}
-                            value={input}
-                            onChange={(e) => setInput(e.target.value)}
+                            defaultValue=""
+                            onChange={(e) => { inputDraftRef.current = e.target.value; setInput(e.target.value); }}
                             onKeyDown={onKeyDown}
                             rows={1}
                             placeholder={mode === "agent" ? "Describe the change…" : "Ask about this note…"}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -9,6 +9,7 @@ import {
     getSpellCheck, setSpellCheck,
     getAutoSave, setAutoSave,
     getOpenInReader, setOpenInReader,
+    getAIHistoryTurns, setAIHistoryTurns, AI_HISTORY_TURNS_MAX,
 } from "../utils/persistence";
 import { AI_PROVIDERS, matchProvider, type AIProvider } from "../utils/aiProviders";
 import { attachFocusTrap } from "../utils/focusTrap";
@@ -109,6 +110,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
 
     const [ai, setAi] = useState(getAIConfig);
     const [aiEnabled, setAiEnabledLocal] = useState(getAIEnabled);
+    const [aiHistoryTurns, setAiHistoryTurnsLocal] = useState(getAIHistoryTurns);
     const aiEndpointInvalid = ai.endpoint.length > 0 && !isValidEndpoint(ai.endpoint);
     const aiConfigured = !!ai.endpoint && !aiEndpointInvalid && !!ai.model;
 
@@ -439,6 +441,27 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                         {activeProvider && (
                                             <span className="block mt-1 text-[11px] text-[var(--text-muted)]">{activeProvider.keyHint}</span>
                                         )}
+                                    </label>
+                                    <label className="block">
+                                        <span className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wider">Chat history depth</span>
+                                        <input
+                                            type="number"
+                                            min={0}
+                                            max={AI_HISTORY_TURNS_MAX}
+                                            step={1}
+                                            value={aiHistoryTurns}
+                                            onChange={(e) => {
+                                                const n = e.target.valueAsNumber;
+                                                if (!Number.isFinite(n)) return;
+                                                const clamped = Math.min(AI_HISTORY_TURNS_MAX, Math.max(0, Math.round(n)));
+                                                setAiHistoryTurnsLocal(clamped);
+                                                setAIHistoryTurns(clamped);
+                                            }}
+                                            className="mt-1 w-24 px-3 py-2 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-md)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)] font-mono"
+                                        />
+                                        <span className="block mt-1 text-[11px] text-[var(--text-muted)]">
+                                            How many previous chat turns are sent with each AI panel message. Lower saves tokens; 0 makes every message start fresh. The document itself is always attached only to the newest message.
+                                        </span>
                                     </label>
                                     <div className="flex items-center gap-3">
                                         <button

--- a/src/utils/aiProviders.test.ts
+++ b/src/utils/aiProviders.test.ts
@@ -12,6 +12,12 @@ describe("matchProvider", () => {
         expect(matchProvider("  https://api.openai.com/v1/chat/completions/ ")?.id).toBe("openai");
     });
 
+    it("matches LM Studio's default local server address", () => {
+        const p = matchProvider("http://localhost:1234/v1/chat/completions");
+        expect(p?.id).toBe("lmstudio");
+        expect(p?.keyOptional).toBe(true);
+    });
+
     it("returns null for empty and hand-configured endpoints", () => {
         expect(matchProvider("")).toBeNull();
         expect(matchProvider("   ")).toBeNull();

--- a/src/utils/aiProviders.ts
+++ b/src/utils/aiProviders.ts
@@ -38,6 +38,16 @@ export const AI_PROVIDERS: AIProvider[] = [
         keyHint: "No key needed. Everything stays on your machine.",
         keyOptional: true,
     },
+    {
+        id: "lmstudio",
+        name: "LM Studio (local)",
+        endpoint: "http://localhost:1234/v1/chat/completions",
+        // LM Studio has no universal model id — recent versions route unknown
+        // names to the loaded model, older ones want the model's API identifier.
+        defaultModel: "local-model",
+        keyHint: "No key needed. Start the server in LM Studio's Developer tab; set Model to the loaded model's API identifier if requests are rejected.",
+        keyOptional: true,
+    },
 ];
 
 const normalize = (url: string) => url.trim().replace(/\/+$/, "");

--- a/src/utils/persistence.test.ts
+++ b/src/utils/persistence.test.ts
@@ -6,6 +6,7 @@ import {
     getWordWrap,
     migrateLegacyKeys, getLastFile,
     getOpenInReader, setOpenInReader,
+    getAIHistoryTurns, setAIHistoryTurns, AI_HISTORY_TURNS_DEFAULT, AI_HISTORY_TURNS_MAX,
 } from "./persistence";
 
 beforeEach(() => localStorage.clear());
@@ -102,5 +103,29 @@ describe("AI config", () => {
 describe("defaults", () => {
     it("word wrap defaults to true", () => {
         expect(getWordWrap()).toBe(true);
+    });
+});
+
+describe("AI chat history depth", () => {
+    it("defaults to 8 turns", () => {
+        expect(getAIHistoryTurns()).toBe(AI_HISTORY_TURNS_DEFAULT);
+    });
+    it("round-trips a valid value", () => {
+        setAIHistoryTurns(3);
+        expect(getAIHistoryTurns()).toBe(3);
+        setAIHistoryTurns(0);
+        expect(getAIHistoryTurns()).toBe(0);
+    });
+    it("clamps out-of-range and rounds fractional values", () => {
+        setAIHistoryTurns(999);
+        expect(getAIHistoryTurns()).toBe(AI_HISTORY_TURNS_MAX);
+        setAIHistoryTurns(-4);
+        expect(getAIHistoryTurns()).toBe(0);
+        setAIHistoryTurns(2.6);
+        expect(getAIHistoryTurns()).toBe(3);
+    });
+    it("falls back to the default on a malformed stored value", () => {
+        localStorage.setItem("paperling:aiHistoryTurns", JSON.stringify("lots"));
+        expect(getAIHistoryTurns()).toBe(AI_HISTORY_TURNS_DEFAULT);
     });
 });

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -144,6 +144,20 @@ const KEY_AI_ENABLED = "paperling:aiEnabled";
 export const getAIEnabled = (): boolean => safeGet<boolean>(KEY_AI_ENABLED, true);
 export const setAIEnabled = (v: boolean): void => safeSet(KEY_AI_ENABLED, v);
 
+// How many previous chat turns (user + assistant pairs) accompany each AI
+// panel request. Read live per send; clamped so a hand-edited value can't
+// balloon requests. 0 = every message starts fresh. Issue #111.
+const KEY_AI_HISTORY_TURNS = "paperling:aiHistoryTurns";
+export const AI_HISTORY_TURNS_DEFAULT = 8;
+export const AI_HISTORY_TURNS_MAX = 50;
+export const getAIHistoryTurns = (): number => {
+    const v = safeGet<number>(KEY_AI_HISTORY_TURNS, AI_HISTORY_TURNS_DEFAULT);
+    if (typeof v !== "number" || !Number.isFinite(v)) return AI_HISTORY_TURNS_DEFAULT;
+    return Math.min(AI_HISTORY_TURNS_MAX, Math.max(0, Math.round(v)));
+};
+export const setAIHistoryTurns = (v: number): void =>
+    safeSet(KEY_AI_HISTORY_TURNS, Math.min(AI_HISTORY_TURNS_MAX, Math.max(0, Math.round(v))));
+
 // Version the user chose to skip in the update popup, so we don't nag about
 // it on every launch. A newer release has a different version string and
 // prompts again.


### PR DESCRIPTION
Batch 4 of the community feedback work. These commits existed on the branch but had never been merged; rebased onto current main (was 34 behind) and verified.

Closes #115.

## What is in here

**LM Studio provider preset (#115).** LM Studio already worked through the custom-endpoint path, it just was not discoverable. Adds it next to Gemini, OpenAI and Ollama so the endpoint fills itself and no key is required. The `keyHint` calls out that older LM Studio versions want the loaded model''s API identifier, since there is no universal model id.

**Configurable chat history depth (#111).** Blaze-Leo asked for control over how many previous turns are sent with each request. New Settings, AI field, default 8 (the previous hardcoded value, so behavior is unchanged unless you touch it). Clamped 0 to 50 on both read and write so a hand-edited localStorage value cannot balloon requests. 0 makes every message start fresh, which is useful for small local models.

**Undo in the AI chat composer (#111).** Ctrl+Z did nothing while typing a message. The composer was resetting the native undo history.

## Verification

Local, on a clean install:

- `bun run build` (tsc + vite) passes
- `bun run test` passes, 32 files / **307** tests, up from 302 on main (5 new tests across `aiProviders.test.ts` and `persistence.test.ts`)

## Note

No version bump and no release in this PR, deliberately. This just lands on main.