### PR TITLE
feat: add backlinks panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Dark, Light, Paper, and Dracula.
 - **Restore last opened file** on launch
 - **File Explorer** with folder navigation
 - **Outline pane** that follows the cursor
+- **Backlinks panel** showing which notes in the current folder link to the open file
 
 ### <img src="images/art/icon-theme-swatches.png" width="26" alt=""> Customization
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -399,6 +399,38 @@ pub async fn search_files(
         .map_err(|e| CommandError::ReadError(e.to_string()))?
 }
 
+/// Find markdown files under `directory` that link to `target_file` using
+/// either Paperling wikilinks (`[[Note]]`) or relative markdown links
+/// (`[label](Note.md)`). Both paths are canonicalized before the scan so the
+/// command cannot be used to inspect files outside the open document folder.
+#[tauri::command]
+pub async fn find_backlinks(
+    directory: String,
+    target_file: String,
+) -> Result<Vec<FileSearchResult>, CommandError> {
+    let root = tokio::fs::canonicalize(&directory)
+        .await
+        .map_err(|e| CommandError::ReadError(e.to_string()))?;
+    if !root.is_dir() {
+        return Err(CommandError::ReadError(
+            "Backlink search root is not a directory".to_string(),
+        ));
+    }
+
+    let target = tokio::fs::canonicalize(&target_file)
+        .await
+        .map_err(|e| CommandError::ReadError(e.to_string()))?;
+    if !target.is_file() || !target.starts_with(&root) {
+        return Err(CommandError::ReadError(
+            "Backlink target must be inside the search folder".to_string(),
+        ));
+    }
+
+    tokio::task::spawn_blocking(move || Ok(find_backlinks_in_tree(root, target)))
+        .await
+        .map_err(|e| CommandError::ReadError(e.to_string()))?
+}
+
 /// Synchronous, bounded recursive search used by `search_files`. Pulled out so
 /// it can be unit-tested without a Tauri/async harness. `query` is assumed
 /// non-empty and already trimmed.
@@ -502,6 +534,210 @@ fn search_markdown_tree(root: PathBuf, query: &str, case_sensitive: bool) -> Vec
 
     results.sort_by_key(|r| r.name.to_lowercase());
     results
