### PR TITLE
feat: Zen mode reading canvas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,6 +93,8 @@ import {
   setTourDone,
   setTypewriterMode,
   setWordWrap,
+  getZenMode,
+  setZenMode,
 } from "./utils/persistence";
 import { getAutoSave } from "./utils/persistence";
 import { resolveRelativePath } from "./utils/resolveRelativePath";
@@ -151,6 +153,7 @@ function AppContent() {
   const [typewriterModeEnabled, setTypewriterModeEnabled] = usePersistedState<boolean>(getTypewriterMode, setTypewriterMode);
   const [toolbarVisible, setToolbarVisible] = usePersistedState<boolean>(getToolbarEnabled, setToolbarEnabled);
   const [wordWrapEnabled, setWordWrapEnabled] = usePersistedState<boolean>(getWordWrap, setWordWrap);
+  const [zenMode, setZenModeState] = usePersistedState<boolean>(getZenMode, setZenMode);
   const [spellCheckEnabled, setSpellCheckEnabled] = usePersistedState<boolean>(getSpellCheck, setSpellCheck);
   const [cursorPosition, setCursorPosition] = useState({ line: 1, col: 1 });
   // Editor selection range. Collapsed (start === end) means no selection;
@@ -323,6 +326,9 @@ function AppContent() {
       ["paperling:toolbar-toggle", (e) => setToolbarVisible(!!(e as CustomEvent).detail?.enabled)],
       ["paperling:wordwrap-toggle", (e) => setWordWrapEnabled(!!(e as CustomEvent).detail?.enabled)],
       ["paperling:spellcheck-toggle", (e) => setSpellCheckEnabled(!!(e as CustomEvent).detail?.enabled)],
+      // Settings → Editor toggle for Zen mode. App owns the flag (persisted
+      // via usePersistedState); the modal only fires this event. ZEN-01.
+      ["paperling:zen-toggle", (e) => setZenModeState(!!(e as CustomEvent).detail?.enabled)],
       ["paperling:autosave-toggle", (e) => setAutoSaveEnabled(!!(e as CustomEvent).detail?.enabled)],
       // Opened from the title-bar settings dropdown's "More settings…" entry.
       ["paperling:open-settings", () => setShowSettings(true)],
@@ -668,6 +674,36 @@ function AppContent() {
     setShowBacklinks(false);
   }, []);
 
+  // Zen mode: hide every toolbar and panel, leaving only the rendered reading
+  // canvas. Entering closes the drawers and the AI panel so exiting zen
+  // returns to a clean state. The flag persists, so read-mostly users stay in
+  // zen across restarts; rendering gates on `zenActive` below. ZEN-01.
+  const handleToggleZen = useCallback(() => {
+    if (!zenMode) {
+      closeAllPanels();
+      setShowAIPanel(false);
+      setPreviewFindOpen(false);
+      showToast("Zen mode — press F9 to exit", "info");
+    }
+    setZenModeState(!zenMode);
+  }, [zenMode, closeAllPanels, showToast]);
+
+  // Effective zen: the flag alone means nothing on the welcome screen (there
+  // is no canvas to isolate), so chrome hides only once a file is open.
+  const zenActive = zenMode && hasFile;
+
+  // Invisible drag handle for the frameless window while zen hides the title
+  // bar. Single-drag moves the window, double-click toggles maximize — the
+  // same contract as the title bar. ZEN-01.
+  const handleZenDrag = useCallback(async (event: { button: number; detail: number }) => {
+    if (event.button !== 0) return;
+    try {
+      const w = Window.getCurrent();
+      if (event.detail === 2) await w.toggleMaximize();
+      else await w.startDragging();
+    } catch {/* browser dev mode */}
+  }, []);
+
   // Handle file drop
   const handleFileDrop = useCallback(
     (path: string) => {
@@ -740,7 +776,7 @@ function AppContent() {
   useGlobalShortcuts({
     handleOpenFile, handleSaveFile, handleSaveAs, handleNewFile,
     handleToggleMode, handleToggleSplit, handleToggleFileExplorer, handleToggleTOC,
-    toggleFullscreen,
+    toggleFullscreen, toggleZen: handleToggleZen,
     openCheatsheet: () => setShowCheatsheet(true),
     openPalette: () => setShowPalette(true),
     openSettings: () => setShowSettings(true),
@@ -894,6 +930,15 @@ function AppContent() {
         section: "View",
         icon: "vertical_split",
         run: handleToggleSplit,
+      });
+      items.push({
+        id: "view.zen",
+        label: zenMode ? "Exit Zen mode" : "Enter Zen mode",
+        hint: formatShortcut("zenMode"),
+        section: "View",
+        icon: "self_improvement",
+        keywords: "zen distraction free focus minimal reading",
+        run: handleToggleZen,
       });
       items.push({
         id: "view.explorer",
@@ -1073,7 +1118,7 @@ function AppContent() {
     handleToggleSplit, handleToggleFileExplorer, handleToggleTOC, handleToggleBacklinks, toggleFullscreen,
     loadFile, filePath, hasFile, showToast, closeTab,
     typewriterModeEnabled, toolbarVisible, aiEnabled,
-    theme, setTheme, openFind, openReplace,
+    theme, setTheme, openFind, openReplace, zenMode, handleToggleZen,
   ]);
 
   // Heading items are recomputed only while the palette is actually open.
@@ -1170,6 +1215,9 @@ function AppContent() {
 
   return (
     <div className="h-screen flex flex-col bg-[var(--bg-primary)] overflow-hidden transition-colors">
+      {/* Zen mode hides the title bar (and every other toolbar). The thin
+          drag strip below keeps the frameless window movable. ZEN-01. */}
+      {!zenActive && (
       <TitleBar
         fileName={fileName ?? undefined}
         isDirty={isDirty}
@@ -1187,10 +1235,11 @@ function AppContent() {
         onReplace={openReplace}
         onFindInFiles={() => setShowSearch(true)}
       />
+      )}
 
       {/* Tab bar — always shown once a file is open (even with one tab), with a
           + button, so it's clear more files can be opened in tabs. TABS-01. */}
-      {hasFile && tabBarItems.length >= 1 && (
+      {hasFile && !zenActive && tabBarItems.length >= 1 && (
         <TabBar
           tabs={tabBarItems}
           activeId={activeTabId}
@@ -1228,6 +1277,13 @@ function AppContent() {
           {/* Split-aware layout. Both views always mounted; CSS toggles their display
               and width so editor/preview state (scroll, selection) is preserved across
               mode switches. */}
+          {zenActive && (
+            <div
+              onMouseDown={handleZenDrag}
+              title="Drag to move window — press F9 to exit Zen mode"
+              className="h-2.5 shrink-0 bg-transparent"
+            />
+          )}
           <div
             ref={splitContainerRef}
             className="flex-1 overflow-hidden flex flex-row"
@@ -1240,8 +1296,8 @@ function AppContent() {
             // at left-0, so reserve padding-left when one is open so they reflow the
             // editor beside them instead of overlaying it.
             style={{
-                paddingLeft: (showFileExplorer || showTOC || showBacklinks) ? `${SIDEBAR_WIDTH}px` : 0,
-                paddingRight: showAIPanel ? `min(${aiPanelWidth}px, 90vw)` : 0,
+                paddingLeft: !zenActive && (showFileExplorer || showTOC || showBacklinks) ? `${SIDEBAR_WIDTH}px` : 0,
+                paddingRight: !zenActive && showAIPanel ? `min(${aiPanelWidth}px, 90vw)` : 0,
                 transition: "padding 0.15s ease",
             }}
           >
@@ -1249,7 +1305,7 @@ function AppContent() {
               data-split-left
               className="overflow-hidden flex flex-col"
               style={{
-                display: mode === "code" || mode === "split" ? "flex" : "none",
+                display: !zenActive && (mode === "code" || mode === "split") ? "flex" : "none",
                 flexBasis: mode === "split" ? `${splitRatio * 100}%` : "100%",
                 flexGrow: mode === "split" ? 0 : 1,
                 flexShrink: 0,
@@ -1285,7 +1341,7 @@ function AppContent() {
             <div
               className="overflow-hidden flex flex-col relative"
               style={{
-                display: mode === "preview" || mode === "split" ? "flex" : "none",
+                display: zenActive || mode === "preview" || mode === "split" ? "flex" : "none",
                 flexBasis: mode === "split" ? `${(1 - splitRatio) * 100}%` : "100%",
                 flexGrow: mode === "split" ? 0 : 1,
                 flexShrink: 0,
@@ -1327,11 +1383,13 @@ function AppContent() {
             </div>
           </div>
 
+          {!zenActive && (
           <ModeToggle mode={mode} onSetMode={setMode} aiPanelOpen={showAIPanel} aiPanelWidth={aiPanelWidth} />
+          )}
 
           {/* Sidebar Panels — only mount when actually open so they don't
               load their module until first use. */}
-          {showFileExplorer && (
+          {!zenActive && showFileExplorer && (
             <Suspense fallback={null}>
               <FileExplorer
                 isOpen={showFileExplorer}
@@ -1341,7 +1399,7 @@ function AppContent() {
               />
             </Suspense>
           )}
-          {showTOC && (
+          {!zenActive && showTOC && (
             <Suspense fallback={null}>
               <TableOfContents
                 isOpen={showTOC}
@@ -1351,7 +1409,7 @@ function AppContent() {
               />
             </Suspense>
           )}
-          {showBacklinks && currentDirectory && filePath && (
+          {!zenActive && showBacklinks && currentDirectory && filePath && (
             <Suspense fallback={null}>
               <BacklinksPanel
                 isOpen={showBacklinks}
@@ -1365,7 +1423,7 @@ function AppContent() {
 
           {/* Right-side AI assistant panel. Reads the live document + current
               selection; chat is read-only for now (edit/agent flow is next). */}
-          {aiEnabled && showAIPanel && (
+          {!zenActive && aiEnabled && showAIPanel && (
             <Suspense fallback={null}>
               <AIPanel
                 isOpen={showAIPanel}
@@ -1381,6 +1439,7 @@ function AppContent() {
             </Suspense>
           )}
 
+          {!zenActive && (
 <StatusBar
             isSaved={!isDirty}
             lineNumber={mode === "preview" ? previewLine : cursorPosition.line}
@@ -1398,6 +1457,7 @@ function AppContent() {
             selectionLength={mode !== "preview" ? selectionLength : 0}
             selectionWordCount={selectionWordCount}
           />
+          )}
         </>
       )}
 
@@ -1497,7 +1557,7 @@ function AppContent() {
 
       {/* First-run welcome tour. Gated on hasFile because every spotlight
           target (editor panes, mode toggle) only exists with an open buffer. */}
-      {showTour && hasFile && !booting && (
+      {showTour && hasFile && !booting && !zenActive && (
         <Tour onClose={handleCloseTour} onOpenTutorial={handleOpenTutorial} />
       )}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { revealItemInDir } from "@tauri-apps/plugin-opener";
 
 import { ThemeProvider, useTheme, type Theme } from "./context/ThemeContext";
 import { TitleBar } from "./components/TitleBar";
+import { ZenTopBar } from "./components/ZenTopBar";
 import { WelcomeScreen } from "./components/WelcomeScreen";
 import { CodeEditor } from "./components/CodeEditor";
 import { StatusBar } from "./components/StatusBar";
@@ -154,6 +155,12 @@ function AppContent() {
   const [toolbarVisible, setToolbarVisible] = usePersistedState<boolean>(getToolbarEnabled, setToolbarEnabled);
   const [wordWrapEnabled, setWordWrapEnabled] = usePersistedState<boolean>(getWordWrap, setWordWrap);
   const [zenMode, setZenModeState] = usePersistedState<boolean>(getZenMode, setZenMode);
+  // Live mirrors for the mount-once Settings event listener below, so the
+  // Settings toggle routes through the same toggle (with view-mode
+  // park/restore) as F9 instead of flipping the bare flag. ZEN-01.
+  const zenModeRef = useRef(zenMode);
+  zenModeRef.current = zenMode;
+  const zenToggleRef = useRef<() => void>(() => {});
   const [spellCheckEnabled, setSpellCheckEnabled] = usePersistedState<boolean>(getSpellCheck, setSpellCheck);
   const [cursorPosition, setCursorPosition] = useState({ line: 1, col: 1 });
   // Editor selection range. Collapsed (start === end) means no selection;
@@ -326,9 +333,12 @@ function AppContent() {
       ["paperling:toolbar-toggle", (e) => setToolbarVisible(!!(e as CustomEvent).detail?.enabled)],
       ["paperling:wordwrap-toggle", (e) => setWordWrapEnabled(!!(e as CustomEvent).detail?.enabled)],
       ["paperling:spellcheck-toggle", (e) => setSpellCheckEnabled(!!(e as CustomEvent).detail?.enabled)],
-      // Settings → Editor toggle for Zen mode. App owns the flag (persisted
-      // via usePersistedState); the modal only fires this event. ZEN-01.
-      ["paperling:zen-toggle", (e) => setZenModeState(!!(e as CustomEvent).detail?.enabled)],
+      // Settings → Editor toggle for Zen mode. Routed through the shared
+      // toggle (a no-op when already in the desired state) so entering via
+      // Settings parks/restores the view mode exactly like F9 does. ZEN-01.
+      ["paperling:zen-toggle", (e) => {
+        if (!!(e as CustomEvent).detail?.enabled !== zenModeRef.current) zenToggleRef.current();
+      }],
       ["paperling:autosave-toggle", (e) => setAutoSaveEnabled(!!(e as CustomEvent).detail?.enabled)],
       // Opened from the title-bar settings dropdown's "More settings…" entry.
       ["paperling:open-settings", () => setShowSettings(true)],
@@ -674,35 +684,32 @@ function AppContent() {
     setShowBacklinks(false);
   }, []);
 
-  // Zen mode: hide every toolbar and panel, leaving only the rendered reading
-  // canvas. Entering closes the drawers and the AI panel so exiting zen
-  // returns to a clean state. The flag persists, so read-mostly users stay in
-  // zen across restarts; rendering gates on `zenActive` below. ZEN-01.
+  // Zen mode: hide every toolbar and panel, leaving only the canvas. Entering
+  // closes the drawers and the AI panel and parks the view in Reader; the
+  // pre-zen view mode is restored on exit. Ctrl+E (and the palette view
+  // commands) keep working inside zen, so editing stays one keypress away —
+  // only the chrome stays hidden. ZEN-01.
+  const preZenModeRef = useRef<ViewMode | null>(null);
   const handleToggleZen = useCallback(() => {
     if (!zenMode) {
+      preZenModeRef.current = mode;
       closeAllPanels();
       setShowAIPanel(false);
       setPreviewFindOpen(false);
-      showToast("Zen mode — press F9 to exit", "info");
+      setMode("preview");
+      showToast(`Zen mode — ${formatShortcut("toggleMode")} to edit, ${formatShortcut("zenMode")} to exit`, "info");
+    } else {
+      const prev = preZenModeRef.current;
+      preZenModeRef.current = null;
+      if (prev) setMode(prev);
     }
     setZenModeState(!zenMode);
-  }, [zenMode, closeAllPanels, showToast]);
+  }, [zenMode, mode, closeAllPanels, showToast, setMode]);
+  zenToggleRef.current = handleToggleZen;
 
   // Effective zen: the flag alone means nothing on the welcome screen (there
   // is no canvas to isolate), so chrome hides only once a file is open.
   const zenActive = zenMode && hasFile;
-
-  // Invisible drag handle for the frameless window while zen hides the title
-  // bar. Single-drag moves the window, double-click toggles maximize — the
-  // same contract as the title bar. ZEN-01.
-  const handleZenDrag = useCallback(async (event: { button: number; detail: number }) => {
-    if (event.button !== 0) return;
-    try {
-      const w = Window.getCurrent();
-      if (event.detail === 2) await w.toggleMaximize();
-      else await w.startDragging();
-    } catch {/* browser dev mode */}
-  }, []);
 
   // Handle file drop
   const handleFileDrop = useCallback(
@@ -1277,11 +1284,14 @@ function AppContent() {
           {/* Split-aware layout. Both views always mounted; CSS toggles their display
               and width so editor/preview state (scroll, selection) is preserved across
               mode switches. */}
+          {/* Zen top bar: hover-reveal panel with the Normal exit button and
+              the window controls (the frameless window has no title bar in
+              zen). Its invisible hover strip doubles as the drag handle. */}
           {zenActive && (
-            <div
-              onMouseDown={handleZenDrag}
-              title="Drag to move window — press F9 to exit Zen mode"
-              className="h-2.5 shrink-0 bg-transparent"
+            <ZenTopBar
+              isFullscreen={isFullscreen}
+              onToggleFullscreen={toggleFullscreen}
+              onExitZen={handleToggleZen}
             />
           )}
           <div
@@ -1305,7 +1315,7 @@ function AppContent() {
               data-split-left
               className="overflow-hidden flex flex-col"
               style={{
-                display: !zenActive && (mode === "code" || mode === "split") ? "flex" : "none",
+                display: mode === "code" || mode === "split" ? "flex" : "none",
                 flexBasis: mode === "split" ? `${splitRatio * 100}%` : "100%",
                 flexGrow: mode === "split" ? 0 : 1,
                 flexShrink: 0,
@@ -1341,7 +1351,7 @@ function AppContent() {
             <div
               className="overflow-hidden flex flex-col relative"
               style={{
-                display: zenActive || mode === "preview" || mode === "split" ? "flex" : "none",
+                display: mode === "preview" || mode === "split" ? "flex" : "none",
                 flexBasis: mode === "split" ? `${(1 - splitRatio) * 100}%` : "100%",
                 flexGrow: mode === "split" ? 0 : 1,
                 flexShrink: 0,

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -387,7 +387,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                         onChange={(v) => { setOpenInReaderLocal(v); setOpenInReader(v); }} />
                                 )}
                                 {matches("zen mode") && (
-                                    <ToggleRow label="Zen mode" description="Reading canvas only — hides every toolbar and panel. Files always open in zen. Press F9 to exit." checked={zenMode}
+                                    <ToggleRow label="Zen mode" description="Just the page. Ctrl+E edits, F9 exits." checked={zenMode}
                                         onChange={(v) => { setZenModeLocal(v); setZenMode(v); fire("paperling:zen-toggle", v); }} />
                                 )}
                             </div>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -9,6 +9,7 @@ import {
     getSpellCheck, setSpellCheck,
     getAutoSave, setAutoSave,
     getOpenInReader, setOpenInReader,
+    getZenMode, setZenMode,
     getAIHistoryTurns, setAIHistoryTurns, AI_HISTORY_TURNS_MAX,
     getAIIconAnimation, setAIIconAnimation,
 } from "../utils/persistence";
@@ -102,6 +103,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
     const [spellCheck, setSpellCheckLocal] = useState(getSpellCheck);
     const [autoSave, setAutoSaveLocal] = useState(getAutoSave);
     const [openInReader, setOpenInReaderLocal] = useState(getOpenInReader);
+    const [zenMode, setZenModeLocal] = useState(getZenMode);
 
     // The running app's version for the About panel (#148). Read from the Tauri
     // core API rather than a build-time constant so it always reflects the
@@ -383,6 +385,10 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                                     // file open (same pattern as toggle-ai-panel).
                                     <ToggleRow label="Open files in reader mode" description="Every file opens read-first; editing stays one click away" checked={openInReader}
                                         onChange={(v) => { setOpenInReaderLocal(v); setOpenInReader(v); }} />
+                                )}
+                                {matches("zen mode") && (
+                                    <ToggleRow label="Zen mode" description="Reading canvas only — hides every toolbar and panel. Files always open in zen. Press F9 to exit." checked={zenMode}
+                                        onChange={(v) => { setZenModeLocal(v); setZenMode(v); fire("paperling:zen-toggle", v); }} />
                                 )}
                             </div>
                         )}

--- a/src/components/ShortcutCheatsheet.tsx
+++ b/src/components/ShortcutCheatsheet.tsx
@@ -54,6 +54,7 @@ const groups: ShortcutGroup[] = [
         items: [
             { keys: formatShortcut("toggleMode"), description: "Toggle Reader / Code" },
             { keys: formatShortcut("toggleSplit"), description: "Toggle split view" },
+            { keys: formatShortcut("zenMode"), description: "Toggle Zen mode (reading canvas only)" },
             { keys: formatShortcut("fullscreen"), description: "Toggle fullscreen" },
             { keys: formatShortcut("toggleFileExplorer"), description: "Toggle file explorer" },
             { keys: formatShortcut("searchInFolder"), description: "Search across files" },

--- a/src/components/ZenTopBar.test.tsx
+++ b/src/components/ZenTopBar.test.tsx
@@ -1,0 +1,55 @@
+// Zen-mode top bar (ZEN-02): hover-reveal panel with the Normal exit button
+// and the three window controls. Hidden by default (invisible, not merely
+// transparent, so the buttons leave the tab order until revealed).
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+
+// No IPC host under jsdom; the window controls only need to exist.
+vi.mock("@tauri-apps/api/window", () => ({
+    Window: {
+        getCurrent: () => ({
+            minimize: async () => {},
+            toggleMaximize: async () => {},
+            startDragging: async () => {},
+            close: async () => {},
+        }),
+    },
+}));
+
+import { ZenTopBar } from "./ZenTopBar";
+
+afterEach(cleanup);
+
+const renderBar = (props: Partial<Parameters<typeof ZenTopBar>[0]> = {}) =>
+    render(<ZenTopBar onExitZen={() => {}} {...props} />);
+
+describe("ZenTopBar", () => {
+    it("stays hidden until hovered (out of the tab order while hidden)", () => {
+        renderBar();
+        const bar = screen.getByRole("toolbar", { name: "Zen mode top bar" });
+        expect(bar).toHaveClass("invisible");
+        expect(bar).toHaveClass("opacity-0");
+        expect(bar).toHaveClass("group-hover/zenbar:visible");
+        expect(bar).toHaveClass("group-hover/zenbar:opacity-100");
+    });
+
+    it("offers Normal plus minimize, maximize, and close", () => {
+        renderBar();
+        expect(screen.getByRole("button", { name: "Exit Zen mode" })).toHaveTextContent("Normal");
+        expect(screen.getByRole("button", { name: "Minimize" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Maximize" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+    });
+
+    it("exits zen when Normal is clicked", () => {
+        const onExitZen = vi.fn();
+        renderBar({ onExitZen });
+        fireEvent.click(screen.getByRole("button", { name: "Exit Zen mode" }));
+        expect(onExitZen).toHaveBeenCalledTimes(1);
+    });
+
+    it("labels the maximize button as exit-fullscreen while fullscreen", () => {
+        renderBar({ isFullscreen: true, onToggleFullscreen: () => {} });
+        expect(screen.getByRole("button", { name: "Exit fullscreen" })).toBeInTheDocument();
+    });
+});

--- a/src/components/ZenTopBar.tsx
+++ b/src/components/ZenTopBar.tsx
@@ -1,0 +1,117 @@
+import { memo, useCallback } from "react";
+import type { MouseEvent } from "react";
+import { Window } from "@tauri-apps/api/window";
+
+interface ZenTopBarProps {
+    isFullscreen?: boolean;
+    onToggleFullscreen?: () => void;
+    /** Leave Zen mode and restore the normal chrome. */
+    onExitZen: () => void;
+}
+
+function ZenTopBarImpl({ isFullscreen, onToggleFullscreen, onExitZen }: ZenTopBarProps) {
+    const handleMinimize = useCallback(async () => {
+        try {
+            await Window.getCurrent().minimize();
+        } catch {/* browser dev mode — no Tauri window */}
+    }, []);
+
+    const handleMaximize = useCallback(async () => {
+        // Same contract as the title bar: while fullscreen this button exits
+        // fullscreen instead of toggling maximize underneath it. ZEN-02.
+        if (isFullscreen) {
+            onToggleFullscreen?.();
+            return;
+        }
+        try {
+            await Window.getCurrent().toggleMaximize();
+        } catch {/* browser dev mode */}
+    }, [isFullscreen, onToggleFullscreen]);
+
+    // close() fires the Tauri close-requested event, which App intercepts when
+    // the buffer is dirty — the same code path as Alt+F4, so unsaved work is
+    // still guarded from zen. ZEN-02.
+    const handleClose = useCallback(async () => {
+        try {
+            await Window.getCurrent().close();
+        } catch {/* browser dev mode */}
+    }, []);
+
+    // The bar (and its invisible hover strip) doubles as the drag handle for
+    // the frameless window; buttons opt out so they stay clickable. ZEN-02.
+    const handleBarMouseDown = useCallback(async (event: MouseEvent<HTMLElement>) => {
+        const target = event.target;
+        if (
+            event.button !== 0 ||
+            (target instanceof Element && target.closest("button"))
+        ) {
+            return;
+        }
+        try {
+            const appWindow = Window.getCurrent();
+            if (event.detail === 2) {
+                if (isFullscreen) onToggleFullscreen?.();
+                else await appWindow.toggleMaximize();
+            } else {
+                await appWindow.startDragging();
+            }
+        } catch {/* browser dev mode */}
+    }, [isFullscreen, onToggleFullscreen]);
+
+    return (
+        <div
+            className="absolute top-0 inset-x-0 z-50 group/zenbar"
+            onMouseDown={handleBarMouseDown}
+        >
+            {/* Invisible hover trigger (also a drag strip while the bar is
+                hidden, so the window stays movable in zen). */}
+            <div className="h-3 w-full" aria-hidden="true" />
+            {/* Reveal panel: hidden until the mouse reaches the top edge, then
+                fades/slides in. `invisible` (not just opacity-0) keeps the
+                buttons out of the tab order and away from screen readers while
+                hidden; the hide lags 150ms so a slipping mouse doesn't flicker
+                it. ZEN-02. */}
+            <div
+                role="toolbar"
+                aria-label="Zen mode top bar"
+                className="absolute top-0 inset-x-0 h-11 flex items-center justify-between pl-3 pr-2 bg-[var(--bg-titlebar)]/95 backdrop-blur-sm border-b border-[var(--border)] transition-all duration-150 delay-150 group-hover/zenbar:delay-0 invisible opacity-0 -translate-y-1 pointer-events-none group-hover/zenbar:visible group-hover/zenbar:opacity-100 group-hover/zenbar:translate-y-0 group-hover/zenbar:pointer-events-auto"
+            >
+                <button
+                    onClick={onExitZen}
+                    aria-label="Exit Zen mode"
+                    title="Back to normal view (F9)"
+                    className="flex items-center gap-1 px-2 py-1 rounded-[var(--radius-md)] hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors text-xs"
+                >
+                    <span className="material-symbols-outlined text-[16px]">web_asset</span>
+                    <span>Normal</span>
+                </button>
+                <div className="flex items-center gap-1">
+                    <button
+                        onClick={handleMinimize}
+                        aria-label="Minimize"
+                        className="flex items-center justify-center w-8 h-8 rounded-lg hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                    >
+                        <span className="material-symbols-outlined text-[18px]">remove</span>
+                    </button>
+                    <button
+                        onClick={handleMaximize}
+                        aria-label={isFullscreen ? "Exit fullscreen" : "Maximize"}
+                        title={isFullscreen ? "Exit fullscreen (F11)" : "Maximize"}
+                        className="flex items-center justify-center w-8 h-8 rounded-lg hover:bg-[var(--bg-hover)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                    >
+                        <span className="material-symbols-outlined text-[16px]">{isFullscreen ? "fullscreen_exit" : "crop_square"}</span>
+                    </button>
+                    <button
+                        onClick={handleClose}
+                        aria-label="Close"
+                        className="flex items-center justify-center w-8 h-8 rounded-lg hover:bg-[var(--danger)] text-[var(--text-secondary)] hover:text-[var(--accent-text)] transition-colors"
+                    >
+                        <span className="material-symbols-outlined text-[18px]">close</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export const ZenTopBar = memo(ZenTopBarImpl);

--- a/src/config/keybindings.test.ts
+++ b/src/config/keybindings.test.ts
@@ -113,4 +113,15 @@ describe("keybindings on Windows/Linux", () => {
         expect(kb.formatShortcut("nextTab")).toBe("Ctrl+Tab");
         expect(kb.formatShortcut("settings")).toBe("Ctrl+,");
     });
+
+    it("toggles Zen mode on plain F9", async () => {
+        const kb = await loadFresh();
+        expect(kb.matchesBinding(kev({ key: "F9" }), "zenMode")).toBe(true);
+        expect(kb.matchesBinding(kev({ key: "F9", ctrlKey: true }), "zenMode")).toBe(false);
+        expect(kb.matchesBinding(kev({ key: "F9", shiftKey: true }), "zenMode")).toBe(false);
+        expect(kb.formatShortcut("zenMode")).toBe("F9");
+        // F9 must not collide with the F1 palette alias or F11 fullscreen.
+        expect(kb.matchesBinding(kev({ key: "F9" }), "palette")).toBe(false);
+        expect(kb.matchesBinding(kev({ key: "F9" }), "fullscreen")).toBe(false);
+    });
 });

--- a/src/config/keybindings.ts
+++ b/src/config/keybindings.ts
@@ -45,6 +45,7 @@ export const BINDINGS = {
     // View
     toggleMode: { key: "e", mod: true },
     toggleSplit: { key: "\\", mod: true },
+    zenMode: { key: "F9" },
     toggleFileExplorer: { key: "e", mod: true, shift: true },
     toggleTOC: { key: "o", mod: true, shift: true },
     searchInFolder: { key: "f", mod: true, shift: true },

--- a/src/hooks/useGlobalShortcuts.test.tsx
+++ b/src/hooks/useGlobalShortcuts.test.tsx
@@ -15,6 +15,7 @@ function makeHandlers(over: Partial<ShortcutHandlers> = {}): ShortcutHandlers {
         handleToggleMode: vi.fn(),
         handleToggleSplit: vi.fn(),
         toggleFullscreen: vi.fn(),
+        toggleZen: vi.fn(),
         handleToggleFileExplorer: vi.fn(),
         handleToggleTOC: vi.fn(),
         openCheatsheet: vi.fn(),
@@ -83,6 +84,11 @@ describe("useGlobalShortcuts", () => {
     it("F11 toggles fullscreen", () => {
         press({ key: "F11" });
         expect(h.toggleFullscreen).toHaveBeenCalledTimes(1);
+    });
+
+    it("F9 toggles Zen mode, with or without a file open", () => {
+        press({ key: "F9" });
+        expect(h.toggleZen).toHaveBeenCalledTimes(1);
     });
 
     it("Alt+J dispatches the AI-assist event", () => {

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -10,6 +10,8 @@ export interface ShortcutHandlers {
     handleNewFile: () => void;
     handleToggleMode: () => void;
     handleToggleSplit: () => void;
+    /** Toggle Zen mode (F9). Works with or without a file open. */
+    toggleZen: () => void;
     /** Toggle OS fullscreen (F11). Cross-platform via the Tauri window API. */
     toggleFullscreen: () => void;
     handleToggleFileExplorer: () => void;
@@ -111,6 +113,14 @@ export function useGlobalShortcuts(handlers: ShortcutHandlers) {
             if (matchesBinding(e, "toggleSplit")) {
                 e.preventDefault();
                 if (s.hasFile) s.handleToggleSplit();
+                return;
+            }
+            // F9 - Toggle Zen mode (distraction-free reading canvas). No
+            // hasFile gate: the flag persists, so enabling it on the welcome
+            // screen still takes effect when the next file opens. ZEN-01.
+            if (matchesBinding(e, "zenMode")) {
+                e.preventDefault();
+                s.toggleZen();
                 return;
             }
             // mod+W - close the active tab (falls back to the welcome screen

--- a/src/utils/persistence.test.ts
+++ b/src/utils/persistence.test.ts
@@ -6,6 +6,7 @@ import {
     getWordWrap,
     migrateLegacyKeys, getLastFile,
     getOpenInReader, setOpenInReader,
+    getZenMode, setZenMode,
     getAIHistoryTurns, setAIHistoryTurns, AI_HISTORY_TURNS_DEFAULT, AI_HISTORY_TURNS_MAX,
 } from "./persistence";
 
@@ -63,6 +64,18 @@ describe("open in reader", () => {
     it("treats a malformed stored value as the default", () => {
         localStorage.setItem("paperling:openInReader", "{not json");
         expect(getOpenInReader()).toBe(false);
+    });
+});
+
+describe("zen mode", () => {
+    it("defaults off and round-trips", () => {
+        expect(getZenMode()).toBe(false);
+        setZenMode(true);
+        expect(getZenMode()).toBe(true);
+    });
+    it("treats a malformed stored value as the default", () => {
+        localStorage.setItem("paperling:zenMode", "{not json");
+        expect(getZenMode()).toBe(false);
     });
 });
 

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -140,6 +140,14 @@ const KEY_OPEN_IN_READER = "paperling:openInReader";
 export const getOpenInReader = (): boolean => safeGet<boolean>(KEY_OPEN_IN_READER, false);
 export const setOpenInReader = (v: boolean): void => safeSet(KEY_OPEN_IN_READER, v);
 
+// Zen mode: distraction-free reading canvas. Hides the title bar, tab bar,
+// mode toggle, status bar, and all side panels, leaving only the rendered
+// markdown. Toggled via F9, the command palette, or Settings → Editor; the
+// flag persists so read-mostly users stay in zen across restarts. ZEN-01.
+const KEY_ZEN_MODE = "paperling:zenMode";
+export const getZenMode = (): boolean => safeGet<boolean>(KEY_ZEN_MODE, false);
+export const setZenMode = (v: boolean): void => safeSet(KEY_ZEN_MODE, v);
+
 // Master switch for every AI surface (title-bar button, side panel, toolbar
 // sparkle, Alt+J, command palette entry). On by default; flipped in Settings.
 const KEY_AI_ENABLED = "paperling:aiEnabled";


### PR DESCRIPTION
Adds a Zen mode for read-mostly use: one persisted toggle that strips the app down to just the rendered page.

**How it works**
- Press `F9` (or command palette → Enter Zen mode, or Settings → Editor → Zen mode) to hide the title bar, tab bar, mode toggle, status bar, and all side panels.
- Hovering the top edge reveals a slim bar with a Normal button (exits zen) plus minimize, maximize, and close. Its invisible hover strip doubles as the window drag handle, and close still goes through the unsaved-changes guard.
- `Ctrl+E` keeps working inside zen, so editing is one keypress away. Entering zen parks the view in Reader and restores the previous view on exit.
- The flag persists in localStorage, so files always open in zen across restarts.

**Verification**
- `tsc --noEmit` clean.
- New tests: `ZenTopBar.test.tsx` (hidden-by-default, Normal exit, fullscreen label), F9 binding match/no-collision in `keybindings.test.ts`, F9 dispatch in `useGlobalShortcuts.test.tsx`. Full suite shows no new failures (the 6 failing files fail identically on clean `main` — pre-existing jsdom `localStorage` environment issue).