### PR TITLE
feat: support custom system fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Custom system fonts.** Enter an installed font family in Appearance to use
+  it across the interface, Markdown preview and exports, with Inter as a safe
+  fallback. (#113)
 - **Paperling remembers your window.** Size, position and whether it was
   maximized are restored the next time you launch, instead of always reopening
   at the default 1000x700 in the middle of the screen. Thanks to

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Dark, Light, Paper, and Dracula.
 ### <img src="images/art/icon-theme-swatches.png" width="26" alt=""> Customization
 
 - **Four themes** — Dark, Light, Paper, Dracula
-- **Five fonts** — Inter, Merriweather, Lora, Source Serif, Fira Sans
+- **Five bundled fonts plus custom system fonts** — Inter, Merriweather, Lora, Source Serif, Fira Sans, or a locally installed family
 - **Three font sizes**
 - **WCAG-friendly** — visible focus rings, `prefers-reduced-motion` respected
 

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -28,7 +28,7 @@ type ExportFormat = 'html' | 'pdf' | 'docx';
 export function ExportMenu({ fileName, getExportHtml, onSuccess, onError }: ExportMenuProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [isExporting, setIsExporting] = useState(false);
-    const { theme, font, fontSize } = useTheme();
+    const { theme, font, customFont, fontSize } = useTheme();
     const menuRef = useRef<HTMLDivElement>(null);
     const panelRef = useRef<HTMLDivElement>(null);
     const onMenuKeyDown = useDropdownKeyboard(isOpen, panelRef, () => setIsOpen(false));
@@ -71,16 +71,16 @@ export function ExportMenu({ fileName, getExportHtml, onSuccess, onError }: Expo
             const mod = await loadExportModule();
             if (format === 'html') {
                 // exportToHTML returns false when the save dialog is cancelled.
-                if (await mod.exportToHTML(htmlContent, fileName, theme, font, fontSize)) {
+                if (await mod.exportToHTML(htmlContent, fileName, theme, font, fontSize, customFont)) {
                     onSuccess?.('HTML');
                 }
             } else if (format === 'docx') {
                 // exportToDocx returns false on a cancelled save dialog.
-                if (await mod.exportToDocx(htmlContent, fileName, theme, font, fontSize)) {
+                if (await mod.exportToDocx(htmlContent, fileName, theme, font, fontSize, customFont)) {
                     onSuccess?.('DOCX');
                 }
             } else {
-                const result = await mod.exportToPDF(htmlContent, fileName, theme, font, fontSize);
+                const result = await mod.exportToPDF(htmlContent, fileName, theme, font, fontSize, customFont);
                 // Only the native save path (Windows/macOS) can confirm a
                 // written file. The Linux print-dialog fallback ('printing') is
                 // its own visible feedback, so we don't claim success there.

--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -25,7 +25,7 @@ const fontSizes: { id: FontSize; name: string; size: string }[] = [
 
 export function SettingsMenu() {
     const [isOpen, setIsOpen] = useState(false);
-    const { theme, setTheme, font, setFont, fontSize, setFontSize } = useTheme();
+    const { theme, setTheme, font, setFont, customFont, setCustomFont, fontSize, setFontSize } = useTheme();
     const menuRef = useRef<HTMLDivElement>(null);
     const panelRef = useRef<HTMLDivElement>(null);
     const onMenuKeyDown = useDropdownKeyboard(isOpen, panelRef, () => setIsOpen(false));
@@ -126,6 +126,27 @@ export function SettingsMenu() {
                                     {f.name}
                                 </button>
                             ))}
+                            <button
+                                type="button"
+                                onClick={() => setFont('custom')}
+                                className={`w-full text-left px-3 py-2 rounded-lg transition-all text-sm ${font === 'custom'
+                                    ? 'bg-[var(--accent)] text-[var(--accent-text)] font-medium'
+                                    : 'text-[var(--text-primary)] hover:bg-[var(--bg-hover)]'
+                                    }`}
+                            >
+                                Custom system font
+                            </button>
+                            <input
+                                type="text"
+                                value={customFont}
+                                maxLength={100}
+                                onFocus={() => setFont('custom')}
+                                onChange={(e) => setCustomFont(e.target.value)}
+                                onBlur={() => setCustomFont(customFont.trim())}
+                                placeholder="e.g. Atkinson Hyperlegible"
+                                aria-label="Custom system font family"
+                                className="w-full mt-1 px-3 py-2 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded-lg text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+                            />
                         </div>
                     </div>
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -94,7 +94,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     const dialogRef = useRef<HTMLDivElement>(null);
     const [section, setSection] = useState<Section>("appearance");
     const [filter, setFilter] = useState("");
-    const { theme, setTheme, font, setFont, fontSize, setFontSize } = useTheme();
+    const { theme, setTheme, font, setFont, customFont, setCustomFont, fontSize, setFontSize } = useTheme();
 
     const [typewriter, setTypewriterLocal] = useState(getTypewriterMode);
     const [toolbar, setToolbarLocal] = useState(getToolbarEnabled);
@@ -299,6 +299,33 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                                     </button>
                                                 );
                                             })}
+                                            <div className={`col-span-2 flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius-md)] border transition-all ${font === "custom"
+                                                ? "border-[var(--accent)] bg-[var(--bg-hover)] ring-1 ring-[var(--accent)]"
+                                                : "border-[var(--border)]"
+                                                }`}>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setFont("custom")}
+                                                    aria-pressed={font === "custom"}
+                                                    className="shrink-0 text-left"
+                                                >
+                                                    <span className="block text-[15px] leading-tight text-[var(--text-primary)]">Custom</span>
+                                                    <span className="block text-[10px] text-[var(--text-muted)] mt-0.5">System font</span>
+                                                </button>
+                                                <input
+                                                    type="text"
+                                                    value={customFont}
+                                                    maxLength={100}
+                                                    onFocus={() => setFont("custom")}
+                                                    onChange={(e) => setCustomFont(e.target.value)}
+                                                    onBlur={() => setCustomFont(customFont.trim())}
+                                                    placeholder="e.g. Atkinson Hyperlegible"
+                                                    aria-label="Custom system font family"
+                                                    className="min-w-0 flex-1 px-2.5 py-1.5 text-sm bg-[var(--bg-input)] border border-[var(--border)] rounded-[var(--radius-md)] text-[var(--text-primary)] outline-none focus:border-[var(--accent)]"
+                                                    style={{ fontFamily: customFont ? `"${customFont}", 'Inter'` : "'Inter'" }}
+                                                />
+                                                {font === "custom" && <span className="material-symbols-outlined text-[18px] text-[var(--accent)] shrink-0">check</span>}
+                                            </div>
                                         </div>
                                     </section>
                                 )}