+}
+
+/// Bounded recursive backlink scan. This deliberately shares the same caps and
+/// ignored-directory rules as global search so opening the panel cannot turn a
+/// large workspace into an unbounded read.
+fn find_backlinks_in_tree(root: PathBuf, target: PathBuf) -> Vec<FileSearchResult> {
+    let target_name = target
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let target_stem = target
+        .file_stem()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let target_parent = target.parent().map(PathBuf::from);
+
+    let mut results = Vec::new();
+    let mut files_scanned = 0usize;
+    let mut stack = vec![root];
+
+    while let Some(dir) = stack.pop() {
+        if results.len() >= SEARCH_MAX_RESULTS || files_scanned >= SEARCH_MAX_FILES {
+            break;
+        }
+        let read_dir = match std::fs::read_dir(&dir) {
+            Ok(read_dir) => read_dir,
+            Err(_) => continue,
+        };
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(_) => continue,
+            };
+            if file_type.is_dir() {
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if name.starts_with('.') || name == "node_modules" || name == "target" {
+                        continue;
+                    }
+                }
+                stack.push(path);
+                continue;
+            }
+            let is_markdown = path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .map(|extension| {
+                    extension.eq_ignore_ascii_case("md")
+                        || extension.eq_ignore_ascii_case("markdown")
+                })
+                .unwrap_or(false);
+            if !is_markdown || path == target {
+                continue;
+            }
+
+            files_scanned += 1;
+            if files_scanned > SEARCH_MAX_FILES {
+                break;
+            }
+            if entry
+                .metadata()
+                .map(|metadata| metadata.len() > SEARCH_MAX_FILE_BYTES)
+                .unwrap_or(true)
+            {
+                continue;
+            }
+            let content = match std::fs::read_to_string(&path) {
+                Ok(content) => content,
+                Err(_) => continue,
+            };
+
+            let mut matches = Vec::new();
+            for (index, line) in content.lines().enumerate() {
+                if line_links_to_target(
+                    line,
+                    &path,
+                    &target,
+                    target_parent.as_deref(),
+                    &target_name,
+                    &target_stem,
+                ) {
+                    let trimmed = line.trim();
+                    let text = if trimmed.chars().count() > SEARCH_SNIPPET_CHARS {
+                        let mut snippet: String =
+                            trimmed.chars().take(SEARCH_SNIPPET_CHARS).collect();
+                        snippet.push('…');
+                        snippet
+                    } else {
+                        trimmed.to_string()
+                    };
+                    matches.push(SearchMatch {
+                        line: (index + 1) as u32,
+                        text,
+                    });
+                    if matches.len() >= SEARCH_MAX_MATCHES_PER_FILE {
+                        break;
+                    }
+                }
+            }
+            if !matches.is_empty() {
+                results.push(FileSearchResult {
+                    name: path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    path: path.to_string_lossy().to_string(),
+                    matches,
+                });
+                if results.len() >= SEARCH_MAX_RESULTS {
+                    break;
+                }
+            }
+        }
+    }
+
+    results.sort_by_key(|result| result.name.to_ascii_lowercase());
+    results
+}
+
+fn line_links_to_target(
+    line: &str,
+    source: &std::path::Path,
+    target: &std::path::Path,
+    target_parent: Option<&std::path::Path>,
+    target_name: &str,
+    target_stem: &str,
+) -> bool {
+    // Wikilinks resolve beside their source file in Paperling. Support aliases
+    // and heading fragments while avoiding prefix matches such as [[Notebook]].
+    let mut wikilink_rest = line;
+    while let Some(start) = wikilink_rest.find("[[") {
+        wikilink_rest = &wikilink_rest[start + 2..];
+        let Some(end) = wikilink_rest.find("]]") else {
+            break;
+        };
+        let raw_target = wikilink_rest[..end]
+            .split('|')
+            .next()
+            .unwrap_or_default()
+            .split('#')
+            .next()
+            .unwrap_or_default()
+            .trim();
+        let normalized = raw_target.to_ascii_lowercase();
+        if !raw_target.contains('/')
+            && !raw_target.contains('\\')
+            && source.parent() == target_parent
+            && (normalized == target_name || normalized == target_stem)
+        {
+            return true;
+        }
+        wikilink_rest = &wikilink_rest[end + 2..];
+    }
+
+    // Markdown links may point through subdirectories or `..`, so resolve each
+    // candidate from the source file and compare canonical paths. Images are
+    // excluded (`![alt](...)`) because they are embeds, not note backlinks.
+    let mut markdown_rest = line;
+    while let Some(start) = markdown_rest.find("](") {
+        let prefix = &markdown_rest[..start];
+        let is_image = prefix
+            .rfind('[')
+            .is_some_and(|open| open > 0 && prefix.as_bytes()[open - 1] == b'!');
+        markdown_rest = &markdown_rest[start + 2..];
+        let Some(end) = markdown_rest.find(')') else {
+            break;
+        };
+        if !is_image {
+            let raw_destination = markdown_rest[..end].trim();
+            let wrapped_destination = raw_destination
+                .strip_prefix('<')
+                .and_then(|value| value.strip_suffix('>'));
+            let destination = wrapped_destination.unwrap_or_else(|| {
+                raw_destination
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or_default()
+            });
+            let destination = destination.split(['#', '?']).next().unwrap_or_default();
+            let is_markdown = std::path::Path::new(destination)
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .map(|extension| {
+                    extension.eq_ignore_ascii_case("md")
+                        || extension.eq_ignore_ascii_case("markdown")
+                })
+                .unwrap_or(false);
+            if is_markdown && !destination.contains("://") {
+                if let Some(parent) = source.parent() {
+                    if let Ok(resolved) = std::fs::canonicalize(parent.join(destination)) {
+                        if resolved == target {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        markdown_rest = &markdown_rest[end + 1..];
+    }
+
+    false
 }
 
 /// Strip any path components from a filename so it can't traverse outside the
@@ -721,8 +957,8 @@ pub fn set_ai_key(key: String) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_eol, read_file, sanitize_image_name, save_file, search_markdown_tree,
-        validate_rel_path, Eol,
+        apply_eol, find_backlinks_in_tree, read_file, sanitize_image_name, save_file,
+        search_markdown_tree, validate_rel_path, Eol,
     };
 
     #[test]
@@ -767,6 +1003,45 @@ mod tests {
         let results = search_markdown_tree(dir.clone(), "needle", false);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].name, "keep.md");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn backlinks_match_exact_wikilinks_and_relative_markdown_links() {
+        let dir = std::env::temp_dir().join(format!("paperling-backlinks-{}", std::process::id()));
+        let sub = dir.join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        let target = dir.join("Target Note.md");
+        std::fs::write(&target, "# Target\n[[Target Note]]").unwrap();
+        std::fs::write(
+            dir.join("wiki.md"),
+            "[[Target Note|alias]]\n[[Target Note#Heading]]\n[[Target Notebook]]",
+        )
+        .unwrap();
+        std::fs::write(
+            sub.join("relative.md"),
+            "[target](<../Target Note.md#section>)\n![image](<../Target Note.md>)",
+        )
+        .unwrap();
+        std::fs::write(sub.join("not-sibling.md"), "[[Target Note]]").unwrap();
+
+        let results = find_backlinks_in_tree(
+            std::fs::canonicalize(&dir).unwrap(),
+            std::fs::canonicalize(&target).unwrap(),
+        );
+
+        assert_eq!(results.len(), 2);
+        let wiki = results
+            .iter()
+            .find(|result| result.name == "wiki.md")
+            .unwrap();
+        assert_eq!(wiki.matches.len(), 2);
+        let relative = results
+            .iter()
+            .find(|result| result.name == "relative.md")
+            .unwrap();
+        assert_eq!(relative.matches.len(), 1);
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,8 +3,8 @@ mod commands;
 mod pdf;
 
 use commands::{
-    get_ai_key, get_file_info, list_directory_files, read_file, read_image_file, save_file,
-    save_image, search_files, set_ai_key,
+    find_backlinks, get_ai_key, get_file_info, list_directory_files, read_file, read_image_file,
+    save_file, save_image, search_files, set_ai_key,
 };
 use std::sync::Mutex;
 use tauri::{Emitter, Manager};
@@ -116,6 +116,7 @@ pub fn run() {
             get_file_info,
             list_directory_files,
             search_files,
+            find_backlinks,
             save_image,
             read_image_file,
             get_ai_key,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,9 @@ const FileExplorer = lazy(() =>
 const TableOfContents = lazy(() =>
     import("./components/TableOfContents").then((m) => ({ default: m.TableOfContents }))
 );
+const BacklinksPanel = lazy(() =>
+    import("./components/BacklinksPanel").then((m) => ({ default: m.BacklinksPanel }))
+);
 const SettingsModal = lazy(() =>
     import("./components/SettingsModal").then((m) => ({ default: m.SettingsModal }))
 );
@@ -165,6 +168,7 @@ function AppContent() {
   // Sidebar panel state
   const [showFileExplorer, setShowFileExplorer] = useState(false);
   const [showTOC, setShowTOC] = useState(false);
+  const [showBacklinks, setShowBacklinks] = useState(false);
   const [showAIPanel, setShowAIPanel] = useState(false);
   // Live during a drag; the panel writes the settled value to storage itself.
   const [aiPanelWidth, setAiPanelWidth] = useState(getAIPanelWidth);
@@ -624,12 +628,21 @@ function AppContent() {
   const handleToggleFileExplorer = useCallback(() => {
     setShowFileExplorer((prev) => !prev);
     setShowTOC(false);
+    setShowBacklinks(false);
   }, []);
 
   // Toggle table of contents (mutually exclusive with file explorer)
   const handleToggleTOC = useCallback(() => {
     setShowTOC((prev) => !prev);
     setShowFileExplorer(false);
+    setShowBacklinks(false);
+  }, []);
+
+  // Toggle backlinks (mutually exclusive with the other left drawers)
+  const handleToggleBacklinks = useCallback(() => {
+    setShowBacklinks((prev) => !prev);
+    setShowFileExplorer(false);
+    setShowTOC(false);
   }, []);
 
   // Toggle the right-side AI assistant panel.
@@ -652,6 +665,7 @@ function AppContent() {
   const closeAllPanels = useCallback(() => {
     setShowFileExplorer(false);
     setShowTOC(false);
+    setShowBacklinks(false);
   }, []);
 
   // Handle file drop
@@ -924,6 +938,14 @@ function AppContent() {
         icon: "format_list_bulleted",
         run: handleToggleTOC,
       });
+      items.push({
+        id: "view.backlinks",
+        label: "Show backlinks",
+        section: "View",
+        icon: "link",
+        keywords: "links references notes pointing here",
+        run: handleToggleBacklinks,
+      });
     }
 
     // Fullscreen works anywhere (including the welcome screen), so unlike the
@@ -1048,7 +1070,7 @@ function AppContent() {
     // (post-debounce) for no reason. Headings are computed below in a
     // separate hook that's gated on the palette actually being open.
     handleNewFile, handleOpenFile, handleSaveFile, handleSaveAs, handleOpenTutorial,
-    handleToggleSplit, handleToggleFileExplorer, handleToggleTOC, toggleFullscreen,
+    handleToggleSplit, handleToggleFileExplorer, handleToggleTOC, handleToggleBacklinks, toggleFullscreen,
     loadFile, filePath, hasFile, showToast, closeTab,
     typewriterModeEnabled, toolbarVisible, aiEnabled,
     theme, setTheme, openFind, openReplace,
@@ -1218,7 +1240,7 @@ function AppContent() {
             // at left-0, so reserve padding-left when one is open so they reflow the
             // editor beside them instead of overlaying it.
             style={{
-                paddingLeft: (showFileExplorer || showTOC) ? `${SIDEBAR_WIDTH}px` : 0,
+                paddingLeft: (showFileExplorer || showTOC || showBacklinks) ? `${SIDEBAR_WIDTH}px` : 0,
                 paddingRight: showAIPanel ? `min(${aiPanelWidth}px, 90vw)` : 0,
                 transition: "padding 0.15s ease",
             }}
@@ -1329,6 +1351,17 @@ function AppContent() {
               />
             </Suspense>
           )}
+          {showBacklinks && currentDirectory && filePath && (
+            <Suspense fallback={null}>
+              <BacklinksPanel
+                isOpen={showBacklinks}
+                directory={currentDirectory}
+                currentFilePath={filePath}
+                onFileSelect={handleOpenSearchResult}
+                onClose={closeAllPanels}
+              />
+            </Suspense>
+          )}
 
           {/* Right-side AI assistant panel. Reads the live document + current
               selection; chat is read-only for now (edit/agent flow is next). */}
@@ -1355,8 +1388,10 @@ function AppContent() {
             mode={mode}
             showFileExplorer={showFileExplorer}
             showTOC={showTOC}
+            showBacklinks={showBacklinks}
             onToggleFileExplorer={handleToggleFileExplorer}
             onToggleTOC={handleToggleTOC}
+            onToggleBacklinks={handleToggleBacklinks}
             wordCount={wordCount}
             charCount={charCount}
             readingTimeMin={readingTimeMin}

--- a/src/components/BacklinksPanel.test.tsx
+++ b/src/components/BacklinksPanel.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BacklinksPanel } from "./BacklinksPanel";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+describe("BacklinksPanel", () => {
+    beforeEach(() => vi.mocked(invoke).mockReset());
+
+    it("loads backlinks for the active file and opens the selected match", async () => {
+        vi.mocked(invoke).mockResolvedValue([
+            { path: "C:/notes/source.md", name: "source.md", matches: [{ line: 4, text: "See [[target]]" }] },
+        ]);
+        const onFileSelect = vi.fn();
+
+        render(
+            <BacklinksPanel
+                isOpen
+                directory="C:/notes"
+                currentFilePath="C:/notes/target.md"
+                onFileSelect={onFileSelect}
+                onClose={vi.fn()}
+            />,
+        );
+
+        await waitFor(() =>
+            expect(invoke).toHaveBeenCalledWith("find_backlinks", {
+                directory: "C:/notes",
+                targetFile: "C:/notes/target.md",
+            }),
+        );
+        fireEvent.click(await screen.findByRole("button", { name: "Open source.md at line 4" }));
+        expect(onFileSelect).toHaveBeenCalledWith("C:/notes/source.md", 4);
+    });
+
+    it("shows an empty state when no note links to the file", async () => {
+        vi.mocked(invoke).mockResolvedValue([]);
+
+        render(
+            <BacklinksPanel
+                isOpen
+                directory="C:/notes"
+                currentFilePath="C:/notes/target.md"
+                onFileSelect={vi.fn()}
+                onClose={vi.fn()}
+            />,
+        );
+
+        expect(await screen.findByText("No notes link here yet.")).toBeInTheDocument();
+    });
+});

--- a/src/components/BacklinksPanel.tsx
+++ b/src/components/BacklinksPanel.tsx
@@ -1,0 +1,161 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import mascotMagnify from "../assets/mascot/mascot-magnify.png";
+import mascotReading from "../assets/mascot/mascot-reading.png";
+import { attachFocusTrap } from "../utils/focusTrap";
+
+interface BacklinkMatch {
+    line: number;
+    text: string;
+}
+
+interface BacklinkResult {
+    path: string;
+    name: string;
+    matches: BacklinkMatch[];
+}
+
+interface BacklinksPanelProps {
+    isOpen: boolean;
+    directory: string;
+    currentFilePath: string;
+    onFileSelect: (path: string, line: number) => void;
+    onClose: () => void;
+}
+
+export function BacklinksPanel({
+    isOpen,
+    directory,
+    currentFilePath,
+    onFileSelect,
+    onClose,
+}: BacklinksPanelProps) {
+    const [results, setResults] = useState<BacklinkResult[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const panelRef = useRef<HTMLElement>(null);
+
+    const loadBacklinks = useCallback(async () => {
+        setIsLoading(true);
+        setError(null);
+        try {
+            const next = await invoke<BacklinkResult[]>("find_backlinks", {
+                directory,
+                targetFile: currentFilePath,
+            });
+            setResults(next);
+        } catch (err) {
+            setResults([]);
+            setError(String(err));
+        } finally {
+            setIsLoading(false);
+        }
+    }, [currentFilePath, directory]);
+
+    useEffect(() => {
+        if (isOpen) void loadBacklinks();
+    }, [isOpen, loadBacklinks]);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const refresh = () => void loadBacklinks();
+        window.addEventListener("focus", refresh);
+        return () => window.removeEventListener("focus", refresh);
+    }, [isOpen, loadBacklinks]);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === "Escape") {
+                event.preventDefault();
+                onClose();
+            }
+        };
+        document.addEventListener("keydown", handleKeyDown);
+        panelRef.current?.focus();
+        const detachTrap = attachFocusTrap(panelRef.current);
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+            detachTrap();
+        };
+    }, [isOpen, onClose]);
+
+    const matchCount = results.reduce((count, result) => count + result.matches.length, 0);
+
+    return (
+        <aside
+            ref={panelRef}
+            role="navigation"
+            aria-label="Backlinks"
+            tabIndex={-1}
+            className={`fixed left-0 top-12 bottom-7 w-72 bg-[var(--bg-secondary)] border-r border-[var(--border)] z-50 shadow-2xl flex flex-col overflow-hidden transition-transform duration-200 ease-out ${isOpen ? "translate-x-0" : "-translate-x-full"}`}
+        >
+            <div className="h-10 shrink-0 px-4 flex items-center justify-between border-b border-[var(--border)] bg-[var(--bg-titlebar)]">
+                <div className="flex items-center gap-2 text-sm font-semibold text-[var(--text-primary)] no-select">
+                    <span className="material-symbols-outlined text-[18px]">link</span>
+                    <span>Backlinks</span>
+                    {!isLoading && !error && (
+                        <span className="text-[10px] text-[var(--text-muted)]">{matchCount}</span>
+                    )}
+                </div>
+                <div className="flex items-center gap-1">
+                    <button
+                        onClick={() => void loadBacklinks()}
+                        aria-label="Refresh backlinks"
+                        className="btn-press flex items-center justify-center w-7 h-7 rounded-[var(--radius-sm)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                    >
+                        <span className="material-symbols-outlined text-[18px]">refresh</span>
+                    </button>
+                    <button
+                        onClick={onClose}
+                        aria-label="Close backlinks"
+                        className="btn-press flex items-center justify-center w-7 h-7 rounded-[var(--radius-sm)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                    >
+                        <span className="material-symbols-outlined text-[18px]">close</span>
+                    </button>
+                </div>
+            </div>
+
+            <div className="flex-1 min-h-0 overflow-y-auto">
+                {isLoading ? (
+                    <div className="py-8 text-center text-sm text-[var(--text-secondary)]">Loading…</div>
+                ) : error ? (
+                    <div className="flex flex-col items-center justify-center gap-3 py-8 px-4 text-center text-sm" role="alert">
+                        <img src={mascotMagnify} alt="" aria-hidden="true" draggable={false} className="w-20 h-20 object-contain select-none opacity-90" />
+                        <span className="text-[var(--danger)]">{error}</span>
+                    </div>
+                ) : results.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center gap-3 py-8 px-4 text-center text-sm text-[var(--text-secondary)]">
+                        <img src={mascotReading} alt="" aria-hidden="true" draggable={false} className="w-20 h-20 object-contain select-none opacity-90" />
+                        <span>No notes link here yet.</span>
+                    </div>
+                ) : (
+                    <ul className="py-2" aria-label="Notes linking to this file">
+                        {results.map((result) => (
+                            <li key={result.path} className="border-b border-[var(--border-subtle)] last:border-b-0">
+                                <div className="px-4 pt-2 pb-1 flex items-center gap-2 text-xs font-semibold text-[var(--text-primary)]">
+                                    <span className="material-symbols-outlined text-[14px]">description</span>
+                                    <span className="truncate">{result.name}</span>
+                                </div>
+                                <ul className="pb-2">
+                                    {result.matches.map((match) => (
+                                        <li key={`${result.path}:${match.line}`}>
+                                            <button
+                                                onClick={() => onFileSelect(result.path, match.line)}
+                                                className="btn-press w-full px-4 py-1.5 text-left text-xs text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] transition-colors"
+                                                aria-label={`Open ${result.name} at line ${match.line}`}
+                                            >
+                                                <span className="mr-2 text-[10px] text-[var(--text-muted)]">{match.line}</span>
+                                                <span className="line-clamp-2">{match.text}</span>
+                                            </button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        </aside>
+    );
+}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -7,8 +7,10 @@ interface StatusBarProps {
     mode?: "preview" | "code" | "split";
     showFileExplorer?: boolean;
     showTOC?: boolean;
+    showBacklinks?: boolean;
     onToggleFileExplorer?: () => void;
     onToggleTOC?: () => void;
+    onToggleBacklinks?: () => void;
     wordCount?: number;
     charCount?: number;
     readingTimeMin?: number;
@@ -34,8 +36,10 @@ function StatusBarImpl({
     mode = "preview",
     showFileExplorer = false,
     showTOC = false,
+    showBacklinks = false,
     onToggleFileExplorer,
     onToggleTOC,
+    onToggleBacklinks,
     wordCount,
     charCount,
     readingTimeMin,
@@ -81,6 +85,20 @@ function StatusBarImpl({
                     <span className="material-symbols-outlined text-[14px]">
                         format_list_bulleted
                     </span>
+                </button>
+
+                {/* Backlinks Toggle */}
+                <button
+                    onClick={onToggleBacklinks}
+                    title="Backlinks"
+                    aria-label={showBacklinks ? "Close backlinks" : "Open backlinks"}
+                    aria-pressed={showBacklinks}
+                    className={`btn-press flex items-center justify-center w-8 h-6 rounded transition-colors ${showBacklinks
+                        ? "bg-[var(--accent)] text-[var(--accent-text)]"
+                        : "hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+                        }`}
+                >
+                    <span className="material-symbols-outlined text-[14px]">link</span>
                 </button>
             </div>
             <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary

- add a Backlinks panel for notes that reference the current file
- recognize exact sibling wikilinks, aliases/headings, and relative Markdown links while excluding image embeds and prefix matches
- bound the recursive scan using the existing global-search limits and validate paths in Rust
- open each result at its matching source line

## Testing

- `node node_modules\vitest\vitest.mjs run src\components\BacklinksPanel.test.tsx --pool=threads --maxWorkers=1` (2 tests)
- `node node_modules\typescript\bin\tsc --noEmit`
- `node node_modules\vite\bin\vite.js build`
- `rustfmt --edition 2021 --check src-tauri\src\commands.rs`
- `git diff --check`

The focused Rust test could not be compiled locally because this Windows host does not have MSVC's `link.exe`; CI will provide the Rust toolchain validation.

Closes #89