### PR TITLE
fix(find): search both sides of the diff during AI review (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Undo in the AI chat box.** Ctrl+Z now works while typing a message in the
   AI panel; the composer no longer resets the native undo history on Linux.
   (#111)
+- **Find now searches AI suggested changes properly.** While reviewing an AI
+  edit, Ctrl+F only looked at the proposed text, so words sitting in the removed
+  lines were never found: you could see four matches on screen and the bar would
+  say two, with next/previous skipping the ones you were looking at. Find now
+  covers both sides of the diff and steps through them in the order they appear
+  on screen. Replace still only touches the proposed text, since the removed
+  lines are the version being replaced. (#111)
 - **API keys are no longer sent unencrypted.** If an AI endpoint used plain
   `http://` and pointed at anything other than your own machine, the key went
   over the network in the clear. Paperling now refuses that request and says so

--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -25,8 +25,21 @@ import {
     type EditorState,
 } from "../utils/editorActions";
 import { FindBar, type FindController } from "./FindBar";
-import { findAll, matchLength, replaceOne, replaceAllMatches, isValidPattern } from "../utils/findReplace";
-import { findHighlightField, setFindMatches, type FindRange } from "../utils/editorFindHighlight";
+import { replaceOne, replaceAllMatches, isValidPattern } from "../utils/findReplace";
+import { findHighlightField, setFindMatches } from "../utils/editorFindHighlight";
+import {
+    collectUnifiedMatches,
+    docRanges,
+    activeDocIndex,
+    replaceableOffsets,
+    type DeletedRegion,
+    type UnifiedMatch,
+} from "../utils/reviewFind";
+import {
+    highlightRemovedMatch,
+    clearRemovedHighlight,
+    deletedChunkElementAt,
+} from "../utils/reviewFindHighlight";
 import { FormatToolbar } from "./FormatToolbar";
 import { SlashMenu, type SlashCommand } from "./SlashMenu";
 import { AIBubble } from "./AIBubble";
@@ -668,6 +681,9 @@ function CodeEditorImpl({
         lastReviewRef.current = null;
         reviewHadChunksRef.current = false;
         setReviewActive(false);
+        // The removed lines are gone, so drop any find highlight pinned to them
+        // rather than leave a stale registration behind (#111).
+        clearRemovedHighlight();
         viewRef.current?.dispatch({ effects: mergeCompRef.current.reconfigure([]) });
         lastEmittedRef.current = final; // keep the App content-sync from re-dispatching
         onReviewResolveRef.current?.(final);
@@ -686,6 +702,7 @@ function CodeEditorImpl({
         reviewingRef.current = false;
         lastReviewRef.current = null;
         setReviewActive(false);
+        clearRemovedHighlight();
         view.dispatch({
             changes: { from: 0, to: view.state.doc.length, insert: orig },
             effects: mergeCompRef.current.reconfigure([]),
@@ -841,15 +858,27 @@ function CodeEditorImpl({
     // findReplace helpers, paint matches via the findHighlightField decoration,
     // and replace through applyResultToView. Stable identity (refs + module-level
     // helpers only) so FindBar's effects don't churn.
-    const findRangesRef = useRef<FindRange[]>([]);
+    const findMatchesRef = useRef<UnifiedMatch[]>([]);
+    // setActive() gets only an index, so the query that produced the matches is
+    // stashed here for the removed-side highlighter to reuse.
+    const findQueryRef = useRef({ query: "", caseSensitive: false });
     const editorFindController = useMemo<FindController>(() => {
-        const rangesFor = (query: string, opts: { caseSensitive: boolean; regex: boolean }): FindRange[] => {
-            const v = viewRef.current;
-            if (!v) return [];
-            const doc = v.state.doc.toString();
-            return findAll(doc, query, opts.caseSensitive, opts.regex)
-                .map((from) => ({ from, to: from + matchLength(doc, from, query, opts.caseSensitive, opts.regex) }))
-                .filter((r) => r.to > r.from);
+        // During an AI review the document holds only the proposed text; the
+        // removed original lines are merge widgets, absent from the document.
+        // Feed them to the search as extra regions so a match the user can
+        // plainly see is actually found. Outside review this is empty and the
+        // search collapses to a plain document search. Issue #111.
+        const removedRegions = (v: EditorView): { regions: DeletedRegion[]; original: string } => {
+            if (!reviewingRef.current) return { regions: [], original: "" };
+            const chunks = getChunks(v.state)?.chunks;
+            if (!chunks?.length) return { regions: [], original: "" };
+            return {
+                original: getOriginalDoc(v.state).toString(),
+                // A pure insertion has toA === fromA and renders no removed lines.
+                regions: chunks
+                    .filter((c) => c.toA > c.fromA)
+                    .map((c) => ({ fromA: c.fromA, toA: c.toA, anchor: c.fromB })),
+            };
         };
         return {
             supportsReplace: true,
@@ -857,41 +886,74 @@ function CodeEditorImpl({
             isValidPattern: (query, opts) => isValidPattern(query, opts.regex),
             search: (query, opts) => {
                 const v = viewRef.current;
-                const ranges = rangesFor(query, opts);
-                findRangesRef.current = ranges;
-                let activeIndex = -1;
-                if (v && ranges.length) {
-                    const caret = v.state.selection.main.from;
-                    activeIndex = ranges.findIndex((r) => r.from >= caret);
-                    if (activeIndex === -1) activeIndex = 0;
-                    v.dispatch({ effects: setFindMatches.of({ ranges, activeIndex: -1 }) });
+                if (!v) {
+                    findMatchesRef.current = [];
+                    return { count: 0, activeIndex: -1 };
                 }
-                return { count: ranges.length, activeIndex };
+                const { regions, original } = removedRegions(v);
+                const matches = collectUnifiedMatches(v.state.doc.toString(), original, regions, query, opts);
+                findMatchesRef.current = matches;
+                findQueryRef.current = { query, caseSensitive: opts.caseSensitive };
+                clearRemovedHighlight();
+
+                let activeIndex = -1;
+                if (matches.length) {
+                    // Order by on-screen position, so `anchor` (not `from`, which
+                    // indexes the original doc for removed matches) is the cursor
+                    // comparison.
+                    const caret = v.state.selection.main.from;
+                    activeIndex = matches.findIndex((m) => m.anchor >= caret);
+                    if (activeIndex === -1) activeIndex = 0;
+                }
+                v.dispatch({ effects: setFindMatches.of({ ranges: docRanges(matches), activeIndex: -1 }) });
+                return { count: matches.length, activeIndex };
             },
             setActive: (index) => {
                 const v = viewRef.current;
-                const ranges = findRangesRef.current;
-                const r = ranges[index];
-                if (!v || !r) return;
+                const matches = findMatchesRef.current;
+                const m = matches[index];
+                if (!v || !m) return;
                 v.dispatch({
-                    effects: [setFindMatches.of({ ranges, activeIndex: index }), EditorView.scrollIntoView(r.from, { y: "center" })],
+                    effects: [
+                        // activeDocIndex, not `index`: the bar counts removed
+                        // matches too, so the two numberings differ.
+                        setFindMatches.of({ ranges: docRanges(matches), activeIndex: activeDocIndex(matches, index) }),
+                        EditorView.scrollIntoView(m.anchor, { y: "center" }),
+                    ],
+                });
+                if (m.side !== "deleted") {
+                    clearRemovedHighlight();
+                    return;
+                }
+                // The widget is only in the DOM once its chunk is near the
+                // viewport, so paint after the scroll above has been applied.
+                // Best-effort: if it can't be painted the user is still here.
+                requestAnimationFrame(() => {
+                    const view = viewRef.current;
+                    if (!view) return;
+                    const { query, caseSensitive } = findQueryRef.current;
+                    highlightRemovedMatch(deletedChunkElementAt(view, m.anchor), query, caseSensitive, m.ordinalInRegion);
                 });
             },
             clear: () => {
-                findRangesRef.current = [];
+                findMatchesRef.current = [];
+                clearRemovedHighlight();
                 viewRef.current?.dispatch({ effects: setFindMatches.of({ ranges: [], activeIndex: -1 }) });
             },
             replaceActive: (index, replacement, query, opts) => {
                 const v = viewRef.current;
-                const r = findRangesRef.current[index];
-                if (!v || !r) return;
-                const res = replaceOne(v.state.doc.toString(), r.from, query, replacement, opts.caseSensitive, opts.regex);
+                const m = findMatchesRef.current[index];
+                // Removed text is the version being replaced: it is not in the
+                // document and its offsets index the original, so splicing at
+                // them would corrupt unrelated text.
+                if (!v || !m || m.side !== "doc") return;
+                const res = replaceOne(v.state.doc.toString(), m.from, query, replacement, opts.caseSensitive, opts.regex);
                 if (res) applyResultToView(v, { text: res.content, selStart: res.cursor, selEnd: res.cursor });
             },
             replaceAll: (replacement, query, opts) => {
                 const v = viewRef.current;
                 if (!v) return;
-                const starts = findRangesRef.current.map((r) => r.from);
+                const starts = replaceableOffsets(findMatchesRef.current);
                 const res = replaceAllMatches(v.state.doc.toString(), starts, query, replacement, opts.caseSensitive, opts.regex);
                 if (res) applyResultToView(v, { text: res.content, selStart: res.cursor, selEnd: res.cursor });
             },

--- a/src/index.css
+++ b/src/index.css
@@ -331,6 +331,16 @@ select:focus-visible,
   color: #1a1a1a;
 }
 
+/* The active find match when it lands inside an AI review's removed lines
+   (issue #111). Those lines are a @codemirror/merge block widget, not document
+   text, so editor decorations can't reach them and the Custom Highlight API is
+   used instead. Same strong amber as the active match above, so "the one you
+   are on" looks the same wherever it is; only ever one range is registered. */
+::highlight(paperling-find-removed) {
+  background-color: rgba(255, 145, 0, 0.65);
+  color: #1a1a1a;
+}
+
 /* Editor-side find matches (CodeMirror decorations — FIND-01). Same amber as the
    reader-mode preview highlights above so find looks identical on both surfaces:
    every match dim, the active one brighter. */

--- a/src/utils/domTextMatches.test.ts
+++ b/src/utils/domTextMatches.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { collectDomMatches } from "./domTextMatches";
+
+const root = (html: string): HTMLElement => {
+    const el = document.createElement("div");
+    el.innerHTML = html;
+    return el;
+};
+
+describe("collectDomMatches", () => {
+    it("finds every occurrence in document order", () => {
+        const el = root("<p>milk</p><p>eggs</p><p>milk</p>");
+        const ranges = collectDomMatches(el, "milk", false);
+        expect(ranges).toHaveLength(2);
+        expect(ranges.map((r) => r.toString())).toEqual(["milk", "milk"]);
+    });
+
+    it("finds repeats inside one text node without overlapping", () => {
+        const ranges = collectDomMatches(root("<p>aaaa</p>"), "aa", false);
+        expect(ranges).toHaveLength(2);
+    });
+
+    it("is case-insensitive by default and exact when asked", () => {
+        expect(collectDomMatches(root("<p>Milk</p>"), "milk", false)).toHaveLength(1);
+        expect(collectDomMatches(root("<p>Milk</p>"), "milk", true)).toHaveLength(0);
+    });
+
+    it("returns nothing for an empty query", () => {
+        expect(collectDomMatches(root("<p>anything</p>"), "", false)).toEqual([]);
+    });
+
+    // A review chunk wraps its removed lines next to Accept/Reject buttons.
+    // Matching button labels would both inflate the count and highlight chrome.
+    it("skips subtrees matching the skip selectors", () => {
+        const el = root(
+            '<div class="cm-chunkButtons"><button>Accept item</button></div>' +
+            '<div class="cm-deletedLine"><del>keep item</del></div>'
+        );
+
+        expect(collectDomMatches(el, "item", false)).toHaveLength(2);
+
+        const scoped = collectDomMatches(el, "item", false, [".cm-chunkButtons"]);
+        expect(scoped).toHaveLength(1);
+        expect(scoped[0].startContainer.parentElement?.tagName).toBe("DEL");
+    });
+
+    it("skips a subtree even when the text node is nested deeper than the match", () => {
+        const el = root('<div class="cm-chunkButtons"><span><b>Reject</b></span></div><p>Reject</p>');
+        expect(collectDomMatches(el, "Reject", false, [".cm-chunkButtons"])).toHaveLength(1);
+    });
+
+    it("does not match across element boundaries (documented limit)", () => {
+        // "bold" + "text" are separate nodes, so "boldtext" is not a hit.
+        expect(collectDomMatches(root("<p><b>bold</b>text</p>"), "boldtext", false)).toEqual([]);
+    });
+
+    it("walks sibling nodes of one line independently", () => {
+        // A review line split at a change boundary: two text nodes, one hit each.
+        const el = root('<div class="cm-deletedLine"><del>buy <span>milk</span> and milk</del></div>');
+        expect(collectDomMatches(el, "milk", false)).toHaveLength(2);
+    });
+});

--- a/src/utils/domTextMatches.ts
+++ b/src/utils/domTextMatches.ts
@@ -1,0 +1,52 @@
+// Plain-text matching over rendered DOM, shared by the two find surfaces that
+// search painted output rather than source text: reader mode (previewFind) and
+// the removed lines of an AI review (reviewFindHighlight).
+//
+// Extracted from previewFind so both use one implementation, and so the
+// text-node walking is testable on its own.
+//
+// Known limit, inherited and deliberate: a match that spans element boundaries
+// (`bold**text**`, or a review line split at a change boundary) is not found,
+// because each text node is scanned independently. That is the same trade-off
+// VS Code's webview find makes.
+
+export const MAX_DOM_MATCHES = 5000;
+
+/**
+ * Ranges for every occurrence of `query` in `root`'s text nodes, in document
+ * order. Nodes under any selector in `skip` are ignored, which keeps chrome
+ * (e.g. a review chunk's Accept/Reject buttons) out of the results.
+ */
+export function collectDomMatches(
+    root: HTMLElement,
+    query: string,
+    caseSensitive: boolean,
+    skip: readonly string[] = []
+): Range[] {
+    const ranges: Range[] = [];
+    if (!query) return ranges;
+    const q = caseSensitive ? query : query.toLowerCase();
+
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+        acceptNode: (node) =>
+            skip.length && node.parentElement?.closest(skip.join(","))
+                ? NodeFilter.FILTER_REJECT
+                : NodeFilter.FILTER_ACCEPT,
+    });
+
+    let node: Node | null;
+    while ((node = walker.nextNode())) {
+        const data = (node as Text).data;
+        const text = caseSensitive ? data : data.toLowerCase();
+        let i = text.indexOf(q);
+        while (i !== -1) {
+            const r = new Range();
+            r.setStart(node, i);
+            r.setEnd(node, i + q.length);
+            ranges.push(r);
+            if (ranges.length >= MAX_DOM_MATCHES) return ranges;
+            i = text.indexOf(q, i + q.length);
+        }
+    }
+    return ranges;
+}

--- a/src/utils/previewFind.ts
+++ b/src/utils/previewFind.ts
@@ -8,8 +8,8 @@
 // acceptable for a reading aid, the same trade-off VS Code's webview find makes.
 
 import type { FindController, FindOpts, FindResult } from "../components/FindBar";
+import { collectDomMatches } from "./domTextMatches";
 
-const MAX_MATCHES = 5000;
 const HIGHLIGHT_ALL = "paperling-find";
 const HIGHLIGHT_ACTIVE = "paperling-find-active";
 
@@ -25,28 +25,6 @@ const cssHighlights = (): HighlightsRegistry | null => {
 
 const HighlightCtor = (): (new (...r: Range[]) => unknown) | undefined =>
     (globalThis as unknown as { Highlight?: new (...r: Range[]) => unknown }).Highlight;
-
-function collectMatches(root: HTMLElement, query: string, caseSensitive: boolean): Range[] {
-    const ranges: Range[] = [];
-    if (!query) return ranges;
-    const q = caseSensitive ? query : query.toLowerCase();
-    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
-    let node: Node | null;
-    while ((node = walker.nextNode())) {
-        const data = (node as Text).data;
-        const text = caseSensitive ? data : data.toLowerCase();
-        let i = text.indexOf(q);
-        while (i !== -1) {
-            const r = new Range();
-            r.setStart(node, i);
-            r.setEnd(node, i + q.length);
-            ranges.push(r);
-            if (ranges.length >= MAX_MATCHES) return ranges;
-            i = text.indexOf(q, i + q.length);
-        }
-    }
-    return ranges;
-}
 
 /**
  * Build a FindController over a rendered-markdown root. `rootRef` is read at call
@@ -73,7 +51,7 @@ export function createPreviewFindController(
 
         search(query: string, opts: FindOpts): FindResult {
             const root = rootRef.current;
-            ranges = root ? collectMatches(root, query.trim(), opts.caseSensitive) : [];
+            ranges = root ? collectDomMatches(root, query.trim(), opts.caseSensitive) : [];
             const reg = cssHighlights();
             const H = HighlightCtor();
             if (reg) {

--- a/src/utils/reviewFind.integration.test.ts
+++ b/src/utils/reviewFind.integration.test.ts
@@ -1,0 +1,147 @@
+// Integration check for the review-find fix (#111).
+//
+// reviewFind.test.ts covers the arithmetic with hand-written regions. This file
+// pins the assumption those regions are BUILT on: that `@codemirror/merge`
+// exposes removed text as `Chunk.fromA..toA` against `getOriginalDoc`, mounted
+// at `Chunk.fromB` in the live document. If a future version of the library
+// changes that mapping, the unit tests would still pass while the feature
+// silently broke, so assert it against the real library.
+
+import { describe, it, expect } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { unifiedMergeView, getChunks, getOriginalDoc } from "@codemirror/merge";
+import { collectUnifiedMatches, replaceableOffsets, type DeletedRegion } from "./reviewFind";
+
+/** Mirrors CodeEditor's review setup: doc = proposed text, original = before. */
+function reviewState(original: string, proposed: string): EditorState {
+    return EditorState.create({
+        doc: proposed,
+        extensions: [unifiedMergeView({ original })],
+    });
+}
+
+/** Mirrors `removedRegions()` in CodeEditor. */
+function regionsOf(state: EditorState): { regions: DeletedRegion[]; original: string } {
+    const chunks = getChunks(state)?.chunks;
+    if (!chunks?.length) return { regions: [], original: "" };
+    return {
+        original: getOriginalDoc(state).toString(),
+        regions: chunks
+            .filter((c) => c.toA > c.fromA)
+            .map((c) => ({ fromA: c.fromA, toA: c.toA, anchor: c.fromB })),
+    };
+}
+
+describe("review find against a real unifiedMergeView", () => {
+    it("exposes the original document and chunks at all", () => {
+        const state = reviewState("old line\n", "new line\n");
+        expect(getOriginalDoc(state).toString()).toBe("old line\n");
+        expect(getChunks(state)?.chunks?.length).toBeGreaterThan(0);
+    });
+
+    it("region offsets address the removed text in the original document", () => {
+        const state = reviewState("keep\nremoveme\n", "keep\n");
+        const { regions, original } = regionsOf(state);
+
+        expect(regions.length).toBeGreaterThan(0);
+        // Every region must slice to text that really is in the original.
+        for (const r of regions) {
+            expect(original.slice(r.fromA, r.toA).length).toBeGreaterThan(0);
+            expect(original).toContain(original.slice(r.fromA, r.toA));
+        }
+        // And the removed word must be inside one of them.
+        const removedText = regions.map((r) => original.slice(r.fromA, r.toA)).join("");
+        expect(removedText).toContain("removeme");
+    });
+
+    it("region anchors are valid positions in the live document", () => {
+        const state = reviewState("a\nb\nc\n", "a\nZ\nc\n");
+        const { regions } = regionsOf(state);
+
+        for (const r of regions) {
+            expect(r.anchor).toBeGreaterThanOrEqual(0);
+            expect(r.anchor).toBeLessThanOrEqual(state.doc.length);
+        }
+    });
+
+    // The exact scenario from #111: a word appears twice in the removed text and
+    // twice in the proposed text. Find used to report only the proposed two.
+    it("counts matches on both sides of the diff", () => {
+        const original = "buy milk\nbuy milk\n";
+        const proposed = "buy milk\nbuy milk\nbuy eggs\n";
+        const state = reviewState(original, proposed);
+        const { regions, original: orig } = regionsOf(state);
+
+        const docOnly = collectUnifiedMatches(state.doc.toString(), orig, [], "buy", {
+            caseSensitive: false,
+            regex: false,
+        });
+        const unified = collectUnifiedMatches(state.doc.toString(), orig, regions, "buy", {
+            caseSensitive: false,
+            regex: false,
+        });
+
+        // The whole point: the unified search sees at least as much as the
+        // document-only search, and strictly more when text was removed.
+        expect(unified.length).toBeGreaterThanOrEqual(docOnly.length);
+        expect(unified.filter((m) => m.side === "doc").length).toBe(docOnly.length);
+    });
+
+    it("finds text that exists ONLY in the removed lines", () => {
+        const original = "chapter one\nvanished paragraph\n";
+        const proposed = "chapter one\n";
+        const state = reviewState(original, proposed);
+        const { regions, original: orig } = regionsOf(state);
+
+        const matches = collectUnifiedMatches(state.doc.toString(), orig, regions, "vanished", {
+            caseSensitive: false,
+            regex: false,
+        });
+
+        // Not present in the document at all, so the old code found nothing.
+        expect(state.doc.toString()).not.toContain("vanished");
+        expect(matches).toHaveLength(1);
+        expect(matches[0].side).toBe("deleted");
+        expect(orig.slice(matches[0].from, matches[0].to)).toBe("vanished");
+    });
+
+    it("never offers removed matches to replace", () => {
+        const original = "target gone\n";
+        const proposed = "target here\n";
+        const state = reviewState(original, proposed);
+        const { regions, original: orig } = regionsOf(state);
+
+        const matches = collectUnifiedMatches(state.doc.toString(), orig, regions, "target", {
+            caseSensitive: false,
+            regex: false,
+        });
+        const offsets = replaceableOffsets(matches);
+
+        // Every replaceable offset must actually point at the query in the DOC.
+        const doc = state.doc.toString();
+        for (const off of offsets) {
+            expect(doc.slice(off, off + "target".length).toLowerCase()).toBe("target");
+        }
+        expect(offsets.length).toBe(matches.filter((m) => m.side === "doc").length);
+    });
+
+    it("produces no regions when the proposal only adds text", () => {
+        // A pure insertion has toA === fromA, so there are no removed lines and
+        // find must behave exactly as it does outside review.
+        const state = reviewState("line one\n", "line one\nline two\n");
+        const { regions } = regionsOf(state);
+        expect(regions).toEqual([]);
+    });
+
+    it("orders every match by its position on screen", () => {
+        const state = reviewState("aaa removed\nkeep\n", "keep\naaa added\n");
+        const { regions, original } = regionsOf(state);
+
+        const matches = collectUnifiedMatches(state.doc.toString(), original, regions, "aaa", {
+            caseSensitive: false,
+            regex: false,
+        });
+        const anchors = matches.map((m) => m.anchor);
+        expect(anchors).toEqual([...anchors].sort((a, b) => a - b));
+    });
+});

--- a/src/utils/reviewFind.test.ts
+++ b/src/utils/reviewFind.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import {
+    collectUnifiedMatches,
+    replaceableOffsets,
+    docRanges,
+    activeDocIndex,
+    type DeletedRegion,
+    type UnifiedMatch,
+} from "./reviewFind";
+
+const plain = { caseSensitive: false, regex: false };
+
+describe("collectUnifiedMatches", () => {
+    it("reduces to a plain document search when there are no removed regions", () => {
+        const matches = collectUnifiedMatches("alpha beta alpha", "", [], "alpha", plain);
+        expect(matches.map((m) => [m.side, m.from, m.to])).toEqual([
+            ["doc", 0, 5],
+            ["doc", 11, 16],
+        ]);
+    });
+
+    it("returns nothing for an empty query", () => {
+        expect(collectUnifiedMatches("alpha", "alpha", [{ fromA: 0, toA: 5, anchor: 0 }], "", plain)).toEqual([]);
+    });
+
+    // The reported case: two hits in the new text, two more in the removed
+    // lines, and the bar used to say 2. #111.
+    it("finds matches in removed lines that are not in the document", () => {
+        const original = "milk\neggs\nmilk\n";
+        const doc = "milk\nbread\n";
+        const regions: DeletedRegion[] = [{ fromA: 0, toA: original.length, anchor: 0 }];
+
+        const matches = collectUnifiedMatches(doc, original, regions, "milk", plain);
+
+        expect(matches).toHaveLength(3);
+        expect(matches.filter((m) => m.side === "deleted")).toHaveLength(2);
+        expect(matches.filter((m) => m.side === "doc")).toHaveLength(1);
+    });
+
+    it("reports removed-side offsets against the original document, not the live one", () => {
+        // "gamma" sits at 12 in the original and nowhere in the doc, so a naive
+        // implementation reusing document offsets would point at the wrong text.
+        const original = "alpha\nbeta\ngamma\n";
+        const doc = "alpha\n";
+        const regions: DeletedRegion[] = [{ fromA: 6, toA: 17, anchor: 6 }];
+
+        const [m] = collectUnifiedMatches(doc, original, regions, "gamma", plain);
+
+        expect(m.side).toBe("deleted");
+        expect(original.slice(m.from, m.to)).toBe("gamma");
+        expect(m.from).toBe(11);
+    });
+
+    it("orders removed lines before the new text of the same chunk", () => {
+        // One chunk at anchor 10: its removed lines paint above its new text,
+        // because @codemirror/merge mounts a block widget at fromB.
+        const original = "hit-old";
+        const doc = "aaaaaaaaaahit-new";
+        const regions: DeletedRegion[] = [{ fromA: 0, toA: 7, anchor: 10 }];
+
+        const sides = collectUnifiedMatches(doc, original, regions, "hit", plain).map((m) => m.side);
+
+        expect(sides).toEqual(["deleted", "doc"]);
+    });
+
+    it("interleaves multiple chunks in screen order", () => {
+        //  doc:  "x .... x .... x"   with removed chunks anchored at 10 and 20
+        const doc = "x" + " ".repeat(14) + "x" + " ".repeat(9) + "x";
+        const original = "x-removed-early x-removed-late";
+        const regions: DeletedRegion[] = [
+            { fromA: 16, toA: 30, anchor: 20 }, // deliberately out of order on input
+            { fromA: 0, toA: 15, anchor: 10 },
+        ];
+
+        const matches = collectUnifiedMatches(doc, original, regions, "x", plain);
+        const anchors = matches.map((m) => m.anchor);
+
+        // Sorted ascending regardless of the order regions were supplied in.
+        expect(anchors).toEqual([...anchors].sort((a, b) => a - b));
+        expect(matches.map((m) => `${m.side}@${m.anchor}`)).toEqual([
+            "doc@0",
+            "deleted@10",
+            "doc@15",
+            "deleted@20",
+            "doc@25",
+        ]);
+    });
+
+    it("numbers matches within each region so the highlighter can pick one", () => {
+        const original = "dup dup dup";
+        const doc = "";
+        const regions: DeletedRegion[] = [{ fromA: 0, toA: 11, anchor: 0 }];
+
+        const ordinals = collectUnifiedMatches(doc, original, regions, "dup", plain).map((m) => m.ordinalInRegion);
+
+        expect(ordinals).toEqual([0, 1, 2]);
+    });
+
+    it("honours case sensitivity on both sides", () => {
+        const regions: DeletedRegion[] = [{ fromA: 0, toA: 3, anchor: 0 }];
+        const sensitive = { caseSensitive: true, regex: false };
+
+        expect(collectUnifiedMatches("ABC", "abc", regions, "abc", sensitive)).toHaveLength(1);
+        expect(collectUnifiedMatches("ABC", "abc", regions, "abc", plain)).toHaveLength(2);
+    });
+
+    it("supports regex on both sides", () => {
+        const regions: DeletedRegion[] = [{ fromA: 0, toA: 6, anchor: 0 }];
+        const re = { caseSensitive: false, regex: true };
+
+        const matches = collectUnifiedMatches("a1b2", "x9y8z7", regions, "\\d", re);
+
+        expect(matches).toHaveLength(5);
+        expect(matches.filter((m) => m.side === "deleted")).toHaveLength(3);
+    });
+
+    it("never lets a regex match span the seam between removed and new text", () => {
+        // "olddnew" only exists if the two surfaces are concatenated. They are
+        // separate blocks on screen, so a match across them is not a real hit.
+        const regions: DeletedRegion[] = [{ fromA: 0, toA: 4, anchor: 0 }];
+        const matches = collectUnifiedMatches("new", "old", regions, "oldnew", { caseSensitive: false, regex: true });
+        expect(matches).toEqual([]);
+    });
+
+    it("skips malformed regions instead of slicing nonsense", () => {
+        const regions: DeletedRegion[] = [
+            { fromA: 5, toA: 5, anchor: 0 }, // empty
+            { fromA: 9, toA: 2, anchor: 0 }, // inverted
+        ];
+        expect(collectUnifiedMatches("", "abcabcabc", regions, "abc", plain)).toEqual([]);
+    });
+});
+
+describe("docRanges / activeDocIndex", () => {
+    // deleted, doc, deleted, doc  — the interleaving that breaks naive indexing.
+    const mixed: UnifiedMatch[] = [
+        { side: "deleted", from: 0, to: 3, anchor: 0, ordinalInRegion: 0 },
+        { side: "doc", from: 5, to: 8, anchor: 5, ordinalInRegion: 0 },
+        { side: "deleted", from: 9, to: 12, anchor: 10, ordinalInRegion: 1 },
+        { side: "doc", from: 20, to: 23, anchor: 20, ordinalInRegion: 1 },
+    ];
+
+    it("keeps only document ranges", () => {
+        expect(docRanges(mixed)).toEqual([
+            { from: 5, to: 8 },
+            { from: 20, to: 23 },
+        ]);
+    });
+
+    it("maps bar indices onto decoration indices", () => {
+        // Bar index 1 is the FIRST document match, so decoration index 0.
+        expect(activeDocIndex(mixed, 1)).toBe(0);
+        // Bar index 3 is the SECOND document match: decoration index 1, not 3.
+        expect(activeDocIndex(mixed, 3)).toBe(1);
+    });
+
+    it("returns -1 for removed-side matches, which have no decoration", () => {
+        expect(activeDocIndex(mixed, 0)).toBe(-1);
+        expect(activeDocIndex(mixed, 2)).toBe(-1);
+    });
+
+    it("returns -1 for an out-of-range index", () => {
+        expect(activeDocIndex(mixed, 99)).toBe(-1);
+        expect(activeDocIndex(mixed, -1)).toBe(-1);
+    });
+
+    it("indexes identically to the bar when nothing was removed", () => {
+        const docOnly = collectUnifiedMatches("a a a", "", [], "a", plain);
+        expect(docRanges(docOnly)).toHaveLength(3);
+        expect([0, 1, 2].map((i) => activeDocIndex(docOnly, i))).toEqual([0, 1, 2]);
+    });
+
+    it("agrees with the decoration array it describes", () => {
+        // Property check: every doc match's mapped index must point back at itself.
+        const ranges = docRanges(mixed);
+        mixed.forEach((m, barIdx) => {
+            if (m.side !== "doc") return;
+            const decoIdx = activeDocIndex(mixed, barIdx);
+            expect(ranges[decoIdx]).toEqual({ from: m.from, to: m.to });
+        });
+    });
+});
+
+describe("replaceableOffsets", () => {
+    it("keeps only document matches, so replace can never rewrite removed text", () => {
+        const original = "target gone";
+        const doc = "target here";
+        const regions: DeletedRegion[] = [{ fromA: 0, toA: 11, anchor: 4 }];
+
+        const matches = collectUnifiedMatches(doc, original, regions, "target", plain);
+        expect(matches).toHaveLength(2);
+
+        // The removed-side offset (0) must not appear: splicing the document at
+        // an original-document offset would corrupt unrelated text.
+        expect(replaceableOffsets(matches)).toEqual([0]);
+        expect(matches.find((m) => m.side === "deleted")).toBeDefined();
+    });
+
+    it("returns document offsets in ascending order", () => {
+        const doc = "z z z";
+        const original = "z";
+        const regions: DeletedRegion[] = [{ fromA: 0, toA: 1, anchor: 3 }];
+
+        expect(replaceableOffsets(collectUnifiedMatches(doc, original, regions, "z", plain))).toEqual([0, 2, 4]);
+    });
+
+    it("is empty when every match is on the removed side", () => {
+        const regions: DeletedRegion[] = [{ fromA: 0, toA: 4, anchor: 0 }];
+        const matches = collectUnifiedMatches("", "gone", regions, "gone", plain);
+        expect(matches).toHaveLength(1);
+        expect(replaceableOffsets(matches)).toEqual([]);
+    });
+});

--- a/src/utils/reviewFind.ts
+++ b/src/utils/reviewFind.ts
@@ -1,0 +1,167 @@
+// Find across an AI review (unified merge) view. Issue #111.
+//
+// During review the editor runs `unifiedMergeView`, where the DOCUMENT holds
+// only the proposed (new) text and the removed original lines are rendered as
+// block widgets that are not part of the document at all. The find controller
+// searched `state.doc`, so any match living in a removed line was invisible to
+// it: you could see four hits on screen and the bar would say two, with
+// navigation skipping the ones you were looking at.
+//
+// This module rebuilds the searchable surface the way the user actually sees
+// it: the document text plus, for every chunk, the slice of the ORIGINAL
+// document that chunk renders as removed lines. The result is one list ordered
+// the way the eye travels down the screen.
+//
+// It is deliberately pure (no CodeMirror, no DOM) so the ordering and offset
+// arithmetic — the part that is easy to get subtly wrong — is unit-testable.
+
+import { findAll, matchLength } from "./findReplace";
+
+/** A run of original-document text rendered as removed lines by one chunk. */
+export interface DeletedRegion {
+    /** Start offset in the ORIGINAL document. `Chunk.fromA`. */
+    fromA: number;
+    /** End offset in the ORIGINAL document. `Chunk.toA`. */
+    toA: number;
+    /**
+     * Position in the LIVE document where this chunk's widget is mounted.
+     * `@codemirror/merge` adds it at `Chunk.fromB`, as a block widget, so the
+     * removed lines paint directly above that chunk's new text.
+     */
+    anchor: number;
+}
+
+/** Which surface a match was found on. Only `doc` matches are replaceable. */
+export type MatchSide = "doc" | "deleted";
+
+export interface UnifiedMatch {
+    side: MatchSide;
+    /**
+     * For `doc`, offsets into the live document (usable directly as CodeMirror
+     * positions). For `deleted`, offsets into the ORIGINAL document — NOT valid
+     * document positions, which is exactly why they must never reach replace.
+     */
+    from: number;
+    to: number;
+    /**
+     * Live-document position this match sits at or under, used for ordering and
+     * for scrolling. Equal to `from` for `doc` matches; the owning chunk's
+     * `anchor` for `deleted` ones.
+     */
+    anchor: number;
+    /**
+     * 0-based index of this match among the matches of its own region, so the
+     * highlighter can pick the right occurrence inside the widget's DOM without
+     * needing to map model offsets onto rendered lines.
+     */
+    ordinalInRegion: number;
+}
+
+export interface FindOpts {
+    caseSensitive: boolean;
+    regex: boolean;
+}
+
+/** Matches inside one string, as offsets shifted by `base`. */
+function matchesIn(text: string, base: number, query: string, opts: FindOpts): Array<{ from: number; to: number }> {
+    return findAll(text, query, opts.caseSensitive, opts.regex)
+        .map((at) => ({
+            from: base + at,
+            to: base + at + matchLength(text, at, query, opts.caseSensitive, opts.regex),
+        }))
+        .filter((r) => r.to > r.from);
+}
+
+/**
+ * Every match visible in the review view, in top-to-bottom screen order.
+ *
+ * Pass `regions: []` outside review and this reduces to a plain document
+ * search, which keeps the non-review path byte-for-byte identical.
+ *
+ * Each region is searched on its own rather than as part of one concatenated
+ * string, so a regex can never match across the seam between removed text and
+ * the document — those are separate blocks on screen, and a match spanning them
+ * could not be highlighted or navigated to coherently.
+ */
+export function collectUnifiedMatches(
+    docText: string,
+    originalText: string,
+    regions: readonly DeletedRegion[],
+    query: string,
+    opts: FindOpts
+): UnifiedMatch[] {
+    if (!query) return [];
+
+    const out: UnifiedMatch[] = matchesIn(docText, 0, query, opts).map((r, i) => ({
+        side: "doc" as const,
+        from: r.from,
+        to: r.to,
+        anchor: r.from,
+        ordinalInRegion: i,
+    }));
+
+    for (const region of regions) {
+        // Guard against a malformed range rather than handing slice() nonsense.
+        if (!(region.toA > region.fromA)) continue;
+        const text = originalText.slice(region.fromA, region.toA);
+        matchesIn(text, region.fromA, query, opts).forEach((r, i) => {
+            out.push({
+                side: "deleted",
+                from: r.from,
+                to: r.to,
+                anchor: region.anchor,
+                ordinalInRegion: i,
+            });
+        });
+    }
+
+    // Screen order: by anchor, and at the same anchor the removed lines come
+    // first because the widget is a block widget mounted at `fromB`, i.e. it
+    // paints above the new text that starts there.
+    return out.sort((a, b) => {
+        if (a.anchor !== b.anchor) return a.anchor - b.anchor;
+        if (a.side !== b.side) return a.side === "deleted" ? -1 : 1;
+        return a.from - b.from;
+    });
+}
+
+/**
+ * The document-side matches as plain ranges, for the decoration field.
+ *
+ * The find bar counts every match, removed ones included, but decorations can
+ * only mark document text — so the bar's indices and the decoration array's
+ * indices are different numbering systems. Use `activeDocIndex` to cross over.
+ */
+export function docRanges(matches: readonly UnifiedMatch[]): Array<{ from: number; to: number }> {
+    return matches.filter((m) => m.side === "doc").map((m) => ({ from: m.from, to: m.to }));
+}
+
+/**
+ * Translate a find-bar index into an index into `docRanges(matches)`, or -1 when
+ * the active match is on the removed side and therefore has no decoration to
+ * emphasise. Passing the bar's index straight through would emphasise an
+ * unrelated match whenever a removed one appeared earlier in the list.
+ */
+export function activeDocIndex(matches: readonly UnifiedMatch[], barIndex: number): number {
+    if (matches[barIndex]?.side !== "doc") return -1;
+    let n = 0;
+    for (let i = 0; i < barIndex; i++) {
+        if (matches[i].side === "doc") n++;
+    }
+    return n;
+}
+
+/**
+ * Document offsets of the replaceable matches, in document order.
+ *
+ * Replace must never touch the removed side: that text is the version being
+ * replaced, it is not in the document, and its offsets index a different
+ * string. Feeding them to a splice would corrupt the file at unrelated
+ * positions. Callers use this instead of mapping the match list directly.
+ */
+export function replaceableOffsets(matches: readonly UnifiedMatch[]): number[] {
+    return matches
+        .filter((m) => m.side === "doc")
+        .map((m) => m.from)
+        .sort((a, b) => a - b);
+}

--- a/src/utils/reviewFindHighlight.test.ts
+++ b/src/utils/reviewFindHighlight.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { highlightRemovedMatch, clearRemovedHighlight } from "./reviewFindHighlight";
+
+// jsdom has no CSS Custom Highlight API, so stand one up to observe what the
+// module registers. The real webviews (WebView2 / WKWebView / WebKitGTK) have it.
+class FakeHighlight {
+    ranges: Range[];
+    constructor(...ranges: Range[]) {
+        this.ranges = ranges;
+    }
+}
+
+let registry: Map<string, FakeHighlight>;
+
+const installHighlightApi = () => {
+    registry = new Map();
+    (globalThis as Record<string, unknown>).Highlight = FakeHighlight;
+    (globalThis as unknown as { CSS: unknown }).CSS = { highlights: registry };
+};
+
+const removeHighlightApi = () => {
+    delete (globalThis as Record<string, unknown>).Highlight;
+    delete (globalThis as Record<string, unknown>).CSS;
+};
+
+/** A stand-in for @codemirror/merge's rendered `.cm-deletedChunk`. */
+const chunk = (lines: string[], withButtons = true): HTMLElement => {
+    const el = document.createElement("div");
+    el.className = "cm-deletedChunk";
+    if (withButtons) {
+        el.innerHTML = '<div class="cm-chunkButtons"><button>Accept</button><button>Reject</button></div>';
+    }
+    for (const line of lines) {
+        const div = document.createElement("div");
+        div.className = "cm-deletedLine";
+        div.innerHTML = `<del>${line}</del>`;
+        el.appendChild(div);
+    }
+    return el;
+};
+
+const painted = () => registry.get("paperling-find-removed");
+
+beforeEach(installHighlightApi);
+afterEach(removeHighlightApi);
+
+describe("highlightRemovedMatch", () => {
+    it("paints the requested occurrence", () => {
+        const ok = highlightRemovedMatch(chunk(["buy milk", "buy milk"]), "milk", false, 1);
+        expect(ok).toBe(true);
+        expect(painted()?.ranges).toHaveLength(1);
+        expect(painted()?.ranges[0].toString()).toBe("milk");
+    });
+
+    it("distinguishes the first occurrence from the second", () => {
+        const el = chunk(["alpha", "beta alpha"]);
+        highlightRemovedMatch(el, "alpha", false, 0);
+        const first = painted()?.ranges[0].startContainer;
+        highlightRemovedMatch(el, "alpha", false, 1);
+        const second = painted()?.ranges[0].startContainer;
+        expect(first).not.toBe(second);
+    });
+
+    it("ignores the Accept/Reject buttons", () => {
+        // "Accept" appears only in the chunk chrome, so there is nothing to paint.
+        expect(highlightRemovedMatch(chunk(["nothing here"]), "Accept", false, 0)).toBe(false);
+        expect(painted()).toBeUndefined();
+    });
+
+    it("does not count button text when picking the ordinal", () => {
+        // Without the skip, "e" inside "Accept"/"Reject" would shift every ordinal.
+        const ok = highlightRemovedMatch(chunk(["zebra"]), "e", false, 0);
+        expect(ok).toBe(true);
+        expect(painted()?.ranges[0].startContainer.parentElement?.tagName).toBe("DEL");
+    });
+
+    it("refuses a multi-line query rather than paint the wrong hit", () => {
+        expect(highlightRemovedMatch(chunk(["a", "b"]), "a\nb", false, 0)).toBe(false);
+    });
+
+    it("paints nothing when the model saw more occurrences than the DOM has", () => {
+        // ordinal 3 does not exist here; blindly indexing would throw or mispaint.
+        expect(highlightRemovedMatch(chunk(["one milk"]), "milk", false, 3)).toBe(false);
+        expect(painted()).toBeUndefined();
+    });
+
+    it("is a no-op with no element, no query, or no Highlight API", () => {
+        expect(highlightRemovedMatch(null, "x", false, 0)).toBe(false);
+        expect(highlightRemovedMatch(chunk(["x"]), "", false, 0)).toBe(false);
+
+        removeHighlightApi();
+        expect(highlightRemovedMatch(chunk(["x"]), "x", false, 0)).toBe(false);
+        installHighlightApi();
+    });
+
+    it("honours case sensitivity", () => {
+        expect(highlightRemovedMatch(chunk(["Milk"]), "milk", true, 0)).toBe(false);
+        expect(highlightRemovedMatch(chunk(["Milk"]), "milk", false, 0)).toBe(true);
+    });
+
+    it("clears a previous highlight on every call, including failed ones", () => {
+        expect(highlightRemovedMatch(chunk(["milk"]), "milk", false, 0)).toBe(true);
+        expect(painted()).toBeDefined();
+
+        // A subsequent miss must not leave the old emphasis behind.
+        expect(highlightRemovedMatch(chunk(["milk"]), "absent", false, 0)).toBe(false);
+        expect(painted()).toBeUndefined();
+    });
+
+    it("clearRemovedHighlight removes the registration", () => {
+        highlightRemovedMatch(chunk(["milk"]), "milk", false, 0);
+        clearRemovedHighlight();
+        expect(painted()).toBeUndefined();
+    });
+});

--- a/src/utils/reviewFindHighlight.ts
+++ b/src/utils/reviewFindHighlight.ts
@@ -1,0 +1,102 @@
+// Paints the active find match when it lands inside an AI review's removed
+// lines. Issue #111.
+//
+// Removed lines are a block widget, not document text, so CodeMirror
+// decorations cannot reach them. They ARE real DOM, so the CSS Custom Highlight
+// API works — the same mechanism reader-mode find already uses, and it needs no
+// DOM mutation, so @codemirror/merge's widget is left untouched.
+//
+// Everything here is best-effort by design. Match counting, ordering,
+// navigation and replace safety live in reviewFind.ts and never call into this
+// module, so if the highlight is skipped the user still gets the right count
+// and still gets scrolled to the right chunk.
+
+import type { EditorView } from "@codemirror/view";
+import { collectDomMatches } from "./domTextMatches";
+
+const HIGHLIGHT_REMOVED = "paperling-find-removed";
+
+/** The chunk's Accept/Reject buttons are chrome, not content. */
+const SKIP_INSIDE = [".cm-chunkButtons"];
+
+type HighlightsRegistry = {
+    set(name: string, highlight: unknown): void;
+    delete(name: string): void;
+};
+
+const cssHighlights = (): HighlightsRegistry | null => {
+    const css = (globalThis as { CSS?: { highlights?: HighlightsRegistry } }).CSS;
+    return css?.highlights ?? null;
+};
+
+const HighlightCtor = (): (new (...r: Range[]) => unknown) | undefined =>
+    (globalThis as unknown as { Highlight?: new (...r: Range[]) => unknown }).Highlight;
+
+export function clearRemovedHighlight(): void {
+    cssHighlights()?.delete(HIGHLIGHT_REMOVED);
+}
+
+/**
+ * The rendered removed-lines element for the chunk mounted at `anchor`, or null.
+ *
+ * `@codemirror/merge` adds the deletion as a block widget at `Chunk.fromB`, so
+ * it renders as the previous sibling of the block holding that position. Returns
+ * null when the chunk is scrolled out of the viewport (CodeMirror only renders
+ * what is near the visible range), so callers must scroll first.
+ *
+ * Deliberately narrow: it checks only the immediate previous sibling rather than
+ * scanning backwards, so an unexpected DOM shape yields null instead of
+ * emphasising some unrelated chunk.
+ */
+export function deletedChunkElementAt(view: EditorView, anchor: number): HTMLElement | null {
+    try {
+        const { node } = view.domAtPos(anchor);
+        let el: HTMLElement | null = node instanceof HTMLElement ? node : node.parentElement;
+        // Climb to the block that is a direct child of .cm-content.
+        while (el?.parentElement && !el.parentElement.classList.contains("cm-content")) {
+            el = el.parentElement;
+        }
+        const prev = el?.previousElementSibling;
+        return prev instanceof HTMLElement && prev.classList.contains("cm-deletedChunk") ? prev : null;
+    } catch {
+        // domAtPos throws for a position outside the rendered range.
+        return null;
+    }
+}
+
+/**
+ * Highlight occurrence `ordinal` of `query` inside one removed chunk.
+ *
+ * Returns whether a highlight was actually painted, so callers can tell "shown"
+ * from "scrolled but not painted" rather than guessing.
+ *
+ * Bails out, leaving nothing painted, when:
+ *  - the query spans lines: the model counts such a match but the rendered
+ *    lines are separate elements with no newline between them, so the ordinals
+ *    would not line up;
+ *  - the DOM yields fewer occurrences than the model did, which happens when a
+ *    line is split at a change boundary mid-match (see domTextMatches'
+ *    documented element-boundary limit). Painting `ranges[ordinal]` blindly
+ *    there would emphasise the wrong hit;
+ *  - the platform has no Custom Highlight API.
+ */
+export function highlightRemovedMatch(
+    chunkEl: HTMLElement | null,
+    query: string,
+    caseSensitive: boolean,
+    ordinal: number
+): boolean {
+    clearRemovedHighlight();
+    if (!chunkEl || !query || query.includes("\n")) return false;
+
+    const reg = cssHighlights();
+    const H = HighlightCtor();
+    if (!reg || !H) return false;
+
+    const ranges = collectDomMatches(chunkEl, query, caseSensitive, SKIP_INSIDE);
+    const range = ranges[ordinal];
+    if (!range) return false;
+
+    reg.set(HIGHLIGHT_REMOVED, new H(range));
+    return true;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,10 @@ export default defineConfig({
         // and EditorState.create rejects extensions built by the other copy
         // ("Unrecognized extension value"). Vite's dep pre-bundling hides this
         // in dev/build, so it only bites in tests.
-        dedupe: ["@codemirror/state", "@codemirror/view", "@codemirror/language", "@codemirror/autocomplete", "@codemirror/lint"],
+        // @codemirror/merge is here because reviewFind.integration.test.ts builds
+        // a real unifiedMergeView state; a second @codemirror/state copy behind it
+        // would fail EditorState.create with "Unrecognized extension value".
+        dedupe: ["@codemirror/state", "@codemirror/view", "@codemirror/language", "@codemirror/autocomplete", "@codemirror/lint", "@codemirror/merge"],
     },
     test: {
         environment: "jsdom",


### PR DESCRIPTION
Fixes the Ctrl+F-during-review bug from #111, reported by @Blaze-Leo.

## The bug

While an AI review is open the editor runs `unifiedMergeView`. The **document holds only the proposed text**; the removed original lines are block widgets that are not part of the document at all. The find controller searched `state.doc`, so a match inside a removed line did not exist as far as find was concerned.

> consider that I have exactly two same words in a list, and I asked to divide the list into multiple groups, now before accepting or rejecting I search for the words, I find only 2 instances instead of expected 4

That is exactly it: four on screen, two counted, and next/previous silently skipping the ones you are looking at.

On the second half of the report ("positions of rendering ... not visually correct"): I could not reproduce mispositioning as a separate defect. Decorations are placed by document offset and CodeMirror accounts for widget heights when it lays out, so the surviving highlights land correctly. The wrong-looking positions follow from the missing matches, and go away with them.

## The fix

Rebuild the searchable surface the way it is actually rendered: the document, plus `original[fromA..toA]` for each chunk, ordered by on-screen position. A chunk''s removed lines sort **before** its new text because `@codemirror/merge` mounts the deletion as a block widget at `fromB`.

Outside review the region list is empty and the search collapses to exactly the previous document-only behaviour, so the normal path is unchanged.

## Replace is deliberately asymmetric

Removed text is the version being replaced. It is not in the document, and its offsets index a *different string*, so splicing the document at them would corrupt unrelated text. `replaceActive` no-ops on a removed match and `replaceAll` only ever takes document offsets. There are tests specifically for this.

## Two numbering systems

The bar counts every match; decorations can only mark document text. Those indices are not the same, so `activeDocIndex` translates between them. Passing the bar index straight through would have emphasised the wrong match whenever a removed one appeared earlier in the list. Also tested.

## The highlight is best-effort on purpose

Removed lines get the active highlight via the CSS Custom Highlight API, because decorations cannot reach widget DOM. That path is deliberately isolated: **counting, ordering, navigation and replace safety never call into it.** If it is skipped you still get the right count and still land on the right chunk.

It bails rather than mispaint when:
- the query spans lines (the model counts such a match, but rendered lines are separate elements with no newline between them, so ordinals would not line up)
- the DOM yields fewer occurrences than the model did (a line split at a change boundary mid-match)
- the platform has no Custom Highlight API

It also skips the chunk''s Accept/Reject buttons, so those labels neither inflate the count nor shift the ordinal. Searching "Accept" during a review finds nothing in the chrome, as it should.

## Refactor included

`previewFind`''s text-node walking moved into `domTextMatches` so reader-mode find and this share one implementation. It had **no tests** before; it does now.

## Verification

- `bun run build` (tsc + vite) clean
- `bun run test`: **359 tests, 36 files**, up from 313. 46 new tests.
  - `reviewFind.test.ts` (20) — offset and ordering arithmetic, including the interleaving of multiple chunks and the seam case where a regex must not match across removed/new text
  - `reviewFind.integration.test.ts` (8) — builds a **real** `unifiedMergeView` state and asserts the `fromA`/`toA`/`fromB` contract, so a future `@codemirror/merge` change cannot silently break this while the unit tests still pass. Includes finding text that exists *only* in removed lines.
  - `reviewFindHighlight.test.ts` (10) — drives the highlighter against a stand-in chunk, including the button-skip and refuse-to-mispaint cases
  - `domTextMatches.test.ts` (8) — new coverage for the extracted walker
- Ran the full suite cold (cleared the Vite cache) as well as warm.

## What I could not verify

I have no Rust toolchain or real webview here, so the Custom Highlight paint on the removed side is unverified **on a real build** — jsdom has no Custom Highlight API, so the tests exercise it through a stand-in. The logic it guards is fully tested and the failure mode is benign (scroll without paint). A Test Build is queued so this can be confirmed on a real window.

No version bump and no release in this PR.