--- a/src/context/ThemeContext.test.tsx
+++ b/src/context/ThemeContext.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ThemeProvider, useTheme } from "./ThemeContext";
+
+function FontControls() {
+    const { font, setFont, customFont, setCustomFont } = useTheme();
+    return (
+        <>
+            <span data-testid="font">{font}</span>
+            <span data-testid="custom-font">{customFont}</span>
+            <button onClick={() => setFont("custom")}>Use custom</button>
+            <button onClick={() => setCustomFont('Atkinson"; color: red')}>Set family</button>
+        </>
+    );
+}
+
+describe("ThemeProvider custom font", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        document.documentElement.removeAttribute("data-font");
+        document.documentElement.style.removeProperty("--font-custom");
+    });
+
+    it("persists only a sanitized family and applies the Inter fallback stack", async () => {
+        render(<ThemeProvider><FontControls /></ThemeProvider>);
+
+        fireEvent.click(screen.getByText("Use custom"));
+        fireEvent.click(screen.getByText("Set family"));
+
+        expect(screen.getByTestId("font")).toHaveTextContent("custom");
+        expect(screen.getByTestId("custom-font")).toHaveTextContent("Atkinson color red");
+        expect(localStorage.getItem("paperling-custom-font")).toBe("Atkinson color red");
+        await waitFor(() => {
+            expect(document.documentElement).toHaveAttribute("data-font", "custom");
+            expect(document.documentElement.style.getPropertyValue("--font-custom"))
+                .toBe('"Atkinson color red", \'Inter\'');
+        });
+    });
+});

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,8 +1,9 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { ensureFontLoaded } from '../fonts';
+import { getFontStack, sanitizeCustomFontFamily } from '../utils/fontFamily';
 
 export type Theme = 'dark' | 'light' | 'paper' | 'dracula';
-export type FontFamily = 'inter' | 'merriweather' | 'lora' | 'source-serif' | 'fira-sans';
+export type FontFamily = 'inter' | 'merriweather' | 'lora' | 'source-serif' | 'fira-sans' | 'custom';
 export type FontSize = 'small' | 'medium' | 'large';
 
 interface ThemeContextType {
@@ -10,6 +11,8 @@ interface ThemeContextType {
     setTheme: (theme: Theme) => void;
     font: FontFamily;
     setFont: (font: FontFamily) => void;
+    customFont: string;
+    setCustomFont: (font: string) => void;
     fontSize: FontSize;
     setFontSize: (size: FontSize) => void;
 }
@@ -18,11 +21,12 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 const THEME_STORAGE_KEY = 'paperling-theme';
 const FONT_STORAGE_KEY = 'paperling-font';
+const CUSTOM_FONT_STORAGE_KEY = 'paperling-custom-font';
 const FONT_SIZE_STORAGE_KEY = 'paperling-font-size';
 
 // Valid values for validation against corrupted localStorage
 const VALID_THEMES: Theme[] = ['dark', 'light', 'paper', 'dracula'];
-const VALID_FONTS: FontFamily[] = ['inter', 'merriweather', 'lora', 'source-serif', 'fira-sans'];
+const VALID_FONTS: FontFamily[] = ['inter', 'merriweather', 'lora', 'source-serif', 'fira-sans', 'custom'];
 const VALID_FONT_SIZES: FontSize[] = ['small', 'medium', 'large'];
 
 function getValidated<T extends string>(key: string, validValues: T[], fallback: T): T {
@@ -59,6 +63,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
         getValidated(FONT_STORAGE_KEY, VALID_FONTS, 'inter')
     );
 
+    const [customFont, setCustomFontState] = useState(() =>
+        sanitizeCustomFontFamily(localStorage.getItem(CUSTOM_FONT_STORAGE_KEY) ?? '')
+    );
+
     const [fontSize, setFontSizeState] = useState<FontSize>(() =>
         getValidated(FONT_SIZE_STORAGE_KEY, VALID_FONT_SIZES, 'medium')
     );
@@ -71,6 +79,12 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const setFont = (newFont: FontFamily) => {
         setFontState(newFont);
         localStorage.setItem(FONT_STORAGE_KEY, newFont);
+    };
+
+    const setCustomFont = (newFont: string) => {
+        const safeFont = sanitizeCustomFontFamily(newFont);
+        setCustomFontState(safeFont);
+        localStorage.setItem(CUSTOM_FONT_STORAGE_KEY, safeFont);
     };
 
     const setFontSize = (newSize: FontSize) => {
@@ -87,7 +101,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
         el.setAttribute('data-theme', theme);
         el.setAttribute('data-font', font);
         el.setAttribute('data-font-size', fontSize);
-    }, [theme, font, fontSize]);
+        el.style.setProperty('--font-custom', getFontStack('custom', customFont));
+    }, [theme, font, fontSize, customFont]);
 
     // Track the OS theme until the user picks one explicitly. The handler
     // re-checks storage each time so flipping the OS appearance never overrides
@@ -105,7 +120,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     }, []);
 
     return (
-        <ThemeContext.Provider value={{ theme, setTheme, font, setFont, fontSize, setFontSize }}>
+        <ThemeContext.Provider value={{ theme, setTheme, font, setFont, customFont, setCustomFont, fontSize, setFontSize }}>
             {children}
         </ThemeContext.Provider>
     );

--- a/src/index.css
+++ b/src/index.css
@@ -243,6 +243,10 @@
   --font-body: 'Fira Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
+[data-font="custom"] {
+  --font-body: var(--font-custom, 'Inter');
+}
+
 /* ===== Font Size Variables ===== */
 /* Default font size - must come BEFORE attribute selectors */
 :root {

--- a/src/utils/exportUtils.test.ts
+++ b/src/utils/exportUtils.test.ts
@@ -42,6 +42,15 @@ describe("generateHTML", () => {
         expect(out).toContain("18px"); // large base size
     });
 
+    it("applies a sanitized custom font with Inter as its final fallback", () => {
+        const out = generateHTML(
+            "<p>x</p>", "t", "dark", "custom", "medium", true,
+            'Atkinson Hyperlegible"; color: red'
+        );
+        expect(out).toContain('font-family: "Atkinson Hyperlegible color red", \'Inter\'');
+        expect(out).not.toContain("color: red");
+    });
+
     // ==highlight== and definition lists render in the preview DOM that exports
     // capture, so the export stylesheet must ship matching rules (SYNTAX-01).
     it("ships mark and definition-list styling in the export CSS", () => {

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -2,6 +2,7 @@ import { Theme, FontFamily, FontSize } from '../context/ThemeContext';
 import { save } from '@tauri-apps/plugin-dialog';
 import { writeTextFile, writeFile } from '@tauri-apps/plugin-fs';
 import { invoke } from '@tauri-apps/api/core';
+import { getFontName, getFontStack } from './fontFamily';
 
 // Theme color definitions for export
 const themeColors: Record<Theme, Record<string, string>> = {
@@ -75,15 +76,6 @@ const themeColors: Record<Theme, Record<string, string>> = {
     },
 };
 
-// Font family definitions
-const fontFamilies: Record<FontFamily, string> = {
-    'inter': "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
-    'merriweather': "'Merriweather', Georgia, 'Times New Roman', serif",
-    'lora': "'Lora', Georgia, 'Times New Roman', serif",
-    'source-serif': "'Source Serif 4', Georgia, 'Times New Roman', serif",
-    'fira-sans': "'Fira Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
-};
-
 // Font size definitions
 const fontSizes: Record<FontSize, { base: string; h1: string; h2: string; h3: string; lineHeight: string }> = {
     small: { base: '14px', h1: '1.875em', h2: '1.5em', h3: '1.125em', lineHeight: '1.6' },
@@ -92,9 +84,9 @@ const fontSizes: Record<FontSize, { base: string; h1: string; h2: string; h3: st
 };
 
 // Generate CSS for export
-function generateExportCSS(theme: Theme, font: FontFamily, fontSize: FontSize): string {
+function generateExportCSS(theme: Theme, font: FontFamily, fontSize: FontSize, customFont = ''): string {
     const colors = themeColors[theme];
-    const fontFamily = fontFamilies[font];
+    const fontFamily = getFontStack(font, customFont);
     const sizes = fontSizes[fontSize];
 
     // No Google Fonts @import here — exporting must succeed offline, and the
@@ -424,9 +416,10 @@ export function generateHTML(
     theme: Theme,
     font: FontFamily,
     fontSize: FontSize,
-    includeFooter: boolean = true
+    includeFooter: boolean = true,
+    customFont: string = ''
 ): string {
-    const css = generateExportCSS(theme, font, fontSize);
+    const css = generateExportCSS(theme, font, fontSize, customFont);
     const safeTitle = escapeHtml(title);
     const date = new Date().toLocaleDateString('en-US', {
         year: 'numeric',
@@ -465,11 +458,12 @@ export async function exportToHTML(
     fileName: string,
     theme: Theme,
     font: FontFamily,
-    fontSize: FontSize
+    fontSize: FontSize,
+    customFont: string = ''
 ): Promise<boolean> {
     const title = fileName.replace(/\.(md|markdown)$/i, '');
     const cleaned = await prepareExportHtml(htmlContent);
-    const fullHTML = generateHTML(cleaned, title, theme, font, fontSize);
+    const fullHTML = generateHTML(cleaned, title, theme, font, fontSize, true, customFont);
 
     // Use Tauri save dialog
     const filePath = await save({
@@ -526,8 +520,9 @@ export async function exportToDocx(
     htmlContent: string,
     fileName: string,
     _theme: Theme,
-    _font: FontFamily,
-    _fontSize: FontSize
+    font: FontFamily,
+    _fontSize: FontSize,
+    customFont: string = ''
 ): Promise<boolean> {
     if (!htmlContent || htmlContent.trim() === '') {
         console.error('No HTML content to export!');
@@ -559,7 +554,7 @@ export async function exportToDocx(
         creator: 'Paperling',
         footer: false,
         pageNumber: false,
-        font: 'Calibri',
+        font: getFontName(font, customFont),
         // Word measures run size in half-points; 22 == 11pt body text.
         fontSize: 22,
         table: { row: { cantSplit: true } },
@@ -732,7 +727,8 @@ export async function exportToPDF(
     fileName: string,
     _theme: Theme,
     font: FontFamily,
-    fontSize: FontSize
+    fontSize: FontSize,
+    customFont: string = ''
 ): Promise<PdfExportResult> {
     if (!htmlContent || htmlContent.trim() === '') {
         console.error('No HTML content to export!');
@@ -744,7 +740,7 @@ export async function exportToPDF(
     // Same cleanup as HTML export — strips UI chrome (copy buttons, heading
     // anchor icons) and inlines blob: images as data: URIs.
     const cleaned = await prepareExportHtml(htmlContent);
-    const fullHTML = generateHTML(cleaned, title, 'light', font, fontSize, true);
+    const fullHTML = generateHTML(cleaned, title, 'light', font, fontSize, true, customFont);
 
     const canSaveSilently =
         typeof navigator !== 'undefined' &&

--- a/src/utils/fontFamily.test.ts
+++ b/src/utils/fontFamily.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { getFontName, getFontStack, sanitizeCustomFontFamily } from "./fontFamily";
+
+describe("sanitizeCustomFontFamily", () => {
+    it("keeps ordinary system font names", () => {
+        expect(sanitizeCustomFontFamily("Atkinson Hyperlegible")).toBe("Atkinson Hyperlegible");
+        expect(sanitizeCustomFontFamily("Noto Sans CJK JP")).toBe("Noto Sans CJK JP");
+    });
+
+    it("removes characters that can escape a CSS font-family value", () => {
+        expect(sanitizeCustomFontFamily('Safe"; color: red; /*')).toBe("Safe color red ");
+    });
+});
+
+describe("getFontStack", () => {
+    it("quotes a custom family and keeps Inter as the final fallback", () => {
+        expect(getFontStack("custom", "IBM Plex Sans")).toBe('"IBM Plex Sans", \'Inter\'');
+    });
+
+    it("falls back to Inter when the custom family is empty", () => {
+        expect(getFontStack("custom", "  ")).toBe("'Inter'");
+    });
+
+    it("keeps the bundled font stacks unchanged", () => {
+        expect(getFontStack("lora")).toBe("'Lora', Georgia, 'Times New Roman', serif");
+    });
+});
+
+describe("getFontName", () => {
+    it("returns a safe single family for document exports", () => {
+        expect(getFontName("custom", "IBM Plex Sans")).toBe("IBM Plex Sans");
+        expect(getFontName("custom", "")).toBe("Inter");
+        expect(getFontName("source-serif")).toBe("Source Serif 4");
+    });
+});

--- a/src/utils/fontFamily.ts
+++ b/src/utils/fontFamily.ts
@@ -1,0 +1,43 @@
+import type { FontFamily } from "../context/ThemeContext";
+
+export const CUSTOM_FONT_MAX_LENGTH = 100;
+
+const FONT_STACKS: Record<Exclude<FontFamily, "custom">, string> = {
+    inter: "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    merriweather: "'Merriweather', Georgia, 'Times New Roman', serif",
+    lora: "'Lora', Georgia, 'Times New Roman', serif",
+    "source-serif": "'Source Serif 4', Georgia, 'Times New Roman', serif",
+    "fira-sans": "'Fira Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+};
+
+const FONT_NAMES: Record<Exclude<FontFamily, "custom">, string> = {
+    inter: "Inter",
+    merriweather: "Merriweather",
+    lora: "Lora",
+    "source-serif": "Source Serif 4",
+    "fira-sans": "Fira Sans",
+};
+
+/**
+ * Keep a custom family name safe to place in CSS. Custom fonts are deliberately
+ * a single local family, not an arbitrary font-family declaration, so CSS
+ * delimiters and escapes are removed before the value is stored or rendered.
+ */
+export function sanitizeCustomFontFamily(value: string): string {
+    return value
+        .replace(/[\u0000-\u001f\u007f"\\,;:{}()[\]/*]/g, "")
+        .replace(/\s+/g, " ")
+        .slice(0, CUSTOM_FONT_MAX_LENGTH);
+}
+
+export function getFontStack(font: FontFamily, customFont = ""): string {
+    if (font !== "custom") return FONT_STACKS[font];
+
+    const family = sanitizeCustomFontFamily(customFont).trim();
+    return family ? `${JSON.stringify(family)}, 'Inter'` : "'Inter'";
+}
+
+export function getFontName(font: FontFamily, customFont = ""): string {
+    if (font !== "custom") return FONT_NAMES[font];
+    return sanitizeCustomFontFamily(customFont).trim() || "Inter";
+}


### PR DESCRIPTION
## Summary

- add a persisted custom system-font option to the quick settings menu and Appearance settings
- sanitize the family before applying it, with Inter as the final fallback
- use the selected family in the UI, preview, and HTML/PDF/DOCX exports while keeping CodeMirror on JetBrains Mono

## Testing

- `node node_modules\vitest\vitest.mjs run src/context/ThemeContext.test.tsx src/utils/fontFamily.test.ts src/utils/exportUtils.test.ts` (21 tests)
- `node node_modules\typescript\bin\tsc --noEmit`
- `node node_modules\vite\bin\vite.js build`

Closes #113